### PR TITLE
Fix the support for Ledger HW1/Nano legacy hardware

### DIFF
--- a/plugins/ledger/auth2fa.py
+++ b/plugins/ledger/auth2fa.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import *
 from electroncash.i18n import _
 from electroncash_gui.qt.util import *
 from electroncash.util import print_msg
+from electroncash.address import Address
 
 import os, hashlib, websocket, logging, json, copy
 from electroncash_gui.qt.qrcodewidget import QRCodeWidget
@@ -119,6 +120,7 @@ class LedgerAuthDialog(QDialog):
             if len(s) < len(self.idxs):
                 i = self.idxs[len(s)]
                 addr = self.txdata['address']
+                addr = addr.to_string(Address.FMT_LEGACY)
                 addr = addr[:i] + '<u><b>' + addr[i:i+1] + '</u></b>' + addr[i+1:]
                 self.addrtext.setHtml(str(addr))
             else:


### PR DESCRIPTION
Ledger HW1/Nano have support for Bitcoin Cash in version 1.0.4, so check for that. The call to getWalletPublicKey with cashAddr=True causes the legacy devices to return an error we can use to detect it. The warning about cashddr is suppressed as they have no display anyway. The 2FA dialog has been fixed by converting the address to a legacy address.

Note that the firmware check might be incorrect. I am not sure if Ledger Nano S 1.0.4 supports Bitcoin Cash and I have no firmware history to check this. Maybe we should first determine if it is a legacy device and then test against different firmware versions depending on the device?