### PR TITLE
[Qt] Anti-Phishing: Network Dialog Whitelist and Blacklist (user editable)

### DIFF
--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -33,7 +33,7 @@ import PyQt5.QtCore as QtCore
 from electroncash.i18n import _
 from electroncash.networks import NetworkConstants
 from electroncash.util import print_error, Weak
-from electroncash.network import serialize_server, deserialize_server
+from electroncash.network import serialize_server, deserialize_server, get_eligible_servers
 
 from .util import *
 
@@ -444,7 +444,8 @@ class NetworkChoiceLayout(QObject):
             bl_srv_ct_str = ' ({}) <a href="ViewBlackList">{}</a>'.format(len(self.network.blacklisted_servers), _("View blacklist..."))
         else:
             bl_srv_ct_str = " (0)<i> </i>" # ensure rich text
-        self.legend_label.setText(ServerFlag.Symbol[ServerFlag.Default] + "=" + _("Default") + " ({})".format(len(self.network.whitelisted_servers)) + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
+        servers_whitelisted = set(get_eligible_servers(self.servers, protocol)).intersection(self.network.whitelisted_servers) - self.network.blacklisted_servers
+        self.legend_label.setText(ServerFlag.Symbol[ServerFlag.Default] + "=" + _("Default") + " ({})".format(len(servers_whitelisted)) + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
                                   + ServerFlag.Symbol[ServerFlag.Blacklisted] + "=" + _("Blacklisted") + bl_srv_ct_str)
         self.servers_list.update(self.network, self.servers, self.protocol, self.tor_cb.isChecked())
         self.enable_set_server()

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -115,7 +115,7 @@ class NodesListWidget(QTreeWidget):
             else:
                 x = self
             for i in items:
-                star = ' ☚' if i == network.interface else ''
+                star = ' ◀' if i == network.interface else ''
                 item = QTreeWidgetItem([i.host + star, '%d'%i.tip])
                 item.setData(0, Qt.UserRole, 0)
                 item.setData(1, Qt.UserRole, i.server)

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -58,7 +58,8 @@ class NetworkConstants:
         cls.HEADERS_URL = "http://bitcoincash.com/files/blockchain_headers"
         cls.GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
         cls.DEFAULT_PORTS = {'t': '50001', 's': '50002'}
-        cls.DEFAULT_SERVERS = read_json_dict('servers.json')
+        cls.DEFAULT_SERVERS = read_json_dict('servers.json') # this may get modified by Network class
+        cls.HARDCODED_DEFAULT_SERVERS = cls.DEFAULT_SERVERS.copy() # this is the original servers.json. Do not modify
         cls.TITLE = 'Electron Cash'
 
         # Bitcoin Cash fork block specification
@@ -86,6 +87,7 @@ class NetworkConstants:
         cls.GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
         cls.DEFAULT_PORTS = {'t':'51001', 's':'51002'}
         cls.DEFAULT_SERVERS = read_json_dict('servers_testnet.json')
+        cls.HARDCODED_DEFAULT_SERVERS = cls.DEFAULT_SERVERS.copy()
         cls.TITLE = 'Electron Cash Testnet'
 
         # Bitcoin Cash fork block specification


### PR DESCRIPTION
This addresses #1065.

The rationale for this new facility is that we want the user to be able to guard against sybil attacks. As such, we now offer a facility to specify "white listed" servers, as well as have the user manually specify the previously internal-only server blacklist.

Highlights:

- White-list is called "**Default server**" in the GUI to make it a very neutral term (suggested by im_uname).
- The "white listing" facility is **ONLY** used If the user has "Connect to default servers only" checked. *This option is off by default.*
- The white list is fully user-editable
- The default white-list are the servers specified in the `servers.json` file
- The user may also elect to manually blacklist servers (previous to this, the blacklist was managed internally for servers that were otherwise misbehaving) -- this brings the internal-only blacklist into full view in the UI.
- User may clear the entire blacklist with a couple of clicks in the GUI
- User may manually add/remove servers individually to/from the blacklist
- Blacklisted servers can never be connected to (unless they are unblacklisted).

---

Here are some screen shots: 

<img width="350" alt="screen shot 2019-01-09 at 8 00 47 pm" src="https://user-images.githubusercontent.com/266627/50918624-6ae3e880-1449-11e9-9c12-e5513d8b50d0.png">
<img width="350" alt="screen shot 2019-01-09 at 8 01 28 pm" src="https://user-images.githubusercontent.com/266627/50918619-69b2bb80-1449-11e9-8b4a-ada12161fbba.png">
<img width="350" alt="screen shot 2019-01-09 at 8 01 22 pm" src="https://user-images.githubusercontent.com/266627/50918621-69b2bb80-1449-11e9-800f-ff02e2231345.png">
<img width="350" alt="screen shot 2019-01-09 at 8 01 43 pm" src="https://user-images.githubusercontent.com/266627/50918617-69b2bb80-1449-11e9-8af3-49d567c9cbc9.png">
<img width="350" alt="screen shot 2019-01-09 at 8 01 11 pm" src="https://user-images.githubusercontent.com/266627/50918622-69b2bb80-1449-11e9-9a41-9fa1d664754d.png">
<img width="350" alt="screen shot 2019-01-09 at 8 01 02 pm" src="https://user-images.githubusercontent.com/266627/50918623-6a4b5200-1449-11e9-86ab-ed0cbe96b8e1.png">

---

#### Note: I need help/advice on the icons.  I used some maximally compatible unicode characters here but maybe we can use actual icons or other characters?
