### PR TITLE
required mod to allow complex P2SH processing

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -581,16 +581,20 @@ class Transaction:
 
     @classmethod
     def get_preimage_script(self, txin):
-        if txin['type'] == 'p2pkh':
+        _type = txin['type']
+        if _type == 'p2pkh':
             return txin['address'].to_script().hex()
-        elif txin['type'] in ['p2sh']:
+        elif _type == 'p2sh':
             pubkeys, x_pubkeys = self.get_sorted_pubkeys(txin)
             return multisig_script(pubkeys, txin['num_sig'])
-        elif txin['type'] == 'p2pk':
+        elif _type == 'p2pk':
             pubkey = txin['pubkeys'][0]
             return public_key_to_p2pk_script(pubkey)
+        elif _type == 'unknown':
+            # this approach enables most P2SH smart contracts (but take care if using OP_CODESEPARATOR)
+            return txin['scriptCode']
         else:
-            raise TypeError('Unknown txin type', txin['type'])
+            raise RuntimeError('Unknown txin type', _type)
 
     @classmethod
     def serialize_outpoint(self, txin):


### PR DESCRIPTION
This modifies one of the internal functions called by `Transaction.sign()`, to allow inputs to have a type of 'unknown' where the scriptCode (used in signing that input) needs to be provided. This allows the `sign()` method to correctly create signatures for OP_CHECKSIG even for unusual smart contracts. It is still up to the developer to correctly set up the input dictionary, and to serialize the proper scriptSig after the signature operation is done. (`sign()` leaves the signature in the input dictionary's `'signatures'` list)

I have found this particular modification to be essential in coding my custom P2SH codes (atomic swaps and now also coin splitter), so I thought it would be nice to have in mainline. All other necessary code to handle these smart contracts can be done without modifying the core codebase.