### PR TITLE
update README for making releases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,11 +87,24 @@ Creating Binaries
 =================
 
 
-To create binaries, create the 'packages' directory::
+To create binaries, create the 'packages/' directory::
 
     ./contrib/make_packages
 
 This directory contains the python dependencies used by Electron Cash.
+
+The `make_packages` command may fail with some Ubuntu-packaged versions of
+pip ("can't combine user with prefix."). To solve this, it is necessary to
+upgrade your pip to the official version::
+
+    pip install pip --user
+
+Linux (source with packages)
+----------------------------
+
+Run the following to create the release tarball under `dist/`::
+
+    ./setup.py sdist
 
 Mac OS X / macOS
 --------


### PR DESCRIPTION
Combines two things:

1. I am a noob and had no idea how to create the tarball. I think the instructions I added for that are correct.
2. The `make_packages` was failing, I think because Ubuntu 18.04 has --user as a default pip option, which was interfering with usage of --prefix? Anyway, having official/upgraded pip solved it.

With these two things, I managed to make a source-with-packages tarball that ran successfully on a clean Ubuntu. Yay.