### PR TITLE
Use native libsecp256k1 if available, otherwise fall back to the old slow way.

### DIFF
--- a/contrib/build-wine/README.md
+++ b/contrib/build-wine/README.md
@@ -2,7 +2,7 @@ Windows Binary Builds
 =====================
 
 
-These scripts can be used for cross-compilation of Windows Electrum executables from Linux/Wine.
+These scripts can be used for cross-compilation of Windows Electron Cash executables from Linux/Wine.
 Produced binaries are deterministic so you should be able to generate binaries that match the official releases.
 
 Usage:
@@ -23,10 +23,22 @@ $ wine --version
  wine-2.21
 ```
 
-2. Make sure `/opt` is writable by the current user.
-3. Run `build.sh [<git-ref>]`, where <git-ref> (e.g., 3.3.1) is the branch/tag
+2. Install the following dependencies:
+
+ - dirmngr
+ - gpg
+ - 7Zip
+ - Wine (>= v2)
+ - (and, for building libsecp256k1)
+   - mingw-w64
+   - autotools-dev
+   - autoconf
+   - libtool
+
+3. Make sure `/opt` is writable by the current user.
+4. Run `build.sh [<git-ref>]`, where <git-ref> (e.g., 3.3.1) is the branch/tag
    you want to be checked out from official repo.
    (optional -- defaults a hardcoded tag found in build-electrum-git.sh )
    Note that build.sh may fail the first time after fetching gpg signatures.
    It should work correctly on the second try.
-4. The generated binaries are in `dist`.
+5. The generated binaries are in `dist`.

--- a/contrib/build-wine/build-secp256k1.sh
+++ b/contrib/build-wine/build-secp256k1.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# heavily based on https://github.com/ofek/coincurve/blob/417e726f553460f88d7edfa5dc67bfda397c4e4a/.travis/build_windows_wheels.sh
+
+set -e
+
+build_dll() {
+    #sudo apt-get install -y mingw-w64
+    export SOURCE_DATE_EPOCH=1530212462
+    ./autogen.sh
+    echo "LDFLAGS = -no-undefined" >> Makefile.am
+    LDFLAGS="-Wl,--no-insert-timestamp" ./configure \
+        --host=$1 \
+        --enable-module-recovery \
+        --enable-experimental \
+        --enable-module-ecdh \
+        --disable-jni
+    make
+    ${1}-strip .libs/libsecp256k1-0.dll
+}
+
+
+cd /tmp/electrum-build
+
+if [ ! -d secp256k1 ]; then
+    git clone https://github.com/bitcoin-core/secp256k1.git
+    cd secp256k1;
+else
+    cd secp256k1
+    git pull
+fi
+
+git reset --hard 452d8e4d2a2f9f1b5be6b02e18f1ba102e5ca0b4
+git clean -f -x -q
+
+build_dll i686-w64-mingw32  # 64-bit would be: x86_64-w64-mingw32
+mv .libs/libsecp256k1-0.dll libsecp256k1.dll
+
+find -exec touch -d '2000-11-11T11:11:11+00:00' {} +
+
+echo "building libsecp256k1 finished"

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -13,6 +13,11 @@ echo "Clearing $here/build and $here/dist..."
 rm "$here"/build/* -rf
 rm "$here"/dist/* -rf
 
+rm -fr /tmp/electrum-build
+mkdir -p /tmp/electrum-build
+
+$here/build-secp256k1.sh || exit 1
+
 $here/prepare-wine.sh && \
 $here/prepare-pyinstaller.sh || exit 1
 

--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -22,6 +22,8 @@ hiddenimports += collect_submodules('keepkeylib')
 # Add libusb binary
 binaries = [("c:/python3.5.4/libusb-1.0.dll", ".")]
 
+binaries += [('C:/tmp/libsecp256k1.dll', '.')]
+
 # Workaround for "Retro Look":
 binaries += [b for b in collect_dynamic_libs('PyQt5') if 'qwindowsvista' in b[0]]
 

--- a/contrib/build-wine/prepare-wine.sh
+++ b/contrib/build-wine/prepare-wine.sh
@@ -113,6 +113,11 @@ cp libusb/MS32/dll/libusb-1.0.dll $WINEPREFIX/drive_c/python$PYTHON_VERSION/
 #unzip -o upx.zip
 #cp upx*/upx.exe .
 
+# libsecp256k1
+mkdir -p $WINEPREFIX/drive_c/tmp
+cp /tmp/electrum-build/secp256k1/libsecp256k1.dll $WINEPREFIX/drive_c/tmp/
+
+
 # add dlls needed for pyinstaller:
 cp $WINEPREFIX/drive_c/python$PYTHON_VERSION/Lib/site-packages/PyQt5/Qt/bin/* $WINEPREFIX/drive_c/python$PYTHON_VERSION/
 

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -15,6 +15,7 @@ BUILDDIR=/tmp/electron-cash-build
 PACKAGE=Electron-Cash
 GIT_REPO_ACCT=https://github.com/Electron-Cash
 GIT_REPO=$GIT_REPO_ACCT/Electron-Cash
+LIBSECP_VERSION=452d8e4d2a2f9f1b5be6b02e18f1ba102e5ca0b4
 
 which xcodebuild > /dev/null 2>&1 || fail "Please install Xcode and xcode command line tools to continue"
 
@@ -79,6 +80,18 @@ curl https://homebrew.bintray.com/bottles/libusb-1.0.21.el_capitan.bottle.tar.gz
 tar xz --directory $BUILDDIR
 cp $BUILDDIR/libusb/1.0.21/lib/libusb-1.0.dylib contrib/osx
 DoCodeSignMaybe "libusb" "contrib/osx/libusb-1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
+
+info "Building libsecp256k1"
+git clone https://github.com/bitcoin-core/secp256k1 $BUILDDIR/secp256k1
+pushd $BUILDDIR/secp256k1
+git reset --hard $LIBSECP_VERSION
+git clean -f -x -q
+./autogen.sh
+./configure --enable-module-recovery --enable-experimental --enable-module-ecdh --disable-jni --with-bignum=no
+make
+popd
+cp -fp $BUILDDIR/secp256k1/.libs/libsecp256k1.0.dylib contrib/osx
+DoCodeSignMaybe "libsecp256k1" "contrib/osx/libsecp256k1.0.dylib" "$APP_SIGN" # If APP_SIGN is empty will be a noop
 
 info "Building CalinsQRReader..."
 d=contrib/osx/CalinsQRReader

--- a/contrib/osx/osx.spec
+++ b/contrib/osx/osx.spec
@@ -42,6 +42,7 @@ datas += [(electrum + "contrib/osx/CalinsQRReader/build/Release/CalinsQRReader.a
 
 # Add libusb so Trezor will work
 binaries = [(electrum + "contrib/osx/libusb-1.0.dylib", ".")]
+binaries += [(electrum + "contrib/osx/libsecp256k1.0.dylib", ".")]
 
 # Workaround for "Retro Look":
 binaries += [b for b in collect_dynamic_libs('PyQt5') if 'macstyle' in b[0]]

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -36,6 +36,9 @@ from .networks import NetworkConstants
 from .util import (bfh, bh2u, to_string, print_error, InvalidPassword,
                    assert_bytes, to_bytes, inv_dict)
 from . import version
+from .ecc_fast import do_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1
+
+do_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1()
 
 ################################## transactions
 

--- a/lib/ecc_fast.py
+++ b/lib/ecc_fast.py
@@ -1,0 +1,224 @@
+# taken (with minor modifications) from pycoin
+# https://github.com/richardkiss/pycoin/blob/01b1787ed902df23f99a55deb00d8cd076a906fe/pycoin/ecdsa/native/secp256k1.py
+
+import os
+import sys
+import traceback
+import ctypes
+from ctypes.util import find_library
+from ctypes import (
+    byref, c_byte, c_int, c_uint, c_char_p, c_size_t, c_void_p, create_string_buffer, CFUNCTYPE, POINTER
+)
+
+import ecdsa
+
+from .util import print_stderr, print_error
+
+
+SECP256K1_FLAGS_TYPE_MASK = ((1 << 8) - 1)
+SECP256K1_FLAGS_TYPE_CONTEXT = (1 << 0)
+SECP256K1_FLAGS_TYPE_COMPRESSION = (1 << 1)
+# /** The higher bits contain the actual data. Do not use directly. */
+SECP256K1_FLAGS_BIT_CONTEXT_VERIFY = (1 << 8)
+SECP256K1_FLAGS_BIT_CONTEXT_SIGN = (1 << 9)
+SECP256K1_FLAGS_BIT_COMPRESSION = (1 << 8)
+
+# /** Flags to pass to secp256k1_context_create. */
+SECP256K1_CONTEXT_VERIFY = (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_VERIFY)
+SECP256K1_CONTEXT_SIGN = (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_SIGN)
+SECP256K1_CONTEXT_NONE = (SECP256K1_FLAGS_TYPE_CONTEXT)
+
+SECP256K1_EC_COMPRESSED = (SECP256K1_FLAGS_TYPE_COMPRESSION | SECP256K1_FLAGS_BIT_COMPRESSION)
+SECP256K1_EC_UNCOMPRESSED = (SECP256K1_FLAGS_TYPE_COMPRESSION)
+
+
+def load_library():
+    if sys.platform == 'darwin':
+        library_path = 'libsecp256k1.0.dylib'
+    elif sys.platform in ('windows', 'win32'):
+        library_path = 'libsecp256k1.dll'
+    elif 'ANDROID_DATA' in os.environ:
+        library_path = 'libsecp256k1.so'
+    else:
+        library_path = 'libsecp256k1.so.0'
+
+    secp256k1 = ctypes.cdll.LoadLibrary(library_path)
+    if not secp256k1:
+        print_stderr('[ecc] warning: libsecp256k1 library failed to load')
+        return None
+
+    try:
+        secp256k1.secp256k1_context_create.argtypes = [c_uint]
+        secp256k1.secp256k1_context_create.restype = c_void_p
+
+        secp256k1.secp256k1_context_randomize.argtypes = [c_void_p, c_char_p]
+        secp256k1.secp256k1_context_randomize.restype = c_int
+
+        secp256k1.secp256k1_ec_pubkey_create.argtypes = [c_void_p, c_void_p, c_char_p]
+        secp256k1.secp256k1_ec_pubkey_create.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_sign.argtypes = [c_void_p, c_char_p, c_char_p, c_char_p, c_void_p, c_void_p]
+        secp256k1.secp256k1_ecdsa_sign.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_verify.argtypes = [c_void_p, c_char_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_verify.restype = c_int
+
+        secp256k1.secp256k1_ec_pubkey_parse.argtypes = [c_void_p, c_char_p, c_char_p, c_size_t]
+        secp256k1.secp256k1_ec_pubkey_parse.restype = c_int
+
+        secp256k1.secp256k1_ec_pubkey_serialize.argtypes = [c_void_p, c_char_p, c_void_p, c_char_p, c_uint]
+        secp256k1.secp256k1_ec_pubkey_serialize.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_signature_parse_compact.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_signature_parse_compact.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_signature_normalize.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_signature_normalize.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_signature_serialize_compact.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_signature_serialize_compact.restype = c_int
+
+        secp256k1.secp256k1_ec_pubkey_tweak_mul.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ec_pubkey_tweak_mul.restype = c_int
+
+        secp256k1.ctx = secp256k1.secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY)
+        r = secp256k1.secp256k1_context_randomize(secp256k1.ctx, os.urandom(32))
+        if r:
+            return secp256k1
+        else:
+            print_stderr('[ecc] warning: secp256k1_context_randomize failed')
+            return None
+    except (OSError, AttributeError):
+        #traceback.print_exc(file=sys.stderr)
+        print_stderr('[ecc] warning: libsecp256k1 library was found and loaded but there was an error when using it')
+        return None
+
+
+class _patched_functions:
+    prepared_to_patch = False
+    monkey_patching_active = False
+
+
+def _prepare_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1():
+    if not _libsecp256k1:
+        return
+
+    # save original functions so that we can undo patching (needed for tests)
+    _patched_functions.orig_sign   = staticmethod(ecdsa.ecdsa.Private_key.sign)
+    _patched_functions.orig_verify = staticmethod(ecdsa.ecdsa.Public_key.verifies)
+    _patched_functions.orig_mul    = staticmethod(ecdsa.ellipticcurve.Point.__mul__)
+
+    curve_secp256k1 = ecdsa.ecdsa.curve_secp256k1
+    curve_order = ecdsa.curves.SECP256k1.order
+    point_at_infinity = ecdsa.ellipticcurve.INFINITY
+
+    def mul(self: ecdsa.ellipticcurve.Point, other: int):
+        if self.curve() != curve_secp256k1:
+            # this operation is not on the secp256k1 curve; use original implementation
+            return _patched_functions.orig_mul(self, other)
+        other %= curve_order
+        if self == point_at_infinity or other == 0:
+            return point_at_infinity
+        pubkey = create_string_buffer(64)
+        public_pair_bytes = b'\4' + self.x().to_bytes(32, byteorder="big") + self.y().to_bytes(32, byteorder="big")
+        r = _libsecp256k1.secp256k1_ec_pubkey_parse(
+            _libsecp256k1.ctx, pubkey, public_pair_bytes, len(public_pair_bytes))
+        if not r:
+            return False
+        r = _libsecp256k1.secp256k1_ec_pubkey_tweak_mul(_libsecp256k1.ctx, pubkey, other.to_bytes(32, byteorder="big"))
+        if not r:
+            return point_at_infinity
+
+        pubkey_serialized = create_string_buffer(65)
+        pubkey_size = c_size_t(65)
+        _libsecp256k1.secp256k1_ec_pubkey_serialize(
+            _libsecp256k1.ctx, pubkey_serialized, byref(pubkey_size), pubkey, SECP256K1_EC_UNCOMPRESSED)
+        x = int.from_bytes(pubkey_serialized[1:33], byteorder="big")
+        y = int.from_bytes(pubkey_serialized[33:], byteorder="big")
+        return ecdsa.ellipticcurve.Point(curve_secp256k1, x, y, curve_order)
+
+    def sign(self: ecdsa.ecdsa.Private_key, hash: int, random_k: int):
+        # note: random_k is ignored
+        if self.public_key.curve != curve_secp256k1:
+            # this operation is not on the secp256k1 curve; use original implementation
+            return _patched_functions.orig_sign(self, hash, random_k)
+        secret_exponent = self.secret_multiplier
+        nonce_function = None
+        sig = create_string_buffer(64)
+        sig_hash_bytes = hash.to_bytes(32, byteorder="big")
+        _libsecp256k1.secp256k1_ecdsa_sign(
+            _libsecp256k1.ctx, sig, sig_hash_bytes, secret_exponent.to_bytes(32, byteorder="big"), nonce_function, None)
+        compact_signature = create_string_buffer(64)
+        _libsecp256k1.secp256k1_ecdsa_signature_serialize_compact(_libsecp256k1.ctx, compact_signature, sig)
+        r = int.from_bytes(compact_signature[:32], byteorder="big")
+        s = int.from_bytes(compact_signature[32:], byteorder="big")
+        return ecdsa.ecdsa.Signature(r, s)
+
+    def verify(self: ecdsa.ecdsa.Public_key, hash: int, signature: ecdsa.ecdsa.Signature):
+        if self.curve != curve_secp256k1:
+            # this operation is not on the secp256k1 curve; use original implementation
+            return _patched_functions.orig_verify(self, hash, signature)
+        sig = create_string_buffer(64)
+        input64 = signature.r.to_bytes(32, byteorder="big") + signature.s.to_bytes(32, byteorder="big")
+        r = _libsecp256k1.secp256k1_ecdsa_signature_parse_compact(_libsecp256k1.ctx, sig, input64)
+        if not r:
+            return False
+        r = _libsecp256k1.secp256k1_ecdsa_signature_normalize(_libsecp256k1.ctx, sig, sig)
+
+        public_pair_bytes = b'\4' + self.point.x().to_bytes(32, byteorder="big") + self.point.y().to_bytes(32, byteorder="big")
+        pubkey = create_string_buffer(64)
+        r = _libsecp256k1.secp256k1_ec_pubkey_parse(
+            _libsecp256k1.ctx, pubkey, public_pair_bytes, len(public_pair_bytes))
+        if not r:
+            return False
+
+        return 1 == _libsecp256k1.secp256k1_ecdsa_verify(_libsecp256k1.ctx, sig, hash.to_bytes(32, byteorder="big"), pubkey)
+
+    # save new functions so that we can (re-)do patching
+    _patched_functions.fast_sign   = sign
+    _patched_functions.fast_verify = verify
+    _patched_functions.fast_mul    = mul
+
+    _patched_functions.prepared_to_patch = True
+
+
+def do_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1():
+    if not _libsecp256k1:
+        # FIXME print_error will always print as 'verbosity' is not yet initialised
+        print_error('[ecc] info: libsecp256k1 library not available, falling back to python-ecdsa. '
+                    'This means signing operations will be slower.')
+        return
+    if not _patched_functions.prepared_to_patch:
+        raise Exception("can't patch python-ecdsa without preparations")
+    ecdsa.ecdsa.Private_key.sign      = _patched_functions.fast_sign
+    ecdsa.ecdsa.Public_key.verifies   = _patched_functions.fast_verify
+    ecdsa.ellipticcurve.Point.__mul__ = _patched_functions.fast_mul
+    # ecdsa.ellipticcurve.Point.__add__ = ...  # TODO??
+
+    _patched_functions.monkey_patching_active = True
+    print_error('[ecc] info: libsecp256k1 library found and will be used for ecdsa signing operations.')
+
+
+def undo_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1():
+    if not _libsecp256k1:
+        return
+    if not _patched_functions.prepared_to_patch:
+        raise Exception("can't patch python-ecdsa without preparations")
+    ecdsa.ecdsa.Private_key.sign      = _patched_functions.orig_sign
+    ecdsa.ecdsa.Public_key.verifies   = _patched_functions.orig_verify
+    ecdsa.ellipticcurve.Point.__mul__ = _patched_functions.orig_mul
+
+    _patched_functions.monkey_patching_active = False
+
+
+def is_using_fast_ecc():
+    return _patched_functions.monkey_patching_active
+
+
+try:
+    _libsecp256k1 = load_library()
+except:
+    _libsecp256k1 = None
+    #traceback.print_exc(file=sys.stderr)
+
+_prepare_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1()


### PR DESCRIPTION
Do not merge this yet.  It works but I have to figure out the packaging issues (building for OSX and for Winows) -- likely I'll merge in what upstream did.

