### PR TITLE
setup-release.py: drop mention of QtWebKit, QtNetwork

### DIFF
--- a/setup-release.py
+++ b/setup-release.py
@@ -36,7 +36,6 @@ if sys.platform == 'darwin':
         setup_requires=['py2app'],
         app=[mainscript],
         options=dict(py2app=dict(argv_emulation=False,
-                                 includes=['PyQt5.QtCore', 'PyQt5.QtGui', 'PyQt5.QtWebKit', 'PyQt5.QtNetwork', 'sip'],
                                  packages=['lib', 'gui', 'plugins', 'packages'],
                                  iconfile='electron.icns',
                                  plist=plist,


### PR DESCRIPTION
These are not used. QtWebKit is deprecated since Qt 5.5.