### PR TITLE
[WIP] Fix the support for Ledger HW1/Nano legacy hardware w/o touching Nano S/Blue

### DIFF
--- a/plugins/ledger/auth2fa.py
+++ b/plugins/ledger/auth2fa.py
@@ -8,6 +8,7 @@ from electroncash.i18n import _
 from electroncash_gui.qt.util import *
 from electroncash.util import print_msg
 from electroncash.address import Address
+from electroncash import networks
 
 import os, hashlib, websocket, logging, json, copy
 from electroncash_gui.qt.qrcodewidget import QRCodeWidget
@@ -38,7 +39,7 @@ class LedgerAuthDialog(QDialog):
         self.handler = handler
         self.txdata = data
         self.idxs = self.txdata['keycardData'] if self.txdata['confirmationType'] > 1 else ''
-        self.setMinimumWidth(600)
+        self.setMinimumWidth(1000)
         self.setWindowTitle(_("Ledger Wallet Authentication"))
         self.cfg = copy.deepcopy(self.handler.win.wallet.get_keystore().cfg)
         self.dongle = self.handler.win.wallet.get_keystore().get_client().dongle
@@ -119,10 +120,17 @@ class LedgerAuthDialog(QDialog):
         def pin_changed(s):
             if len(s) < len(self.idxs):
                 i = self.idxs[len(s)]
-                addr = self.txdata['address']
-                addr = addr.to_string(Address.FMT_LEGACY)
-                addr = addr[:i] + '<u><b>' + addr[i:i+1] + '</u></b>' + addr[i+1:]
-                self.addrtext.setHtml(str(addr))
+                address = self.txdata['address']
+
+                # Always generate the mainnet address as the code is generated from mainnet address
+                addressstr = address.to_string(Address.FMT_LEGACY, net=networks.MainNet)
+                addressstr = addressstr[:i] + '<u><b>' + addressstr[i:i+1] + '</u></b>' + addressstr[i+1:]
+
+                # We also show the UI address if it is different
+                if networks.net.TESTNET or not Address.FMT_UI == Address.FMT_LEGACY:
+                    addressstr = address.to_ui_string() + '\n' + addressstr
+
+                self.addrtext.setHtml(str(addressstr))
             else:
                 self.addrtext.setHtml(_("Press Enter"))
 

--- a/plugins/ledger/auth2fa.py
+++ b/plugins/ledger/auth2fa.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import *
 from electroncash.i18n import _
 from electroncash_gui.qt.util import *
 from electroncash.util import print_msg
+from electroncash.address import Address
 
 import os, hashlib, websocket, logging, json, copy
 from electroncash_gui.qt.qrcodewidget import QRCodeWidget
@@ -119,6 +120,7 @@ class LedgerAuthDialog(QDialog):
             if len(s) < len(self.idxs):
                 i = self.idxs[len(s)]
                 addr = self.txdata['address']
+                addr = addr.to_string(Address.FMT_LEGACY)
                 addr = addr[:i] + '<u><b>' + addr[i:i+1] + '</u></b>' + addr[i+1:]
                 self.addrtext.setHtml(str(addr))
             else:

--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -141,9 +141,6 @@ class Ledger_Client():
     def sw_supports_cashaddr(self):
         return self.cashaddrSWSupported
 
-    def is_legacy(self):
-        return self.isLegacy
-
     def supports_cashaddr(self):
         return self.fw_supports_cashaddr() and self.sw_supports_cashaddr()
 
@@ -180,14 +177,12 @@ class Ledger_Client():
                 self.dongleObject.verifyPin(pin)
 
             try:
-                self.isLegacy = False
                 try:
                     self.dongleObject.getWalletPublicKey("44'/145'/0'/0/0", showOnScreen=False, cashAddr=True)
                 except BTChipException as e:
-                    # This call fails on HW1/Nano with a specific error, due to it not supporting cashaddr, so use that to mark them legacy
+                    # This call fails on HW1/Nano with a specific error, due to it not supporting cashaddr
                     if (e.sw != 0x6b00):
                         raise e
-                    self.isLegacy = True
                 self.cashaddrSWSupported = True
             except TypeError:
                 self.cashaddrSWSupported = False
@@ -270,7 +265,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
     def cashaddr_alert(self):
         """Alert users about fw/sw updates for cashaddr."""
         if Address.FMT_UI == Address.FMT_CASHADDR:
-            # Do not warn if the device is legacy, they have no display anyway
+            # Do not warn if the device is HW1, they have no display anyway
             if not self.get_client_electrum().fw_supports_cashaddr() and not self.get_client_electrum().is_hw1():
                 self.handler.show_warning(MSG_NEEDS_FW_UPDATE_CASHADDR)
             if not self.get_client_electrum().sw_supports_cashaddr():

--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -411,7 +411,6 @@ class Ledger_KeyStore(Hardware_KeyStore):
 
             # Sign all inputs
             inputIndex = 0
-            rawTx = tx.serialize()
             self.get_client().enableAlternate2fa(False)
             cashaddr = Address.FMT_UI == Address.FMT_CASHADDR
             if cashaddr and self.get_client_electrum().supports_cashaddr():
@@ -420,7 +419,9 @@ class Ledger_KeyStore(Hardware_KeyStore):
             else:
                 self.get_client().startUntrustedTransaction(True, inputIndex,
                                                             chipInputs, redeemScripts[inputIndex])
-            outputData = self.get_client().finalizeInputFull(txOutput)
+            # we don't set meaningful outputAddress, amount and fees
+            # as we only care about the alternateEncoding==True branch
+            outputData = self.get_client().finalizeInput(b'', 0, 0, changePath, bfh(tx.serialize(True)))
             outputData['outputData'] = txOutput
             transactionOutput = outputData['outputData']
             if outputData['confirmationNeeded']:


### PR DESCRIPTION
#749 seems to be stale, so I thought I'd fix it myself.
The code sets a flag if a HW.1 is connected and checks for version 1.0.4 specifically.
For other devices the newer version is checked as before.
