### PR TITLE
Preserve x_pubkeys

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -471,7 +471,6 @@ class Transaction:
                         j = pubkeys.index(pubkey)
                         print_error("adding sig", i, j, pubkey, sig)
                         self._inputs[i]['signatures'][j] = sig
-                        #self._inputs[i]['x_pubkeys'][j] = pubkey
                         break
         # redo raw
         self.raw = self.serialize()

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -737,7 +737,6 @@ class Transaction:
                     sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
                     assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
                     txin['signatures'][j] = bh2u(sig) + int_to_hex(self.nHashType() & 255, 1)
-                    txin['x_pubkeys'][j] = pubkey
                     txin['pubkeys'][j] = pubkey # needed for fd keys
                     self._inputs[i] = txin
         print_error("is_complete", self.is_complete())


### PR DESCRIPTION
When signing a transaction, don't overwrite the `x_pubkey` with the `pubkey`.
Hardware wallets want to verify that input addresses and change
addresses belong to the same wallet.  For this they need to know the
`x_pubkey`.