### PR TITLE
allow raw hexadecimal input for op_returns (binary stuff, multi-pushes, etc.)

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1306,7 +1306,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         try:
             op_return_script = b'\x6a' + bytes.fromhex(op_return.strip())
         except ValueError:
-            raise OPReturnError(_('OP_RETURN script expected to be hexadecimal'))
+            raise OPReturnError(_('OP_RETURN script expected to be hexadecimal bytes'))
         if len(op_return_script) > 223:
             raise OPReturnTooLarge(_("OP_RETURN script too large, needs to be under 223 bytes"))
         amount = 0

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1110,7 +1110,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         hbox = QHBoxLayout()
         hbox.addWidget(self.message_opreturn_e)
         self.opreturn_rawhex_cb = QCheckBox(_('Hex script'))
-        self.opreturn_rawhex_cb.setToolTip(_('If unchecked, the textbox contents be UTF8-encoded and result in a single-push script: <tt>OP_RETURN PUSH &lt;text&gt;</tt>. If checked, the text contents will be interpreted as a raw hexadecimal script to be appended after the OP_RETURN opcode: <tt>OP_RETURN &lt;script&gt;</tt>.'))
+        self.opreturn_rawhex_cb.setToolTip(_('If unchecked, the textbox contents are UTF8-encoded into a single-push script: <tt>OP_RETURN PUSH &lt;text&gt;</tt>. If checked, the text contents will be interpreted as a raw hexadecimal script to be appended after the OP_RETURN opcode: <tt>OP_RETURN &lt;script&gt;</tt>.'))
         hbox.addWidget(self.opreturn_rawhex_cb)
         grid.addLayout(hbox,  3 , 1, 1, -1)
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1206,6 +1206,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.message_opreturn_e.textEdited.connect(self.update_fee)
         self.message_opreturn_e.textChanged.connect(self.update_fee)
         self.message_opreturn_e.editingFinished.connect(self.update_fee)
+        self.opreturn_rawhex_cb.stateChanged.connect(self.update_fee)
 
         def reset_max(t):
             self.is_max = False
@@ -1243,6 +1244,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.message_opreturn_e.textChanged.connect(entry_changed)
         self.message_opreturn_e.textEdited.connect(entry_changed)
         self.message_opreturn_e.editingFinished.connect(entry_changed)
+        self.opreturn_rawhex_cb.stateChanged.connect(entry_changed)
 
         self.invoices_label = QLabel(_('Invoices'))
         from .invoice_list import InvoiceList

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1109,7 +1109,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.message_opreturn_e = MyLineEdit()
         hbox = QHBoxLayout()
         hbox.addWidget(self.message_opreturn_e)
-        self.opreturn_rawhex_cb = QCheckBox(_('Hex script'))
+        self.opreturn_rawhex_cb = QCheckBox(_('Raw hex script'))
         self.opreturn_rawhex_cb.setToolTip(_('If unchecked, the textbox contents are UTF8-encoded into a single-push script: <tt>OP_RETURN PUSH &lt;text&gt;</tt>. If checked, the text contents will be interpreted as a raw hexadecimal script to be appended after the OP_RETURN opcode: <tt>OP_RETURN &lt;script&gt;</tt>.'))
         hbox.addWidget(self.opreturn_rawhex_cb)
         grid.addLayout(hbox,  3 , 1, 1, -1)


### PR DESCRIPTION
This adds a checkbox so you can input the raw scriptpubkey to appear after the OP_RETURN, in hexadecimal. This gives you exact control over the OP_RETURN message and lets you do multiple pushes, non-minimal pushes, etc.. Here's an example of me using it to manually make a [CashAccount](https://www.cashaccount.info) registration (I just clicked preview -- after the screenshot was taken, I then signed and broadcasted it).

![screenshot from 2019-01-02 21-57-19](https://user-images.githubusercontent.com/36528214/50625053-2bae1880-0eda-11e9-9d94-35c42c077f40.png)
