### PR TITLE
Fix #659. While the user is pondering entering their password to dele…

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -248,8 +248,10 @@ class Daemon(DaemonThread):
         return self.wallets.get(path)
 
     def stop_wallet(self, path):
-        wallet = self.wallets.pop(path)
-        wallet.stop_threads()
+        # Issue #659 wallet may already be stopped.
+        if path in self.wallets:
+            wallet = self.wallets.pop(path)
+            wallet.stop_threads()
 
     def run_cmdline(self, config_options):
         password = config_options.get('password')


### PR DESCRIPTION
…te their wallet, the wallet is stopped in the daemon.  This allows the deletion to proceed without erroring if the wallet is already stopped in the daemon.