### PR TITLE
[Qt] Fix main_window not being Garbage Collected

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -40,7 +40,7 @@ import PyQt5.QtCore as QtCore
 from electroncash.i18n import _, set_language
 from electroncash.plugins import run_hook
 from electroncash import WalletStorage
-from electroncash.util import UserCancelled, print_error
+from electroncash.util import UserCancelled, Weak, print_error
 from electroncash.networks import NetworkConstants
 
 from .installwizard import InstallWizard, GoBack
@@ -97,6 +97,7 @@ class ElectrumGui:
         self.daemon = daemon
         self.plugins = plugins
         self.windows = []
+        self.weak_windows = []
         self.efilter = OpenFileEventFilter(self.windows)
         self.app = QElectrumApplication(sys.argv)
         self.app.installEventFilter(self.efilter)
@@ -175,6 +176,11 @@ class ElectrumGui:
     def create_window_for_wallet(self, wallet):
         w = ElectrumWindow(self, wallet)
         self.windows.append(w)
+        dname = w.diagnostic_name()
+        def onFinalized(wr,wallet=wallet):
+            print_error("[{}] finalized".format(dname))
+            self.weak_windows.remove(wr)
+        self.weak_windows.append(Weak.ref(w,onFinalized))
         self.build_tray_menu()
         # FIXME: Remove in favour of the load_wallet hook
         run_hook('on_new_window', w)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -48,7 +48,8 @@ from electroncash.plugins import run_hook
 from electroncash.i18n import _
 from electroncash.util import (format_time, format_satoshis, PrintError,
                            format_satoshis_plain, NotEnoughFunds, ExcessiveFee,
-                           UserCancelled, bh2u, bfh, format_fee_satoshis)
+                           UserCancelled, bh2u, bfh, format_fee_satoshis, Weak,
+                           print_error)
 import electroncash.web as web
 from electroncash import Transaction
 from electroncash import util, bitcoin, commands
@@ -111,7 +112,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.gui_object = gui_object
         self.config = config = gui_object.config
 
-        self.setup_exception_hook()
+        self.setup_exception_hook(wallet)
 
         self.network = gui_object.daemon.network
         self.fx = gui_object.daemon.fx
@@ -126,8 +127,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.qr_window = None
         self.not_enough_funds = False
         self.op_return_toolong = False
-        self.internalpluginsdialog = None
-        self.externalpluginsdialog = None
         self.require_fee_update = False
         self.tx_notifications = []
         self.tl_windows = []
@@ -221,8 +220,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def on_history(self, b):
         self.new_fx_history_signal.emit()
 
-    def setup_exception_hook(self):
-        Exception_Hook(self)
+    def setup_exception_hook(self, wallet):
+        Exception_Hook(self, wallet)
 
     @rate_limited(3.0) # Rate limit to no more than once every 3 seconds
     def on_fx_history(self):
@@ -356,6 +355,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def close_wallet(self):
         if self.wallet:
             self.print_error('close_wallet', self.wallet.storage.path)
+            self.wallet.thread = None
+
         run_hook('close_wallet', self.wallet)
 
     def load_wallet(self, wallet):
@@ -474,10 +475,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         recent = recent2[:5]
         self.config.set_key('recently_open', recent)
         self.recently_visited_menu.clear()
+        gui_object = self.gui_object
         for i, k in enumerate(sorted(recent)):
             b = os.path.basename(k)
             def loader(k):
-                return lambda: self.gui_object.new_window(k)
+                return lambda: gui_object.new_window(k)
             self.recently_visited_menu.addAction(b, loader(k)).setShortcut(QKeySequence("Ctrl+%d"%(i+1)))
         self.recently_visited_menu.setEnabled(len(recent))
 
@@ -555,7 +557,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         # Settings / Preferences are all reserved keywords in OSX using this as work around
         tools_menu.addAction(_("Electron Cash preferences") if sys.platform == 'darwin' else _("Preferences"), self.settings_dialog)
