### PR TITLE
add note about BIP38 keys on sweep dialog

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2706,9 +2706,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         d.setMinimumSize(600, 300)
 
         vbox = QVBoxLayout(d)
-        l = QLabel(_("Note: Electron Cash does not support import of passworded BIP38 private keys (private keys starting in 6P...). Decrypt keys to WIF format (starting with 5, K, or L) in order to sweep."))
-        l.setWordWrap(True)
-        vbox.addWidget(l)
+        bip38_warn_label = QLabel(_("<b>ERROR: Electron Cash does not support import of passworded BIP38 private keys (private keys starting in 6P...).</b> Decrypt keys to WIF format (starting with 5, K, or L) in order to sweep."))
+        bip38_warn_label.setWordWrap(True)
+        bip38_warn_label.setHidden(True)
+        vbox.addWidget(bip38_warn_label)
         vbox.addWidget(QLabel(_("Enter private keys:")))
 
         keys_e = ScanQRTextEdit(allow_multi=True)
@@ -2728,9 +2729,18 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         def get_priv_keys():
             return keystore.get_private_keys(keys_e.toPlainText())
 
+
         def enable_sweep():
-            sweep_button.setEnabled(bool(get_address_text()
-                                         and get_priv_keys()))
+            try:
+                sweepok = bool(get_address_text() and get_priv_keys())
+                hasbip38 = False
+            except ValueError as e:
+                if e.args != ('bip38',):
+                    raise
+                sweepok = False
+                hasbip38 = True
+            sweep_button.setEnabled(sweepok)
+            bip38_warn_label.setHidden(not hasbip38)
 
         keys_e.textChanged.connect(enable_sweep)
         enable_sweep()

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2706,6 +2706,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         d.setMinimumSize(600, 300)
 
         vbox = QVBoxLayout(d)
+        l = QLabel(_("Note: Electron Cash does not support import of passworded BIP38 private keys (private keys starting in 6P...). Decrypt keys to WIF format (starting with 5, K, or L) in order to sweep."))
+        l.setWordWrap(True)
+        vbox.addWidget(l)
         vbox.addWidget(QLabel(_("Enter private keys:")))
 
         keys_e = ScanQRTextEdit(allow_multi=True)

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -715,10 +715,15 @@ def is_address_list(text):
 
 
 def get_private_keys(text):
+    # break by newline
     parts = text.split('\n')
-    parts = map(lambda x: ''.join(x.split()), parts)
-    parts = list(filter(bool, parts))
-    if bool(parts) and all(bitcoin.is_private_key(x) for x in parts):
+    # for each line, remove all whitespace
+    parts = list(filter(bool, (''.join(x.split()) for x in parts)))
+
+    if any(x.startswith('6P') for x in parts):
+        raise ValueError('bip38')
+
+    if parts and all(bitcoin.is_private_key(x) for x in parts):
         return parts
 
 


### PR DESCRIPTION
I'm thinking it would be a good idea to add a note on sweep dialog like in this PR. This is in relation to #562 

![screenshot from 2018-11-26 19-41-50](https://user-images.githubusercontent.com/36528214/49057175-573f3400-f1b3-11e8-9e9c-9537b0c31c4a.png)

(Not entirely sure about the placement of it, or the exact text. Please discuss.)

Besides in sweep, WIF private key import also happens with imported-privkey wallets but I think that's less of an issue and no warning needed there.