### PR TITLE
Fix infinite loop on network error (closes #994)

### DIFF
--- a/lib/interface.py
+++ b/lib/interface.py
@@ -313,8 +313,8 @@ class Interface(util.PrintError):
         wire_requests = self.unsent_requests[0:n]
         try:
             self.pipe.send_all([make_dict(*r) for r in wire_requests])
-        except socket.error as e:
-            self.print_error("socket error:", e)
+        except (OSError, ssl.SSLError) as e:
+            self.print_error("send_requests: {}: {}".format(type(e).__name__, e))
             return False
         self.unsent_requests = self.unsent_requests[n:]
         for request in wire_requests:

--- a/lib/util.py
+++ b/lib/util.py
@@ -576,17 +576,8 @@ class SocketPipe:
 
     def _send(self, out):
         while out:
-            try:
-                sent = self.socket.send(out)
-                out = out[sent:]
-            except ssl.SSLError as e:
-                print_error("SSLError:", e)
-                time.sleep(0.1)
-                continue
-            except OSError as e:
-                print_error("OSError", e)
-                time.sleep(0.1)
-                continue
+            sent = self.socket.send(out)
+            out = out[sent:]
 
 
 def setup_thread_excepthook():


### PR DESCRIPTION
Based on https://github.com/spesmilo/electrum/commit/ad6dd73a032517651d6e029163628d67039a36d2.

This fixes the problem completely on Android: the error is logged and the network recovers to the normal number of servers within seconds.

Interestingly, the logged error is now "ConnectionAbortedError: [Errno 103] Software caused connection abort". I guess the "Broken pipe" and "Bad file descriptor" errors I was seeing before were because it was continuing to use the socket after it had already been told it was dead.