### PR TITLE
raw opreturn in URIs

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1324,6 +1324,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def output_for_opreturn_rawhex(op_return):
         if not isinstance(op_return, str):
             raise OPReturnError('OP_RETURN parameter needs to be of type str!')
+        if op_return == 'empty':
+            op_return = ''
         try:
             op_return_script = b'\x6a' + bytes.fromhex(op_return.strip())
         except ValueError:
@@ -1769,6 +1771,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         elif op_return_raw is not None:
             # 'is not None' allows blank value.
             # op_return_raw is secondary precedence to op_return
+            if not op_return_raw:
+                op_return_raw='empty'
             self.message_opreturn_e.setText(op_return_raw)
             self.message_opreturn_e.setHidden(False)
             self.opreturn_rawhex_cb.setHidden(False)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1748,6 +1748,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         label = out.get('label')
         message = out.get('message')
         op_return = out.get('op_return')
+        op_return_raw = out.get('op_return_raw')
+
         # use label as description (not BIP21 compliant)
         if label and not message:
             message = label
@@ -1763,6 +1765,14 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.message_opreturn_e.setHidden(False)
             self.opreturn_rawhex_cb.setHidden(False)
             self.opreturn_rawhex_cb.setChecked(False)
+            self.opreturn_label.setHidden(False)
+        elif op_return_raw is not None:
+            # 'is not None' allows blank value.
+            # op_return_raw is secondary precedence to op_return
+            self.message_opreturn_e.setText(op_return_raw)
+            self.message_opreturn_e.setHidden(False)
+            self.opreturn_rawhex_cb.setHidden(False)
+            self.opreturn_rawhex_cb.setChecked(True)
             self.opreturn_label.setHidden(False)
         elif not self.config.get('enable_opreturn'):
             self.message_opreturn_e.setText('')

--- a/lib/web.py
+++ b/lib/web.py
@@ -124,9 +124,9 @@ def parse_URI(uri, on_pr=None):
     # python for android fails to parse query
     if address.find('?') > 0:
         address, query = u.path.split('?')
-        pq = urllib.parse.parse_qs(query)
+        pq = urllib.parse.parse_qs(query, keep_blank_values=True)
     else:
-        pq = urllib.parse.parse_qs(u.query)
+        pq = urllib.parse.parse_qs(u.query, keep_blank_values=True)
 
     for k, v in pq.items():
         if len(v)!=1:


### PR DESCRIPTION
Some extended discussion on #952, combined with the new #1086 , suggests that we should add a new parameter to the uri scheme: **op_return_raw**

* the format is for `op_return_raw=<hex_string>`. The hex string decoded to binary then the byte 0x6a (OP_RETURN) is prefixed, resulting in the final scriptPubKey.
* For example, `op_return_raw=4c077361746f736869510101` results in the following scriptPubKey bytestring: `b'jL\x07satoshiQ\x01\x01'`, i.e., script `OP_RETURN OP_PUSHDATA1 0x07 'satoshi' OP_1 OP_PUSH1 '\x01'`
* Note this means the op_return_raw must include all relevant push opcodes, where desired. This can be used to make non-minimal pushes like the above example. Current bitcoin relay rules mean that op_return scripts must parse to a series of pushes but they need not be minimal.
* If both op_return_raw and op_return are provided, op_return takes precedence and op_return_raw is ignored.
* If the url contains "op_return_raw=" with no payload, then a one-byte scriptPubKey should be created (just op_return).

Above example was tested and I made the following tx: https://bch.btc.com/a4c7a5b85db7a44590d391e9ca54e344795fe15a2fe11ccd77ab30f5a7b41d3b

* note that electron cash supports just entering op_return in send dialog, with no amount and no address. Then it just notarizes the op_return to blockchain and sends the rest of the input coin back as change. Strangely this can be represented in URI form: `bitcoincash:?op_return_raw=4c077361746f736869510101`.

In the UI,if you want truly empty after OP_RETURN you have to type 'empty', to avoid accidents where user has clicked the checkbox. When you do `bitcoincash:?op_return_raw=`, it autofills this 'empty' string into the UI.

(ping @jimtendo)