### PR TITLE
transaction_dialog.py -- normal close if user presses Esc

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -153,7 +153,14 @@ class TxDialog(QDialog, MessageBoxMixin):
             event.ignore()
         else:
             event.accept()
-            dialogs.remove(self)
+            try:
+                dialogs.remove(self)
+            except ValueError:  # wasn't in list
+                pass
+
+    def reject(self):
+        # Override escape-key to close normally (and invoke closeEvent)
+        self.close()
 
     def show_qr(self):
         text = bfh(str(self.tx))


### PR DESCRIPTION
In qt transaction_dialog.py, two things are supposed to happen upon closing (via `closeEvent` function):

* Prompt for save
* Remove self from persisted `dialogs` list (prevent memory leak)

Unfortunately [this does not happen if user presses Escape key](http://doc.qt.io/qt-5/qdialog.html#escape-key), which calls reject() which just hides the dialog and does not invoke closeEvent (I have confirmed this in testing).

This fix makes it so that pressing Esc is equivalent to clicking the Close button.

As a bonus I've included [a fix seen on the spesmilo upstream](https://github.com/spesmilo/electrum/blob/master/electrum/gui/qt/transaction_dialog.py#L176-L179) for the situation where someone has created the dialog directly.