### PR TITLE
Catch-up performance improvements

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -938,8 +938,7 @@ class Network(util.DaemonThread):
                 interface.blockchain = None
                 interface.set_mode(Interface.MODE_BACKWARD)
                 interface.bad = request_base_height + actual_header_count - 1
-                bad_header_hex = blockchain.HeaderChunk(request_base_height, chunk_data).get_header_at_height(interface.bad)
-                interface.bad_header = blockchain.deserialize_header(bad_header_hex, interface.bad)
+                interface.bad_header = blockchain.HeaderChunk(request_base_height, chunk_data).get_header_at_height(interface.bad)
                 self.request_header(interface, min(interface.tip, interface.bad - 1))
             return
         else:


### PR DESCRIPTION
This makes the the catch-up process run about 3 times as fast on Linux, and 2 times as fast on Android. 

There are two changes:
* `deserialize_header` now uses Python's built-in `int.from_bytes` function.
* `HeaderChunk` now deserializes all the chunk's headers during initialization rather than on demand. This mainly benefits `get_bits`, which needs each deserialized header about 144 times. 