### PR TITLE
Provide hooks for changes to contacts.  This enables plugins (or othe…

### DIFF
--- a/gui/qt/contact_list.py
+++ b/gui/qt/contact_list.py
@@ -48,9 +48,7 @@ class ContactList(MyTreeWidget):
         # openalias items shouldn't be editable
         return item.text(1) != "openalias"
 
-    def on_edited(self, item, column, prior):
-        if column == 0:  # Remove old contact if renamed
-            self.parent.contacts.pop(prior)
+    def on_edited(self, item, column, prior_value):
         self.parent.set_contact(item.text(0), item.text(1))
 
     def import_contacts(self):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1707,21 +1707,31 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.show_error(_('Invalid Address'))
             self.contact_list.update()  # Displays original unchanged value
             return False
+        old_entry = self.contacts.get(address, None)
         self.contacts[address] = ('address', label)
         self.contact_list.update()
         self.history_list.update()
         self.update_completions()
+
+        # The contact has changed, update any addresses that are displayed with the old information.
+        run_hook('update_contact', address, self.contacts[address], old_entry)
         return True
 
-    def delete_contacts(self, labels):
+    def delete_contacts(self, addresses):
         if not self.question(_("Remove {} from your list of contacts?")
-                             .format(" + ".join(labels))):
+                             .format(" + ".join(addresses))):
             return
-        for label in labels:
-            self.contacts.pop(label)
+        removed_entries = []
+        for address in addresses:
+            if address in self.contacts.keys():
+                removed_entries.append((address, self.contacts[address]))
+            self.contacts.pop(address)
+
         self.history_list.update()
         self.contact_list.update()
         self.update_completions()
+
+        run_hook('delete_contacts', removed_entries)
 
     def show_invoice(self, key):
         pr = self.invoices.get(key)

--- a/lib/contacts.py
+++ b/lib/contacts.py
@@ -67,6 +67,7 @@ class Contacts(dict):
         dict.__setitem__(self, key, value)
         self.save()
 
+    # This breaks expected dictionary pop behaviour.  In the normal case, it'd return the popped value, or throw a KeyError.
     def pop(self, key):
         if key in self.keys():
             dict.pop(self, key)


### PR DESCRIPTION
Provide hooks for changes to contacts.

This enables plugins (or other internal UI) that wish to upgrade addresses with the name of the contact it applies to, to observe changes and update their displayed addresses in response to user contact creation/renaming and deletion.

This change also removes some related unused code that was never used, and adds a comment to clarify a Python object api change.