### PR TITLE
Do not broadcast transaction for a payment request

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1591,9 +1591,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.payment_request = None
                 refund_address = self.wallet.get_receiving_addresses()[0]
                 ack_status, ack_msg = pr.send_ack(str(tx), refund_address)
+                msg = ack_msg
                 if ack_status:
                     status = True
-                    msg = ack_msg
             else:
                 status, msg =  self.network.broadcast_transaction(tx)
             return status, msg

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1579,19 +1579,23 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         def broadcast_thread():
             # non-GUI thread
+            status = False
+            msg = "Failed"
             pr = self.payment_request
             if pr and pr.has_expired():
                 self.payment_request = None
                 return False, _("Payment request has expired")
-            status, msg =  self.network.broadcast_transaction(tx)
-            if pr and status is True:
+            if pr:
                 self.invoices.set_paid(pr, tx.txid())
                 self.invoices.save()
                 self.payment_request = None
                 refund_address = self.wallet.get_receiving_addresses()[0]
                 ack_status, ack_msg = pr.send_ack(str(tx), refund_address)
                 if ack_status:
+                    status = True
                     msg = ack_msg
+            else:
+                status, msg =  self.network.broadcast_transaction(tx)
             return status, msg
 
         # Capture current TL window; override might be removed on return

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1586,13 +1586,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.payment_request = None
                 return False, _("Payment request has expired")
             if pr:
-                self.invoices.set_paid(pr, tx.txid())
-                self.invoices.save()
-                self.payment_request = None
                 refund_address = self.wallet.get_receiving_addresses()[0]
                 ack_status, ack_msg = pr.send_payment(str(tx), refund_address)
                 msg = ack_msg
                 if ack_status:
+                    self.invoices.set_paid(pr, tx.txid())
+                    self.invoices.save()
+                    self.payment_request = None
                     status = True
             else:
                 status, msg =  self.network.broadcast_transaction(tx)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1590,7 +1590,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.invoices.save()
                 self.payment_request = None
                 refund_address = self.wallet.get_receiving_addresses()[0]
-                ack_status, ack_msg = pr.send_ack(str(tx), refund_address)
+                ack_status, ack_msg = pr.send_payment(str(tx), refund_address)
                 msg = ack_msg
                 if ack_status:
                     status = True

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -261,7 +261,7 @@ class PaymentRequest:
     def get_outputs(self):
         return self.outputs[:]
 
-    def send_ack(self, raw_tx, refund_addr):
+    def send_payment(self, raw_tx, refund_addr):
         pay_det = self.details
         if not self.details.payment_url:
             return False, "no url"

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -270,7 +270,7 @@ class PaymentRequest:
         paymnt.transactions.append(bfh(raw_tx))
         ref_out = paymnt.refund_to.add()
         ref_out.script = bfh(transaction.Transaction.pay_script(refund_addr))
-        paymnt.memo = "Paid using Electrum"
+        paymnt.memo = "Paid using Electron Cash"
         pm = paymnt.SerializeToString()
         payurl = urllib.parse.urlparse(pay_det.payment_url)
         try:

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -282,7 +282,7 @@ class PaymentRequest:
             except Exception as e:
                 print(e)
                 return False, "Payment Message/PaymentACK Failed"
-        if r.status_code >= 500:
+        if r.status_code != 200:
             return False, r.reason
         try:
             paymntack = pb2.PaymentACK()


### PR DESCRIPTION
A transaction from a BIP70 invoice should not be broadcasted by the
wallet.
If a valid PaymentACK is received it is up to the merchant to broadcast
the transaction.
This also fixes a nasty race condition where a transaction was
broadcasted before the merchant had ACK'd it which would likley cause
the user to loose money.

Also updated the memo field from "Electrum" to "Electron Cash".

Please note that this need quite a bit of testing. I have only done some tests against BitPay testnet on the desktop version of Electron Cash. This should be seen as a proposal more then a final solution since there probably is some fine tuning and error handling to do.

Fixes #812