### PR TITLE
Exception reporting window: escape HTML special characters in traceback.

### DIFF
--- a/gui/qt/exception_window.py
+++ b/gui/qt/exception_window.py
@@ -27,6 +27,7 @@ import json
 import locale
 import platform
 import traceback
+import html
 
 import requests
 from PyQt5.QtCore import QObject
@@ -165,7 +166,7 @@ class Exception_Window(QWidget):
 
     def get_report_string(self):
         info = self.get_additional_info()
-        info["traceback"] = "".join(traceback.format_exception(*self.exc_args))
+        info["traceback"] = html.escape("".join(traceback.format_exception(*self.exc_args)), quote=False)
         return issue_template.format(**info)
 
 


### PR DESCRIPTION
I had an assert exception throwing on code containing < character, like `assert len(s) < 100`. Unfortunately this got truncated to `assert len(s) `, since Qt is interpreting the traceback as html. This change escapes the traceback so < characters don't mess it up.