### PR TITLE
update default server list

### DIFF
--- a/lib/servers.json
+++ b/lib/servers.json
@@ -1,60 +1,68 @@
 {
-    "abc1.hsmiths.com": {
+    "94.1.159.183": {
         "pruning": "-",
-        "version": "1.1",
-        "t": "60001",
-        "s": "60002"
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
     },
-    "electroncash.checksum0.com": {
+    "bch.crypto.mldlabs.com": {
         "pruning": "-",
-        "version": "1.1",
-        "t": "50001"
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
     },
-    "35.157.238.5": {
+    "bch.electrumx.cash": {
         "pruning": "-",
-        "version": "1.1",
-        "t":"51001",
-        "s":"51002"
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
     },
-    "electrumx-cash.1209k.com": {
+    "bch.imaginary.cash": {
         "pruning": "-",
-        "version": "1.1",
-        "t":"51001",
-        "s":"51002"
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
     },
-    "shsmithgoggryfbx.onion": {
+    "bitcoincash.quangld.com": {
         "pruning": "-",
-        "version": "1.1",
-        "t": "60001",
-        "s": "60002"
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
     },
-    "bch.curalle.ovh": {
+    "blackie.c3-soft.com": {
         "pruning": "-",
-        "version": "1.1",
-        "t":"51001",
-        "s":"51002"
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
+    },
+    "electron.jochen-hoenicke.de": {
+        "pruning": "-",
+        "s": "51002",
+        "t": "51001",
+        "version": "1.4"
     },
     "electroncash.ueo.ch": {
         "pruning": "-",
-        "version": "1.4.3",
-        "t":"51001",
-        "s":"51002"
-    },
-    "electron-cash.dragon.zone": {
-        "pruning": "-",
-        "version": "1.1",
-        "t":"50001",
-        "s":"50002"
-    },
-    "electroncash.cascharia.com": {
-        "pruning": "-",
-        "version": "1.1",
-        "s": "50002"
+        "s": "51002",
+        "t": "51001",
+        "version": "1.4"
     },
     "electrum.imaginary.cash": {
         "pruning": "-",
-        "version": "1.2.1",
-        "t":"50001",
-        "s":"50002"
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
+    },
+    "electrum.leblancnet.us": {
+        "pruning": "-",
+        "s": "50012",
+        "t": "50011",
+        "version": "1.4"
+    },
+    "wallet.satoshiscoffeehouse.com": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
     }
 }

--- a/lib/servers.json
+++ b/lib/servers.json
@@ -5,10 +5,15 @@
         "t": "50001",
         "version": "1.4"
     },
-    "bch.crypto.mldlabs.com": {
+    "abc1.hsmiths.com": {
+        "pruning": "-",
+        "s": "60002",
+        "t": "60001",
+        "version": "1.4"
+    },
+    "bch.curalle.ovh": {
         "pruning": "-",
         "s": "50002",
-        "t": "50001",
         "version": "1.4"
     },
     "bch.electrumx.cash": {
@@ -18,6 +23,12 @@
         "version": "1.4"
     },
     "bch.imaginary.cash": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
+    },
+    "bch0.kister.net": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
@@ -35,10 +46,40 @@
         "t": "50001",
         "version": "1.4"
     },
+    "crypto.mldlabs.com": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
+    },
+    "electron-cash.dragon.zone": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
+    },
+    "electron.coinucopia.io": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
+    },
     "electron.jochen-hoenicke.de": {
         "pruning": "-",
         "s": "51002",
         "t": "51001",
+        "version": "1.4"
+    },
+    "electroncash.cascharia.com": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
+    },
+    "electroncash.dk": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
         "version": "1.4"
     },
     "electroncash.ueo.ch": {
@@ -57,6 +98,12 @@
         "pruning": "-",
         "s": "50012",
         "t": "50011",
+        "version": "1.4"
+    },
+    "electrumx.hillsideinternet.com": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
         "version": "1.4"
     },
     "wallet.satoshiscoffeehouse.com": {


### PR DESCRIPTION
This updates `lib/server.json`, the initial seed list. This list includes 9 servers that will fork off onto the new ABC rules (three BU, six ABC), and 2 servers that will fork off onto the new SV rules. Was generated using `scripts/servers` then modified. Note that the 'version' field has been incremented from 1.1 to 1.4 since all these servers support protocol 1.4.

Many servers were omitted:

* Servers running old node versions (XT 0.11, ABC 0.17, BU 1.3/1.4), not ready for Nov 15 fork day.
* Servers running BU 1.5 / ABC 0.18 with unpatched ElectrumX (they will crash on Nov 15).
* Servers with expired certs.

Survey for reference:
https://docs.google.com/spreadsheets/d/1xFthIiIG1lUBczGwUinazBzjRinuRmCi9h_xfUSAjZM/edit

(plz don't merge yet)