### PR TITLE
Bumped version to 3.3.3, updated AUTHORS & RELEASE-NOTES

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,12 +10,12 @@ Slush - Work on the server. Designed the original Stratum spec.
 Julian Toash (Tuxavant) - Various fixes to the client.
 rdymac - Website and translations.
 kyuupichan - Miscellaneous.
-Sombernight = many fixes
+Sombernight - many fixes
 Jonald Fyookball - Imperator
 Calin Culiannu - iOS version, MacOS packaging, MacOS QRScanner, miscellaneous
 Malcolm Smith - New Android Version, tuneups and fixups
 Roger Taylor - new version 1.4 blockchain synch code, external plugin system, miscellanous
-Mark Lubdeberg - Windows zbar, Coin Token work, various miscellanity
+Mark Lundeberg - Windows zbar, SLP (Tokens) work, various miscellanity
 Jochen Hoenicke - Trezor, Ledger, and other miscellaneous fixes
 Jonas Lundqvist - BIP70 fix, currency exchanges
 Marcel O'Neil - Miscellaneous + packaging fixups

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ rdymac - Website and translations.
 kyuupichan - Miscellaneous.
 Sombernight - many fixes
 Jonald Fyookball - Imperator
-Calin Culiannu - iOS version, MacOS packaging, MacOS QRScanner, miscellaneous
+Calin Culianu - iOS version, MacOS packaging, MacOS QRScanner, miscellaneous
 Malcolm Smith - New Android Version, tuneups and fixups
 Roger Taylor - new version 1.4 blockchain synch code, external plugin system, miscellanous
 Mark Lundeberg - Windows zbar, SLP (Tokens) work, various miscellanity

--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,12 @@ Slush - Work on the server. Designed the original Stratum spec.
 Julian Toash (Tuxavant) - Various fixes to the client.
 rdymac - Website and translations.
 kyuupichan - Miscellaneous.
+Sombernight = many fixes
+Jonald Fyookball - Imperator
+Calin Culiannu - iOS version, MacOS packaging, MacOS QRScanner, miscellaneous
+Malcolm Smith - New Android Version, tuneups and fixups
+Roger Taylor - new version 1.4 blockchain synch code, external plugin system, miscellanous
+Mark Lubdeberg - Windows zbar, Coin Token work, various miscellanity
+Jochen Hoenicke - Trezor, Ledger, and other miscellaneous fixes
+Jonas Lundqvist - BIP70 fix, currency exchanges
+Marcel O'Neil - Miscellaneous + packaging fixups

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -204,3 +204,18 @@ and there is no warning message.
 * More Spanish language translations!
 * Mac: bitcoincash: URLs working
 * Mac: Bitpay URLs working
+
+# Release 3.5.0
+
+* Added native elliptic curve cryptography using libsecp256k1 (1000x speedup on tx signing in some cases)
+* MacOS QR Reader now works.
+* Windows QR Reader now works.
+* Various performance fixes -- app should be able to handle much larger wallets now with many UTXOs
+* Nework layer fixups
+* Updated Checkpoint to the BCH chain.
+* Various minor UI gltiches fixed
+* MacOS binary size significantly reduced
+* Support for OP_RETURN parameters to bitcoincash: URL
+* Allow 1-of-1 multisig wallets
+* Server list update
+

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -205,7 +205,7 @@ and there is no warning message.
 * Mac: bitcoincash: URLs working
 * Mac: Bitpay URLs working
 
-# Release 3.5.0
+# Release 3.3.3
 
 * Added native elliptic curve cryptography using libsecp256k1 (1000x speedup on tx signing in some cases)
 * MacOS QR Reader now works.

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,4 +1,4 @@
-PACKAGE_VERSION = '3.3.2'     # version of the client package
+PACKAGE_VERSION = '3.5.0'     # version of the client package
 PROTOCOL_VERSION = '1.4'     # protocol version requested
 
 # The hash of the mnemonic seed must begin with this

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,4 +1,4 @@
-PACKAGE_VERSION = '3.5.0'     # version of the client package
+PACKAGE_VERSION = '3.3.3'     # version of the client package
 PROTOCOL_VERSION = '1.4'     # protocol version requested
 
 # The hash of the mnemonic seed must begin with this


### PR DESCRIPTION
Mark & I are in favor of bumping the version to 3.5:

- This makes it clear that 3.3.x is BCH + BSV and 3.5+ is BCH only.
- This avoids the confusing that exists now with users thinking 3.4 is better/newer/stronger than 3.3. 
- It feels good man.  3.5 has a nice ring to it.

I also went ahead and updated the AUTHORS file.  Let me know if I missed anything in the AUTHORS file or if anything needs changing.

Also added what I remembered happening from the commit logs between last release and now to RELEASE NOTES.