-        tools_menu.addAction(_("&Network"), lambda: self.gui_object.show_network_dialog(self))
+        gui_object = self.gui_object
+        weakSelf = Weak(self)
+        tools_menu.addAction(_("&Network"), lambda: gui_object.show_network_dialog(weakSelf))
         tools_menu.addAction(_("Optional &Features"), self.internal_plugins_dialog)
         tools_menu.addAction(_("Installed &Plugins"), self.external_plugins_dialog)
         tools_menu.addSeparator()
@@ -977,6 +981,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         vbox.addLayout(Buttons(CopyCloseButton(pr_e.text, self.app, dialog)))
         dialog.setLayout(vbox)
         dialog.exec_()
+        dialog.setParent(None) # So Python can GC
 
     def export_payment_request(self, addr):
         r = self.wallet.receive_requests[addr]
@@ -1029,7 +1034,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def toggle_qr_window(self):
         from . import qrwindow
         if not self.qr_window:
-            self.qr_window = qrwindow.QR_Window(self)
+            self.qr_window = qrwindow.QR_Window()
             self.qr_window.setVisible(True)
             self.qr_window_geometry = self.qr_window.geometry()
         else:
@@ -1060,7 +1065,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         uri = web.create_URI(self.receive_address, amount, message)
         self.receive_qr.setData(uri)
         if self.qr_window and self.qr_window.isVisible():
-            self.qr_window.set_content(self.receive_address_e.text(), amount,
+            self.qr_window.set_content(self, self.receive_address_e.text(), amount,
                                        message, uri)
 
     def create_send_tab(self):
@@ -1603,7 +1608,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         vbox = QVBoxLayout(dialog)
         vbox.addLayout(clayout.layout())
         vbox.addLayout(Buttons(OkButton(dialog)))
-        if not dialog.exec_():
+        result = dialog.exec_()
+        dialog.setParent(None)
+        if not result:
             return None
         return clayout.selected_index()
 
@@ -1930,6 +1937,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         deleteButton = EnterButton(_('Delete'), do_delete)
         vbox.addLayout(Buttons(exportButton, deleteButton, CloseButton(d)))
         d.exec_()
+        d.setParent(None) # So Python can GC
 
     def do_pay_invoice(self, key):
         pr = self.invoices.get(key)
@@ -1954,13 +1962,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         console.updateNamespace({'wallet' : self.wallet,
                                  'network' : self.network,
                                  'plugins' : self.gui_object.plugins,
-                                 'window': self})
+                                 'window': Weak(self)})
         console.updateNamespace({'util' : util, 'bitcoin':bitcoin})
 
-        c = commands.Commands(self.config, self.wallet, self.network, lambda: self.console.set_json(True))
+        set_json = Weak(self.console.set_json)
+        c = commands.Commands(self.config, self.wallet, self.network, lambda: set_json(True))
         methods = {}
+        password_getter = Weak(self.password_dialog)
         def mkfunc(f, method):
