### PR TITLE
Make Android build script accept more syntax variations in version.py

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,7 +21,7 @@ android {
 
         def ecVersion = null
         file("$REPO_ROOT/lib/version.py").eachLine {
-            def matcher = it =~ /PACKAGE_VERSION = '(.+)'.*/
+            def matcher = it =~ / *PACKAGE_VERSION *= *'([0-9.]+)'.*/
             if (matcher.matches()) {
                 ecVersion = matcher.group(1)
             }


### PR DESCRIPTION
You'll never be able to parse arbitrary Python code with a regex, but this should at least be a bit more flexible.

It still requires the version to be 3 numbers separated by dots, because it uses that to create the integer version code which Android uses internally.