### PR TITLE
Fix address list quirk 

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -73,10 +73,11 @@ class AddressList(MyTreeWidget):
                 it = root.child(i)
                 if it and it.childCount():
                     restore_expanded_items(it, expanded_item_names) # recurse, do leaves first
-                    old = it.isExpanded()
+                    old = bool(it.isExpanded())
                     new = bool(item_path(it) in expanded_item_names)
-                    it.setExpanded(new)
-                    if old != new: print(" ---> RESTORED",item_path(it),old,"->",new)
+                    if old != new:
+                        it.setExpanded(new)
+                        print(" ---> RESTORED",item_path(it),old,"->",new)
         self.wallet = self.parent.wallet
         had_item_count = self.topLevelItemCount()
         item = self.currentItem()

--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Electrum - lightweight Bitcoin client
 # Copyright (C) 2015 Thomas Voegtlin
@@ -54,6 +54,8 @@ class AddressList(MyTreeWidget):
         self.update_headers(headers)
 
     def on_update(self):
+        def item_path(item): # recursively builds the path for an item eg 'parent_name/item_name'
+            return item.text(0) if not item.parent() else item_path(item.parent()) + "/" + item.text(0)
         def remember_expanded_items():
             # save the set of expanded items... so that address list updates don't annoyingly collapse
             # our tree list widget due to the update.
@@ -62,24 +64,34 @@ class AddressList(MyTreeWidget):
                 it = self.topLevelItem(i)
                 if it and it.childCount():
                     if it.isExpanded():
-                        expanded_item_names.add(it.text(0))
+                        expanded_item_names.add(item_path(it))
                     for j in range(0, it.childCount()):
                         it2 = it.child(j)
                         if it2 and it2.childCount() and it2.isExpanded():
-                            expanded_item_names.add(it.text(0) + "/" + it2.text(0))
+                            expanded_item_names.add(item_path(it2))
             return expanded_item_names
-        def restore_expanded_items(seq_item, used_item, expanded_item_names):
-            # restore expanded items.
-            if isinstance(seq_item, QTreeWidgetItem) and not seq_item.isExpanded() and seq_item.text(0) in expanded_item_names:
-                seq_item.setExpanded(True)
-            used_item_name = used_item.text(0) if not used_item.parent() else used_item.parent().text(0) + "/" + used_item.text(0)
-            if not used_item.isExpanded() and used_item_name in expanded_item_names:
-                used_item.setExpanded(True)       
+        def restore_expanded_items(seq_items, used_items, expanded_item_names):
+            for seq_item in seq_items:
+                # restore expanded items.
+                if (isinstance(seq_item, QTreeWidgetItem)
+                    and not seq_item.isExpanded()
+                    and seq_item.childCount()
+                    and item_path(seq_item) in expanded_item_names):
+                    seq_item.setExpanded(True)
+                    print(" ---> RESTORED SEQ ITEM",item_path(seq_item))
+            for used_item in used_items:
+                if (isinstance(used_item, QTreeWidgetItem)
+                    and not used_item.isExpanded()
+                    and used_item.childCount()
+                    and item_path(used_item) in expanded_item_names):
+                    used_item.setExpanded(True)
+                    print(" ---> RESTORED USED ITEM",item_path(used_item))
         self.wallet = self.parent.wallet
         had_item_count = self.topLevelItemCount()
         item = self.currentItem()
         current_address = item.data(0, Qt.UserRole) if item else None
         expanded_item_names = remember_expanded_items()
+        print(" ---> EXPANDED ITEMS:",expanded_item_names)
         self.clear()
         receiving_addresses = self.wallet.get_receiving_addresses()
         change_addresses = self.wallet.get_change_addresses()
@@ -90,6 +102,7 @@ class AddressList(MyTreeWidget):
             fx = None
         account_item = self
         sequences = [0,1] if change_addresses else [0]
+        reselect_items, seq_items_to_restore, used_items_to_restore = [], [], []
         for is_change in sequences:
             if len(sequences) > 1:
                 name = _("Receiving") if not is_change else _("Change")
@@ -100,6 +113,7 @@ class AddressList(MyTreeWidget):
             else:
                 seq_item = account_item
             used_item = QTreeWidgetItem( [ _("Used"), '', '', '', '', ''] )