-            return lambda *args, **kwargs: f(method, *args, password_getter=self.password_dialog,
+            return lambda *args, **kwargs: f(method, *args, password_getter=password_getter,
                                              **kwargs)
         for m in dir(c):
             if m[0]=='_' or m in ['network','wallet','config']: continue
@@ -1996,7 +2006,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         sb.addPermanentWidget(StatusBarButton(QIcon(":icons/preferences.png"), _("Preferences"), self.settings_dialog ) )
         self.seed_button = StatusBarButton(QIcon(":icons/seed.png"), _("Seed"), self.show_seed_dialog )
         sb.addPermanentWidget(self.seed_button)
-        self.status_button = StatusBarButton(QIcon(":icons/status_disconnected.png"), _("Network"), lambda: self.gui_object.show_network_dialog(self))
+        weakSelf = Weak(self)
+        gui_object = self.gui_object
+        self.status_button = StatusBarButton(QIcon(":icons/status_disconnected.png"), _("Network"), lambda: gui_object.show_network_dialog(weakSelf))
         sb.addPermanentWidget(self.status_button)
         run_hook('create_status_bar', sb)
         self.setStatusBar(sb)
@@ -2058,6 +2070,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         vbox.addLayout(Buttons(CancelButton(d), OkButton(d)))
         if d.exec_():
             self.set_contact(line2.text(), line1.text())
+        d.setParent(None) # for Python GC
 
     def show_master_public_keys(self):
         dialog = WindowModalDialog(self, _("Wallet Information"))
@@ -2098,6 +2111,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         vbox.addLayout(Buttons(CloseButton(dialog)))
         dialog.setLayout(vbox)
         dialog.exec_()
+        dialog.setParent(None)
 
     def remove_wallet(self):
         if self.question('\n'.join([
@@ -2165,6 +2179,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         vbox.addLayout(Buttons(CloseButton(d)))
         d.setLayout(vbox)
         d.exec_()
+        d.setParent(None)
 
     msg_sign = _("Signing with an address actually means signing with the corresponding "
                 "private key, and verifying with the corresponding public key. The "
@@ -2250,6 +2265,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         hbox.addWidget(b)
         layout.addLayout(hbox, 4, 1)
         d.exec_()
+        d.setParent(None) # for Python GC
 
     @protected
     def do_decrypt(self, message_e, pubkey_e, encrypted_e, password):
@@ -2310,12 +2326,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         layout.addLayout(hbox, 4, 1)
         d.exec_()
+        d.setParent(None)
 
     def password_dialog(self, msg=None, parent=None):
         from .password_dialog import PasswordDialog
         parent = parent or self
         d = PasswordDialog(parent, msg)
-        return d.run()
+        res = d.run()
+        d.setParent(None) # so Python can GC
+        return res
 
     def tx_from_text(self, txt):
         from electroncash.transaction import tx_from_str
@@ -2476,7 +2495,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         d.finished.connect(on_dialog_closed)
         threading.Thread(target=privkeys_thread).start()
 
-        if not d.exec_():
+        res = d.exec_()
+        d.setParent(None) # for python GC
+        if not res:
             done = True
             return
 
@@ -2552,7 +2573,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         vbox.addLayout(hbox)
         run_hook('export_history_dialog', self, hbox)
         self.update()
-        if not d.exec_():
+        res = d.exec_()
+        d.setParent(None) # for python GC
+        if not res:
             return
         filename = filename_e.text()
         if not filename:
@@ -2633,7 +2656,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         keys_e.textChanged.connect(enable_sweep)
         enable_sweep()
-        if not d.exec_():
+        res = d.exec_()
+        d.setParent(None)
+        if not res:
             return
 
         try:
@@ -3090,6 +3115,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         # run the dialog
         d.exec_()
+        d.setParent(None) # for Python GC
 
         if self.fx:
             self.fx.timeout = 0
@@ -3109,7 +3135,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         event.accept()
 
     def clean_up_connections(self):
-        def _disconnect_signals():
+        def disconnect_signals():
             for attr_name in dir(self):
                 if attr_name.endswith("_signal"):
                     sig = getattr(self, attr_name)
@@ -3119,18 +3145,37 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                             #self.print_error("Disconnected signal:",attr_name)
                         except TypeError: # no connections
                             pass
-        def _disconnect_network_callbacks():
+            try: self.disconnect()
+            except KeyError: pass
+        def disconnect_network_callbacks():
             if self.network:
                 self.network.unregister_callback(self.on_network)
                 self.network.unregister_callback(self.on_quotes)
                 self.network.unregister_callback(self.on_history)
         # /
-        _disconnect_network_callbacks()
-        _disconnect_signals()
+        disconnect_network_callbacks()
+        disconnect_signals()
+
+    def clean_up_children(self):
+        # the menu bar and status bar hold references to self, so kill them to help GC this window
+        self.setMenuBar(None)
+        self.setStatusBar(None)
+        # Reparent children to 'None' so python GC can clean them up sooner rather than later.
+        # This also hopefully helps accelerate this window's GC.
+        children = [c for c in self.children()
+                    if (isinstance(c, (QWidget,QAction,QShortcut,TaskThread))
+                        and not isinstance(c, (QStatusBar, QMenuBar, QFocusFrame)))]
+        for c in children:
+            try:
+                c.disconnect()
+                #self.print_error("disconnected",c,c.objectName())
+            except TypeError: pass
+            c.setParent(None)
+            #self.print_error("reparented",c,c.objectName())
 
     def clean_up(self):
         self.wallet.thread.stop()
-        self.clean_up_connections()
+        self.wallet.thread.wait() # Join the thread to make sure it's really dead.
 
         # We catch these errors with the understanding that there is no recovery at
         # this point, given user has likely performed an action we cannot recover
@@ -3151,13 +3196,24 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         # Should be no side-effects in this function relating to file access past this point.
         if self.qr_window:
             self.qr_window.close()
+            self.qr_window = None # force GC sooner rather than later.
         self.close_wallet()
 
-        self.gui_object.timer.timeout.disconnect(self.timer_actions)
-        self.gui_object.close_window(self)
+
+        try: self.gui_object.timer.timeout.disconnect(self.timer_actions)
+        except TypeError: pass # defensive programming: this can happen if we got an exception before the timer action was connected
+
+        self.gui_object.close_window(self) # implicitly runs the hook: on_close_window
+
+        # At this point all plugins should have removed any references to this window.
+        # Now, just to be paranoid, do some active destruction of signal/slot connections as well as
+        # Removing child widgets forcefully to speed up Python's own GC of this window.
+        self.clean_up_connections()
+        self.clean_up_children()
+
 
     def internal_plugins_dialog(self):
-        self.internalpluginsdialog = d = WindowModalDialog(self, _('Optional Features'))
+        d = WindowModalDialog(self, _('Optional Features'))
 
         plugins = self.gui_object.plugins
 
@@ -3220,11 +3276,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         grid.setRowStretch(len(plugins.internal_plugin_metadata.values()), 1)
         vbox.addLayout(Buttons(CloseButton(d)))
         d.exec_()
+        d.setParent(None) # Python will GC
 
     def external_plugins_dialog(self):
         from . import external_plugins_window
-        self.externalpluginsdialog = d = external_plugins_window.ExternalPluginsDialog(self, _('Plugin Manager'))
+        d = external_plugins_window.ExternalPluginsDialog(self, _('Plugin Manager'))
         d.exec_()
+        d.setParent(None) # Python will GC
 
     def cpfp(self, parent_tx, new_tx):
         total_size = parent_tx.estimated_size() + new_tx.estimated_size()
@@ -3268,7 +3326,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         grid.addWidget(fee_slider, 4, 1)
         vbox.addLayout(grid)
         vbox.addLayout(Buttons(CancelButton(d), OkButton(d)))
-        if not d.exec_():
+        result = d.exec_()
+        d.setParent(None) # So Python can GC
+        if not result:
             return
         fee = fee_e.get_amount()
         if fee > max_fee:

--- a/gui/qt/qrwindow.py
+++ b/gui/qt/qrwindow.py
@@ -34,9 +34,8 @@ from electroncash.i18n import _
 
 class QR_Window(QWidget):
 
-    def __init__(self, win):
-        QWidget.__init__(self)
-        self.win = win
+    def __init__(self):
+        super().__init__() # Top-level window. Parent needs to hold a reference to us and clean us up appropriately.
         self.setWindowTitle('Electron Cash - ' + _('Payment Request'))
         self.setMinimumSize(800, 250)
         self.label = ''
@@ -68,10 +67,10 @@ class QR_Window(QWidget):
         self.setLayout(main_box)
 
 
-    def set_content(self, address_text, amount, message, url):
+    def set_content(self, win, address_text, amount, message, url):
         self.address_label.setText(address_text)
         if amount:
-            amount_text = '{} {}'.format(self.win.format_amount(amount), self.win.base_unit())
+            amount_text = '{} {}'.format(win.format_amount(amount), win.base_unit())
         else:
             amount_text = ''
         self.amount_label.setText(amount_text)

--- a/lib/util.py
+++ b/lib/util.py
@@ -612,7 +612,7 @@ def versiontuple(v):
 class WeakMethodProxy(weakref.WeakMethod):
     ''' Direct-use of this class is discouraged (aside from assigning to its print_func attribute).
         Instead use of the wrapper function 'Weak' defined below is encouraged. '''
-    def print_func(self, *args): # <--- you are encouraged to monkey patched this in client code, either on the class or instance level
+    def print_func(self, *args): # <--- you are encouraged to monkey patch this in client code, either on the class or instance level, to control debug printing behavior
         print_error(*args)
 
     def __init__(self, meth, *args, **kwargs):

--- a/lib/util.py
+++ b/lib/util.py
@@ -649,7 +649,7 @@ def Weak(obj_or_bound_method, *args, **kwargs):
     ugly `foo()(args)`, or perhaps `foo() and foo()(args)` idioms.
 
     Also note that no exception is ever raised with WeakMethodProxy instances
-    when calling them.
+    when calling them on dead references.
 
     Instead, if the weakly bound method is no longer alive (because its object
     died), errors are silently ignored.
@@ -668,7 +668,7 @@ def Weak(obj_or_bound_method, *args, **kwargs):
     This Weak/WeakMethodProxy usage/idiom is intented to be used with Qt's
     signal/slots mechanism to allow for Qt bound signals to not keep target
     objects from being garbage collected -- hence the permissiveness in not
-    throwing exceptions.
+    raising exceptions.
     '''
 
     if inspect.ismethod(obj_or_bound_method):

--- a/lib/util.py
+++ b/lib/util.py
@@ -667,6 +667,13 @@ class Weak:
             # Not a method, just return a weakref.proxy
             return weakref.proxy(obj_or_bound_method, *args, **kwargs)
 
+    ref = weakref.ref # alias for convenience so you don't have to import weakref
+    Set = weakref.WeakSet # alias for convenience
+    ValueDictionary = weakref.WeakValueDictionary # alias for convenience
+    KeyDictionary = weakref.WeakKeyDictionary # alias for convenience
+    Method = weakref.WeakMethod # alias
+    finalize = weakref.finalize # alias
+
     class WeakMethodProxy(weakref.WeakMethod):
         ''' Direct-use of this class is discouraged (aside from assigning to
             its print_func attribute). Instead use of the wrapper class 'Weak'

--- a/lib/util.py
+++ b/lib/util.py
@@ -667,8 +667,8 @@ class Weak:
     class WeakMethodProxy(weakref.WeakMethod):
         ''' Direct-use of this class is discouraged (aside from assigning to its print_func attribute).
             Instead use of the wrapper function 'Weak' defined below is encouraged. '''
-        def print_func(self, this, info): # <--- you are encouraged to monkey patch this in client code, either on the class or instance level, to control debug printing behavior
-            print_error(this, info)
+
+        print_func = lambda x, this, info: print_error(this, info) # <--- you are encouraged to monkey patch this in client code, either on the class or instance level, to control debug printing behavior
 
         def __init__(self, meth, *args, **kwargs):
             super().__init__(meth, *args, **kwargs)


### PR DESCRIPTION
- Introduces a new factory class 'Weak' in `electroncash.util`, which is a convenient wrapper for weakref

- Lots of the windows and dependent temporary dialogs would never get cleaned up.  This has been fixed.

- The exception hook was keeping windows alive.  Fixed.

- Lots of cleanup code introduced to speed up the GC process and get rid of as much stale data as possible right away.
