### PR TITLE
Fixes #941 #939 - When reading tx from file -- None values were populating tx._inputs

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2382,12 +2382,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         file_content = file_content.strip()
         tx_file_dict = json.loads(str(file_content))
         tx = self.tx_from_text(file_content)
-        # Older saved transaction do not include this key.
-        if 'input_values' in tx_file_dict and len(tx_file_dict['input_values']) >= len(tx.inputs()):
-            for i in range(len(tx.inputs())):
-                value = tx_file_dict['input_values'][i]
-                if value is not None:
-                    tx._inputs[i]['value'] = value
         return tx
 
     def do_process_from_text(self):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2385,7 +2385,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         # Older saved transaction do not include this key.
         if 'input_values' in tx_file_dict and len(tx_file_dict['input_values']) >= len(tx.inputs()):
             for i in range(len(tx.inputs())):
-                tx._inputs[i]['value'] = tx_file_dict['input_values'][i]
+                value = tx_file_dict['input_values'][i]
+                if value is not None:
+                    tx._inputs[i]['value'] = value
         return tx
 
     def do_process_from_text(self):

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -187,8 +187,6 @@ class TxDialog(QDialog, MessageBoxMixin):
         fileName = self.main_window.getSaveFileName(_("Select where to save your signed transaction"), name, "*.txn")
         if fileName:
             tx_dict = self.tx.as_dict()
-            input_values = [x.get('value') for x in self.tx.inputs() if x.get('value') is not None]
-            tx_dict['input_values'] = input_values
             with open(fileName, "w+") as f:
                 f.write(json.dumps(tx_dict, indent=4) + '\n')
             self.show_message(_("Transaction saved successfully"))

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -187,7 +187,7 @@ class TxDialog(QDialog, MessageBoxMixin):
         fileName = self.main_window.getSaveFileName(_("Select where to save your signed transaction"), name, "*.txn")
         if fileName:
             tx_dict = self.tx.as_dict()
-            input_values = [x.get('value') for x in self.tx.inputs()]
+            input_values = [x.get('value') for x in self.tx.inputs() if x.get('value') is not None]
             tx_dict['input_values'] = input_values
             with open(fileName, "w+") as f:
                 f.write(json.dumps(tx_dict, indent=4) + '\n')


### PR DESCRIPTION
@rt121212121  You are the one that introduced the change that triggered this bug.  Are you ok with my fixup?

See #939  and #941.