+            print("  ------->  used_item is expanded:", used_item.isExpanded())
             used_flag = False
             addr_list = change_addresses if is_change else receiving_addresses
             for n, address in enumerate(addr_list):
@@ -131,14 +145,22 @@ class AddressList(MyTreeWidget):
                 if is_used:
                     if not used_flag:
                         seq_item.insertChild(0, used_item)
+                        used_items_to_restore.append(used_item)
                         used_flag = True
                     used_item.addChild(address_item)
                 else:
                     seq_item.addChild(address_item)
                 if address == current_address:
-                    self.setCurrentItem(address_item)
-            restore_expanded_items(seq_item, used_item, expanded_item_names)
-
+                    reselect_items.append(address_item)
+                seq_items_to_restore.append(seq_item)
+        restore_expanded_items(seq_items_to_restore, used_items_to_restore, expanded_item_names)
+        if reselect_items:
+            # NB: Need to select the item at the end becasue internally Qt does some index magic
+            # to pick out the selected item and the above code mutates the TreeList, invalidating indices
+            # and other craziness. See #1042
+            self.setCurrentItem(reselect_items[-1])
+            print(" ---> EXPANDED after reselect:", remember_expanded_items())
+        
     def create_menu(self, position):
         from electroncash.wallet import Multisig_Wallet
         is_multisig = isinstance(self.wallet, Multisig_Wallet)

--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -77,13 +77,11 @@ class AddressList(MyTreeWidget):
                     new = bool(item_path(it) in expanded_item_names)
                     if old != new:
                         it.setExpanded(new)
-                        print(" ---> RESTORED",item_path(it),old,"->",new)
         self.wallet = self.parent.wallet
         had_item_count = self.topLevelItemCount()
         item = self.currentItem()
         current_address = item.data(0, Qt.UserRole) if item else None
         expanded_item_names = remember_expanded_items(self.invisibleRootItem())
-        print(" ---> EXPANDED ITEMS:",expanded_item_names)
         self.clear()
         receiving_addresses = self.wallet.get_receiving_addresses()
         change_addresses = self.wallet.get_change_addresses()
@@ -106,7 +104,6 @@ class AddressList(MyTreeWidget):
             else:
                 seq_item = account_item
             used_item = QTreeWidgetItem( [ _("Used"), '', '', '', '', ''] )
-            print("  ------->  used_item is expanded:", used_item.isExpanded())
             used_flag = False
             addr_list = change_addresses if is_change else receiving_addresses
             for n, address in enumerate(addr_list):
@@ -150,12 +147,9 @@ class AddressList(MyTreeWidget):
             # to pick out the selected item and the above code mutates the TreeList, invalidating indices
             # and other craziness, which might produce UI glitches. See #1042
             self.setCurrentItem(items_to_re_select[-1])
-            print(" ----> ReSelected item:", item_path(items_to_re_select[-1]))
-            print(" ----> EXPANDED after reselect:", remember_expanded_items(self.invisibleRootItem()))
         
         # Now, at the very end, enforce previous UI state with respect to what was expanded or not. See #1042
         restore_expanded_items(self.invisibleRootItem(), expanded_item_names)
-        print(" ---> EXPANDED after all is said and done:", remember_expanded_items(self.invisibleRootItem()))
         
     def create_menu(self, position):
         from electroncash.wallet import Multisig_Wallet


### PR DESCRIPTION
See #1042 .

- The code that implemented "restoring the state" for the address list was hard to read and a bit wonky. I made it so it works more generically with any hierarchy of trees and subtrees.

- Restoring the "currentItem" would violate the invariant: it would sometimes cause subtrees that we wanted to stay collapsed to expand if the item is in a collapsed subtree. This fix addresses that. I'm hoping this latter "quirk" is the cause of what you guys saw in #1042.

- The previous code had out-of-spec calls to Qt in that it would sometimes call `setExpanded()` on items that don't live in any tree (the used_item sometimes doesn't live in any tree).  Not sure if that would cause a crash or not but it's definitely not a good thing. See: http://doc.qt.io/qt-5/qtreewidgetitem.html#setExpanded

Let me know if it addresses #1042 !

PS: I am temporarily leaving the print statements in there in case you guys find this doesn't fix it -- maybe you can send me the print() log and I can do further forensics.

If it does fix it I'll push another commit without the prints and we can merge.  Let me know!
