### PR TITLE
[Qt] Update checker + Networks.py refactoring + Misc Nits and Cleanup

### DIFF
--- a/contrib/update_checker/README.md
+++ b/contrib/update_checker/README.md
@@ -1,0 +1,65 @@
+# Electron Cash Update Checker
+### (`releases.json`)
+
+This directory contains the `releases.json` file that the Electron Cash update checker uses to determine when a new version of Electron Cash is available.
+
+#### Update Checker Overview
+As of version 3.3.6 of Electron Cash, there is an update-checking facility built-in to the Qt desktop app. The facility basically functions as follows:
+
+1. When the user selects "Check for updates...", Electron Cash connects to the URL hard-coded in `gui/qt/update_checker.py` (currently: https://raw.github.com/Electron-Cash/Electron-Cash/master/contrib/update_checker/releases.json)
+2. It downloads `releases.json` (the file in this directory)
+3. It checks the versions seen in `releases.json` -- if they are newer than the version in the running app, and if the signed message is valid and is signed with one of the addresses hard-coded in `update_checker.py`, it then informs the user that an update is available.
+
+*No automatic updating is performed* and the user must manually click on the URL hard-coded in the app to go to https://electroncash.org/#download.
+
+The purpose of this facility is merely as a convenience for users who aren't on reddit or aren't constantly refreshing our website to be able to find out when a new version is available.
+
+It hopefully will decrease the number of users running very old versions of Electron Cash.
+
+#### What This Means For You, The Maintainer
+You need to update `releases.json` in this directory whenever a new version of Electron Cash is released, and push it to master.
+
+This file contains a dictionary of:
+```
+    { 
+        "version string" : { "bitcoin address" : "signed message" }
+    }
+```
+- **"version string"** above is a version of the form MAJOR.MINOR.REV[variant], e.g. "3.3.5" or "3.3.5CS" (in the latter, 'CS' is the variant)
+- And empty/omitted variant means "Electron Cash Regular"
+- The variant must match the variant in `lib/version.py`.
+    
+
+#### How To Update `releases.json`
+
+  1. Release Electron Cash as normal, updating the version in `lib/version.py`.
+  2. After release, or in tandem with releasing, edit `releases.json`
+  3. Make sure to replace the entry for the old version with a new entry. 
+  4. So for example if you were on verson "3.3.4" before and you are now releasing "3.3.5", look for "3.3.4" in `releases.json`, and update it to "3.3.5"
+  5. Sign the text "3.3.5" with one of the bitcoin addresses listed in `gui/qt/update_checker.py`.  Paste this address and the signed message (replacing the old address and signed message) into the dictionary entry for "3.3.5" in `releases.json`.
+  6. Push the new commit with the updated `releases.json` to master. (Since currently the `update_checker.py` code looks for this file in master on github).
+  
+##### Example
+*The old entry:*
+
+     "3.3.4": {
+     	"bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82": "G8lW9Wh2/sa2I7Sd0jdAlit+lYwrXFwjG7ZDUEDngSwyPAT29YMKP68hqeaW7+mp4gClY1+qPIAQsFqzPtoMbTw="
+     }
+
+*Gets replaced with:*
+
+    "3.3.5": {
+     	"bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82": "HPC+QnKXdxW/V6qeVFGjYKeP9YQ6DL16Y1SQznavG/G7FUEpMK1wnkAj5yO/RW440mvXxds1PpS35RaEMtvbgJw="
+     }
+
+Notice how the version string is different, the signing address happened to remain the same, and, of course, the signature is different now.
+
+##### How Do I Sign?
+
+- Make sure you control one of the bitcoin addresses listed in `gui/qt/update_checker.py`.  (If you do not, modify this file before release to include one of your addresses!)
+-  Open up Electron Cash and go to that address in the "Addresses" tab and right click on it, selecting **"Sign/Verify Message"**
+-  The message to be signed is the version string you will put into the JSON, so for example the simple string `3.3.5` in the example above.
+-  Hit **sign**, and paste the signed text into the JSON.
+
+##### Feedback / Questions
+Open up an issue in the issue tracker or contact Calin Culianu (/u/NilacTheGrim on reddit), as he is the author of this mechanism in Electron Cash.

--- a/contrib/update_checker/README.md
+++ b/contrib/update_checker/README.md
@@ -59,7 +59,7 @@ Notice how the version string is different, the signing address happened to rema
 - Make sure you control one of the bitcoin addresses listed in `gui/qt/update_checker.py`.  (If you do not, modify this file before release to include one of your addresses!)
 -  Open up Electron Cash and go to that address in the "Addresses" tab and right click on it, selecting **"Sign/Verify Message"**
 -  The message to be signed is the version string you will put into the JSON, so for example the simple string `3.3.5` in the example above.
--  Hit **sign**, and paste the signed text into the JSON.
+-  Hit **sign**, and paste the signature text into the JSON (and signing address, of course, if it's changed).
 
-##### Feedback / Questions
+#### Feedback / Questions
 Open up an issue in the issue tracker or contact Calin Culianu (/u/NilacTheGrim on reddit), as he is the author of this mechanism in Electron Cash.

--- a/contrib/update_checker/releases.json
+++ b/contrib/update_checker/releases.json
@@ -1,0 +1,8 @@
+{
+     "3.3.5": {
+     	"bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82": "HPC+QnKXdxW/V6qeVFGjYKeP9YQ6DL16Y1SQznavG/G7FUEpMK1wnkAj5yO/RW440mvXxds1PpS35RaEMtvbgJw="
+     },
+     "3.3.4CS": {
+         "bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82": "HNkxAJzvWGP5/YPIJrZRQFK5btM1nd/NKCwWAlejc5oEJ6VNbzo6KfqOoIBpPTauK21Tp/qXY7SMmlO+6ssMPOA="
+     }
+}

--- a/electron-cash
+++ b/electron-cash
@@ -95,7 +95,7 @@ if is_local:
 
 from electroncash import bitcoin, util
 from electroncash import SimpleConfig, Network
-from electroncash.networks import NetworkConstants
+from electroncash.networks import NetworkConstants, set_testnet
 from electroncash.wallet import Wallet, ImportedPrivkeyWallet, ImportedAddressWallet
 from electroncash.storage import WalletStorage
 from electroncash.util import print_msg, print_stderr, json_encode, json_decode
@@ -350,7 +350,7 @@ if __name__ == '__main__':
     set_verbosity(config_options.get('verbose') and config_options.get('gui')!='kivy')
 
     if config_options.get('testnet'):
-        NetworkConstants.set_testnet()
+        set_testnet()
 
     # check uri
     uri = config_options.get('url')

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -39,7 +39,6 @@ from electroncash.i18n import _, set_language
 from electroncash.plugins import run_hook
 from electroncash import WalletStorage
 from electroncash.util import UserCancelled, Weak, PrintError, print_error
-from electroncash.networks import NetworkConstants
 
 from .installwizard import InstallWizard, GoBack
 

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -263,7 +263,8 @@ class ElectrumGui(QObject, PrintError):
             self.update_checker.do_check()
 
     def on_auto_update_timeout(self):
-        self.update_checker.do_check()
+        if not self.update_checker.did_check_recently():  # make sure auto-check doesn't happen right after a manual check.
+            self.update_checker.do_check()
         if self.update_checker_timer.first_run:
             self._start_auto_update_timer(first_run = False)
 

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -33,7 +33,6 @@ except Exception:
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtCore import *
-import PyQt5.QtCore as QtCore
 
 from electroncash.i18n import _, set_language
 from electroncash.plugins import run_hook
@@ -65,9 +64,9 @@ class ElectrumGui(QObject, PrintError):
         #    from electroncash.synchronizer import Synchronizer
         #    daemon.network.add_jobs([DebugMem([Abstract_Wallet, SPV, Synchronizer,
         #                                       ElectrumWindow], interval=5)])
-        QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_X11InitThreads)
-        if hasattr(QtCore.Qt, "AA_ShareOpenGLContexts"):
-            QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts)
+        QCoreApplication.setAttribute(Qt.AA_X11InitThreads)
+        if hasattr(Qt, "AA_ShareOpenGLContexts"):
+            QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
         if hasattr(QGuiApplication, 'setDesktopFileName'):
             QGuiApplication.setDesktopFileName('electron-cash.desktop')
         self.config = config
@@ -77,10 +76,12 @@ class ElectrumGui(QObject, PrintError):
         self.weak_windows = []
         self.app = QApplication(sys.argv)
         self.app.installEventFilter(self)
-        self.timer = QTimer(self.app); self.timer.setSingleShot(False); self.timer.setInterval(500) #msec
-        self.gc_timer = QTimer(self.app); self.gc_timer.setSingleShot(True); self.gc_timer.timeout.connect(ElectrumGui.gc); self.gc_timer.setInterval(333) #msec
+        self.timer = QTimer(self); self.timer.setSingleShot(False); self.timer.setInterval(500) #msec
+        self.gc_timer = QTimer(self); self.gc_timer.setSingleShot(True); self.gc_timer.timeout.connect(ElectrumGui.gc); self.gc_timer.setInterval(333) #msec
         self.nd = None
-        self.update_checker = None
+        self.update_checker = UpdateChecker()
+        self.update_checker_timer = QTimer(self); self.update_checker_timer.timeout.connect(self.on_auto_update_timeout); self.update_checker_timer.setSingleShot(False)
+        self.update_checker.got_new_version.connect(lambda x: self.show_update_checker(parent=None, skip_check=True))
         # init tray
         self.dark_icon = self.config.get("dark_icon", False)
         self.tray = QSystemTrayIcon(self.tray_icon(), None)
@@ -91,10 +92,12 @@ class ElectrumGui(QObject, PrintError):
         self.new_window_signal.connect(self.start_new_window)
         run_hook('init_qt', self)
         ColorScheme.update_from_widget(QWidget())
+        if self.has_auto_update_check():
+            self._start_auto_update_timer(first_run = True)
 
     def eventFilter(self, obj, event):
         ''' This event filter allows us to open bitcoincash: URIs on macOS '''
-        if event.type() == QtCore.QEvent.FileOpen:
+        if event.type() == QEvent.FileOpen:
             if len(self.windows) >= 1:
                 self.windows[0].pay_to_URI(event.url().toString())
                 return True
@@ -113,6 +116,8 @@ class ElectrumGui(QObject, PrintError):
             submenu.addAction(_("Show/Hide"), window.show_or_hide)
             submenu.addAction(_("Close"), window.close)
         m.addAction(_("Dark/Light"), self.toggle_tray_icon)
+        m.addSeparator()
+        m.addAction(_("&Check for updates..."), lambda: self.show_update_checker(None))
         m.addSeparator()
         m.addAction(_("Exit Electron Cash"), self.close)
         self.tray.setContextMenu(m)
@@ -199,17 +204,15 @@ class ElectrumGui(QObject, PrintError):
             except BaseException as e:
                 traceback.print_exc(file=sys.stdout)
                 if '2fa' in str(e):
-                    d = QMessageBoxMixin(QMessageBox.Warning, _('Error'), '2FA wallets for Bitcoin Cash are currently unsupported by <a href="https://api.trustedcoin.com/#/">TrustedCoin</a>. Follow <a href="https://github.com/Electron-Cash/Electron-Cash/issues/41#issuecomment-357468208">this guide</a> in order to recover your funds.')
-                    d.exec_()
+                    self.warning(title=_('Error'), message = '2FA wallets for Bitcoin Cash are currently unsupported by <a href="https://api.trustedcoin.com/#/">TrustedCoin</a>. Follow <a href="https://github.com/Electron-Cash/Electron-Cash/issues/41#issuecomment-357468208">this guide</a> in order to recover your funds.')
                 else:
-                    d = QMessageBoxMixin(QMessageBox.Warning, _('Error'), 'Cannot load wallet:\n' + str(e))
-                    d.exec_()
+                    self.warning(title=_('Error'), message = 'Cannot load wallet:\n' + str(e))
                 return
             w = self.create_window_for_wallet(wallet)
         if uri:
             w.pay_to_URI(uri)
         w.bring_to_top()
-        w.setWindowState(w.windowState() & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
+        w.setWindowState(w.windowState() & ~Qt.WindowMinimized | Qt.WindowActive)
 
         # this will activate the window
         w.activateWindow()
@@ -237,7 +240,7 @@ class ElectrumGui(QObject, PrintError):
         Note that rapid-fire calls to this re-start the timer each time, thus
         only the last call takes effect (it's rate-limited). '''
         self.gc_timer.start() # start/re-start the timer to fire exactly once in timeInterval() msecs
-        
+
     @staticmethod
     def gc():
         ''' self.gc_timer timeout() slot '''
@@ -284,21 +287,59 @@ class ElectrumGui(QObject, PrintError):
         else:
             self.print_error("Qt proxy set to: NoProxy")
 
-    def show_update_checker(self, parent):
+    def show_update_checker(self, parent, *, skip_check = False):
         if self.warn_if_no_network(parent):
             return
-        if not self.update_checker:
-            self.update_checker = UpdateChecker()
         self.update_checker.show()
         self.update_checker.raise_()
+        if not skip_check:
+            self.update_checker.do_check()
+
+    def on_auto_update_timeout(self):
         self.update_checker.do_check()
+        if self.update_checker_timer.first_run:
+            self._start_auto_update_timer(first_run = False)
+
+    def _start_auto_update_timer(self, *, first_run = False):
+        self.update_checker_timer.first_run = bool(first_run)
+        if first_run:
+            interval = 10.0*1e3 # do it very soon (in 10 seconds)
+        else:
+            interval = 3600.0*1e3 # once per hour (in ms)
+        self.update_checker_timer.start(interval)
+        self.print_error("Auto update check: interval set to {} seconds".format(interval//1e3))
+
+    def _stop_auto_update_timer(self):
+        self.update_checker_timer.stop()
+        self.print_error("Auto update check: disabled")
 
     def warn_if_no_network(self, parent):
         if not self.daemon.network:
-            parent.show_warning(_('You are using Electron Cash in offline mode; restart Electron Cash if you want to get connected'), title=_('Offline'))
+            self.warning(message=_('You are using Electron Cash in offline mode; restart Electron Cash if you want to get connected'), title=_('Offline'), parent=parent)
             return True
         return False
 
+    def warning(self, title, message, icon = QMessageBox.Warning, parent = None):
+        if isinstance(parent, MessageBoxMixin):
+            parent.msg_box(title=title, text=message, icon=icon, parent=None)
+        else:
+            parent = parent if isinstance(parent, QWidget) else None
+            d = QMessageBoxMixin(QMessageBox.Warning, title, message, QMessageBox.Ok, parent)
+            d.setWindowModality(Qt.WindowModal if parent else Qt.ApplicationModal)
+            d.exec_()
+            d.setParent(None)
+
+    def has_auto_update_check(self):
+        return bool(self.config.get('auto_update_check', False))
+
+    def set_auto_update_check(self, b):
+        was, b = self.has_auto_update_check(), bool(b)
+        if was != b:
+            self.config.set_key('auto_update_check', b, save=True)
+            if b:
+                self._start_auto_update_timer()
+            else:
+                self._stop_auto_update_timer()
 
     def main(self):
         try:
@@ -330,8 +371,9 @@ class ElectrumGui(QObject, PrintError):
             # Shut down the timer cleanly
             self.timer.stop()
             self.gc_timer.stop()
+            self._stop_auto_update_timer()
             # clipboard persistence. see http://www.mail-archive.com/pyqt@riverbankcomputing.com/msg17328.html
-            event = QtCore.QEvent(QtCore.QEvent.Clipboard)
+            event = QEvent(QEvent.Clipboard)
             self.app.sendEvent(self.app.clipboard(), event)
             self.tray.hide()
         self.app.aboutToQuit.connect(clean_up)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -35,8 +35,6 @@ from functools import partial
 
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
-import PyQt5.QtCore as QtCore
-
 from PyQt5.QtWidgets import *
 
 from electroncash import keystore
@@ -3028,6 +3026,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         qr_combo.currentIndexChanged.connect(on_video_device)
         gui_widgets.append((qr_label, qr_combo))
 
+        gui_widgets.append((None, None)) # spacer
+        updatecheck_cb = QCheckBox(_("Automatically check for updates"))
+        updatecheck_cb.setChecked(self.gui_object.has_auto_update_check())
+        updatecheck_cb.setToolTip(_("Enable this option if you wish to be notified as soon as a new version of Electron Cash becomes available"))
+        def on_set_updatecheck(v):
+            self.gui_object.set_auto_update_check(v == Qt.Checked)
+        updatecheck_cb.stateChanged.connect(on_set_updatecheck)
+        gui_widgets.append((updatecheck_cb, None))
+
+
         usechange_cb = QCheckBox(_('Use change addresses'))
         usechange_cb.setChecked(self.wallet.use_change)
         def on_usechange(x):
@@ -3173,7 +3181,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         tabs_info = [
             (fee_widgets, _('Fees')),
             (tx_widgets, _('Transactions')),
-            (gui_widgets, _('Appearance')),
+            (gui_widgets, _('General')),
             (fiat_widgets, _('Fiat')),
             (id_widgets, _('Identity')),
         ]
@@ -3188,7 +3196,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                         grid.addWidget(a, i, 0)
                     grid.addWidget(b, i, 1)
                 else:
-                    grid.addWidget(a, i, 0, 1, 2)
+                    if a:
+                        grid.addWidget(a, i, 0, 1, 2)
+                    else:
+                        grid.addItem(QSpacerItem(15, 15), i, 0, 1, 2)
             tabs.addTab(tab, name)
 
         vbox.addWidget(tabs)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -42,7 +42,7 @@ from PyQt5.QtWidgets import *
 from electroncash import keystore
 from electroncash.address import Address, ScriptOutput
 from electroncash.bitcoin import COIN, TYPE_ADDRESS, TYPE_SCRIPT
-from electroncash.networks import NetworkConstants
+from electroncash import networks
 from electroncash.plugins import run_hook
 from electroncash.i18n import _
 from electroncash.util import (format_time, format_satoshis, PrintError,
@@ -396,7 +396,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.setGeometry(100, 100, 840, 400)
 
     def watching_only_changed(self):
-        title = '%s %s  -  %s' % (NetworkConstants.TITLE,
+        title = '%s %s  -  %s' % (networks.net.TITLE,
                                   self.wallet.electrum_version,
                                   self.wallet.basename())
         extra = [self.wallet.storage.get('wallet_type', '?')]
@@ -592,7 +592,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if d:
             host = self.network.get_parameters()[0]
             self.pay_to_URI('{}:{}?message=donation for {}'
-                            .format(NetworkConstants.CASHADDR_PREFIX, d, host))
+                            .format(networks.net.CASHADDR_PREFIX, d, host))
         else:
             self.show_error(_('No donation address for this server'))
 
@@ -2443,7 +2443,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if not data:
             return
         # if the user scanned a bitcoincash URI
-        if data.lower().startswith(NetworkConstants.CASHADDR_PREFIX + ':'):
+        if data.lower().startswith(networks.net.CASHADDR_PREFIX + ':'):
             self.pay_to_URI(data)
             return
         # else if the user scanned an offline signed tx

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -577,7 +577,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         help_menu = menubar.addMenu(_("&Help"))
         help_menu.addAction(_("&About"), self.show_about)
-        help_menu.addAction(_("&Official website"), lambda: webbrowser.open("http://electroncash.org"))
+        help_menu.addAction(_("&Check for updates..."), lambda: self.gui_object.show_update_checker(self))
+        help_menu.addAction(_("&Official website"), lambda: webbrowser.open("https://electroncash.org"))
         help_menu.addSeparator()
         help_menu.addAction(_("Documentation"), lambda: webbrowser.open("http://electroncash.readthedocs.io/")).setShortcut(QKeySequence.HelpContents)
         help_menu.addAction(_("&Report Bug"), self.show_report_bug)
@@ -1640,9 +1641,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         # Capture current TL window; override might be removed on return
         parent = self.top_level_window()
 
-        if not self.network:
+        if self.gui_object.warn_if_no_network(self):
             # Don't allow a useless broadcast when in offline mode. Previous to this we were getting an exception on broadcast.
-            parent.show_error(_("You are using Electron Cash in offline mode; restart Electron Cash if you want to get connected"))
             return
         elif not self.network.is_connected():
             # Don't allow a potentially very slow broadcast when obviously not connected.

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -31,7 +31,7 @@ from PyQt5.QtWidgets import *
 import PyQt5.QtCore as QtCore
 
 from electroncash.i18n import _
-from electroncash.networks import NetworkConstants
+from electroncash import networks
 from electroncash.util import print_error, Weak
 from electroncash.network import serialize_server, deserialize_server, get_eligible_servers
 
@@ -506,7 +506,7 @@ class NetworkChoiceLayout(QObject):
     def change_protocol(self, use_ssl):
         p = 's' if use_ssl else 't'
         host = self.server_host.text()
-        pp = self.servers.get(host, NetworkConstants.DEFAULT_PORTS)
+        pp = self.servers.get(host, networks.net.DEFAULT_PORTS)
         if p not in pp.keys():
             p = list(pp.keys())[0]
         port = pp[p]
@@ -531,7 +531,7 @@ class NetworkChoiceLayout(QObject):
             self.change_server(str(x.text(0)), self.protocol)
 
     def change_server(self, host, protocol):
-        pp = self.servers.get(host, NetworkConstants.DEFAULT_PORTS)
+        pp = self.servers.get(host, networks.net.DEFAULT_PORTS)
         if protocol and protocol not in protocol_letters:
             protocol = None
         if protocol:

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -32,7 +32,7 @@ import re
 from decimal import Decimal
 from electroncash import bitcoin
 from electroncash.address import Address, ScriptOutput
-from electroncash.networks import NetworkConstants
+from electroncash import networks
 
 from . import util
 
@@ -110,7 +110,7 @@ class PayToEdit(ScanQRTextEdit):
         self.payto_address = None
         if len(lines) == 1:
             data = lines[0]
-            if data.lower().startswith(NetworkConstants.CASHADDR_PREFIX + ":"):
+            if data.lower().startswith(networks.net.CASHADDR_PREFIX + ":"):
                 self.scan_f(data)
                 return
             try:

--- a/gui/qt/update_checker.py
+++ b/gui/qt/update_checker.py
@@ -66,6 +66,7 @@ class UpdateChecker(QWidget, PrintError):
     VERSION_ANNOUNCEMENT_SIGNING_ADDRESSES = (
         address.Address.from_string("bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82", net=MainNet), # Calin's key
         address.Address.from_string("bitcoincash:qqy9myvyt7qffgye5a2mn2vn8ry95qm6asy40ptgx2", net=MainNet), # Mark Lundeberg's key
+        address.Address.from_string("bitcoincash:qz4wq9m860zr5p2nfdpttm5ymdqdyt3psc95qjagae", net=MainNet), # electroncash.org donation address
     )
 
     def __init__(self, parent=None):
@@ -307,7 +308,7 @@ class UpdateChecker(QWidget, PrintError):
         if not self.active_reply:
             self._update_view(None)
             req = QNetworkRequest(QUrl(self.url))
-            req.setMaximumRedirectsAllowed(2)
+            req.setMaximumRedirectsAllowed(5)
             req.setAttribute(QNetworkRequest.EmitAllUploadProgressSignalsAttribute, QVariant(True))
             req.setAttribute(QNetworkRequest.CacheLoadControlAttribute, QVariant(QNetworkRequest.AlwaysNetwork))
             req.setAttribute(QNetworkRequest.RedirectPolicyAttribute, QVariant(QNetworkRequest.NoLessSafeRedirectPolicy))

--- a/gui/qt/update_checker.py
+++ b/gui/qt/update_checker.py
@@ -1,0 +1,315 @@
+##!/usr/bin/env python3
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2015 Thomas Voegtlin
+#
+# Electron Cash - lightweight Bitcoin Cash Client
+# Copyright (C) 2019 The Electron Cash Developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtNetwork import *
+from PyQt5.QtWidgets import *
+
+from electroncash.util import PrintError, print_error
+from electroncash.i18n import _
+from electroncash import version, bitcoin, address
+from electroncash.networks import MainNet
+from .util import *
+import base64, sys, json
+
+class UpdateChecker(QWidget, PrintError):
+    # TODO:
+    # 1. Integrate with settings and have the update check run off a timer periodically.
+    ''' A window that checks for updates.
+
+    If ok, and a new version is detected, will present the hard-coded download
+    URL in the GUI.
+
+    If ok, and we are on the latest version, will present a message to that
+    effect.
+
+    If it can't verify the response or can't talk on network, will present a
+    generic error message.
+
+    Update data is expected to be JSON with a bunch of signed version strings.
+    see self._process_server_reply below for an example.
+    '''
+    # Note: it's guaranteed that every call to do_check() will either result
+    # in a 'checked' signal or a 'failed' signal to be emitted.
+    checked = pyqtSignal(object) # emitted whenever the server gave us a (properly signed) version string. may or may not mean it's a new version.
+    gotNewVersion = pyqtSignal(object) # emitted in tandem with 'checked' above ONLY if the server gave us a (properly signed) version string we recognize as *newer*
+    failed = pyqtSignal() # emitted when there is an exception, network error, or verify error on version check.
+
+    url = "https://www.c3-soft.com/downloads/BitcoinCash/Electron-Cash/update_check"
+    download_url = "https://electroncash.org/#download"
+
+    VERSION_ANNOUNCEMENT_SIGNING_ADDRESSES = (
+        address.Address.from_string("bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82", net=MainNet), # Calin's key
+    )
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle('Electron Cash - ' + _('Update Checker'))
+        self.content = QVBoxLayout()
+        self.content.setContentsMargins(*([10]*4))
+
+        self.heading_label = QLabel()
+        self.content.addWidget(self.heading_label)
+
+        self.detail_label = QLabel()
+        self.detail_label.setTextInteractionFlags(Qt.LinksAccessibleByMouse)
+        self.detail_label.setOpenExternalLinks(True)
+        self.detail_label.setWordWrap(True)
+        self.content.addWidget(self.detail_label)
+
+        self.pb = QProgressBar()
+        self.pb.setMaximum(100)
+        self.pb.setMinimum(0)
+        self.content.addWidget(self.pb)
+
+        versions = QHBoxLayout()
+        versions.addWidget(QLabel(_("Current version: {}".format(version.PACKAGE_VERSION))))
+        self.latest_version_label = QLabel(_("Latest version: {}".format(" ")))
+        versions.addWidget(self.latest_version_label)
+        self.content.addLayout(versions)
+
+        close_button = QPushButton(_("Close"))
+        close_button.clicked.connect(self.close)
+        self.cancel_or_check_button = QPushButton(_("Cancel"))
+        self.cancel_or_check_button.clicked.connect(self.cancel_or_check)
+        self.content.addLayout(Buttons(self.cancel_or_check_button, close_button))
+        grid = QGridLayout()
+        grid.addLayout(self.content, 0, 0)
+        self.setLayout(grid)
+
+        self.network_access_manager = QNetworkAccessManager(self)
+        net_config = self.network_access_manager.configuration()
+        net_config.setConnectTimeout(int(5.0 * 1e3)) # timeout in msecs
+        self.network_access_manager.setConfiguration(net_config)
+        self.network_access_manager.authenticationRequired.connect(self.qam_authentication_required)
+        self.network_access_manager.encrypted.connect(self.qam_encrypted)
+        self.network_access_manager.finished.connect(self.qam_finished)
+        self.active_reply = None
+        self.resize(450, 200)
+
+    def qam_authentication_required(self, reply, authenticator):
+        self.print_error("Authentication required for", reply.url().toString())
+        # doing nothing will result in connection fail and a finished() signal emitted
+
+    def qam_encrypted(self, reply):
+        self.print_error("Encrypted connecton to", reply.url().toString())
+
+    def qam_finished(self, reply):
+        self.print_error("Finished", reply.url().toString(), "with error code:", reply.errorString() if reply.error() else '(No Error)')
+        if reply is self.active_reply:
+            self.on_reply_finished(reply)
+            self.active_reply = None
+            self.print_error("was the active reply, set to None")
+        else:
+            self.print_error("was NOT the active reply")
+        reply.deleteLater()
+
+    def on_reply_downloading(self, reply, bytesReceived, bytesTotal):
+        if reply is self.active_reply:
+            self.print_error("Downloading bytes received", bytesReceived, "/", bytesTotal, "from", reply.url().toString())
+            prog = abs((bytesReceived*100.0) / bytesTotal) if bytesTotal else 1
+            self.pb.setValue(max(0, min(int(prog), 100)))
+        else:
+            self.print_error("Warning: on_reply_downloading called with a reply that is not 'active'!")
+
+    def on_reply_finished(self, reply):
+        self.print_error("Reply finished", reply.url().toString())
+        data, newver = None, None
+        if not reply.error():
+            try:
+                data = bytes(reply.readAll()).decode('utf-8')
+                self.print_error("got data\n" + str(data)) # comment this out for release
+                data = json.loads(data)
+                newver = self._process_server_reply(data)
+            except:
+                data, newver = None, None
+                import traceback
+                self.print_error(traceback.format_exc())
+        if newver is None:
+            self.on_retrieval_failed()
+            self.failed.emit()
+        else:
+            # NB: below 'newver' may actually just be our version or a version
+            # before our version (in case we are on a develpment build).
+            # Client code should check with this class.is_newer if the emitted
+            # version is actually newer.
+            self.on_version_retrieved(newver)
+            self.checked.emit(newver)
+            if self.is_newer(newver):
+                self.gotNewVersion.emit(newver)
+
+    def _process_server_reply(self, signed_version_dict):
+        ''' Returns:
+                - the new package version string if new version found from
+                  server, e.g. '3.3.5', '3.3.5CS', etc
+                - or the current version (version.PACKAGE_VERSION) if no new
+                  version found.
+                - None on failure (such as bad signature).
+
+            May also raise on error. '''
+        # example signed_version_dict:
+        # {
+        #     "3.9.9": {
+        #         "bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82": "IA+2QG3xPRn4HAIFdpu9eeaCYC7S5wS/sDxn54LJx6BdUTBpse3ibtfq8C43M7M1VfpGkD5tsdwl5C6IfpZD/gQ="
+        #     },
+        #     "3.9.9CS": {
+        #         "bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82": "IA+2QG3xPRn4HAIFdpu9eeaCYC7S5wS/sDxn54LJx6BdUTBpse3ibtfq8C43M7M1VfpGkD5tsdwl5C6IfpZD/gQ="
+        #     },
+        #     "3.9.9SLP": {
+        #         "bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82": "IA+2QG3xPRn4HAIFdpu9eeaCYC7S5wS/sDxn54LJx6BdUTBpse3ibtfq8C43M7M1VfpGkD5tsdwl5C6IfpZD/gQ="
+        #     },
+        # }
+        # All signed messages above are signed with the address in the dict, and the message is the "3.9.9" or "3.9.9CS" etc string
+        ct_matching = 0
+        for version_msg, sigdict in signed_version_dict.items():
+            # This looks quadratic, and it is. But the expected results are small.
+            # We needed to do it this way to detect when there was no matching variant and/or no known-key match.
+            if self.is_matching_variant(version_msg):
+                for adr, sig in sigdict.items():
+                    adr = address.Address.from_string(adr, net=MainNet) # may raise
+                    if adr in self.VERSION_ANNOUNCEMENT_SIGNING_ADDRESSES:
+                        ct_matching += 1
+                        if self.is_newer(version_msg): # may raise
+                            try:
+                                is_verified = bitcoin.verify_message(adr, base64.b64decode(sig), version_msg.encode('utf-8'), net=MainNet)
+                            except:
+                                self.print_error("Exception when verifying version signature for", version_msg, ":", repr(sys.exc_info()[1]))
+                                return None
+                            if is_verified:
+                                self.print_error("Got new version", version_msg)
+                                return version_msg.strip()
+                            else:
+                                self.print_error("Got new version", version_msg, "but sigcheck failed!")
+                                return None
+        if 0 == ct_matching:
+            # Hmm. None of the versions we saw matched our variant.
+            # And/Or, none of the keys we saw matched keys we knew about.
+            # This is an error condition, so return None
+            self.print_error("Error: Got a valid reply from server but none of the variants match us and/or none of the signing keys are known!")
+            return None
+        return version.PACKAGE_VERSION
+
+
+    def on_version_retrieved(self, version):
+        self._update_view(version)
+
+    _error_val = 0xdeadb33f
+    def on_retrieval_failed(self):
+        self._update_view(self._error_val)
+
+    @staticmethod
+    def _ver2int(vtup):
+        ''' param vtup is a tuple of ints: (major, minor, revision) as would be
+        returned by version.parse_package_version. Returns version encoded
+        in an int suitable for numerical comparisons (>, <, >=, ==, etc). '''
+        return ((vtup[0]&0xff) << 16) | ((vtup[1]&0xff) << 8) | ((vtup[2]&0xff) << 0)
+
+    @classmethod
+    def _my_version(cls):
+        if not getattr(cls, '_my_version_parsed', None):
+            cls._my_version_parsed = version.parse_package_version(version.PACKAGE_VERSION)
+        return cls._my_version_parsed or (None,)*4
+
+    @classmethod
+    def _parse_version(cls, version_msg):
+        try:
+            return version.parse_package_version(version_msg)
+        except:
+            print_error("[{}] Error parsing version '{}': {}".format(cls.__name__, version_msg, repr(sys.exc_info()[1])))
+            raise
+
+    @classmethod
+    def is_matching_variant(cls, version_msg):
+        parsed_version = cls._parse_version(version_msg)
+        me = cls._my_version()
+        return me[3] == parsed_version[3]
+
+    @classmethod
+    def is_newer(cls, version_msg):
+        if cls.is_matching_variant(version_msg): # make sure it's the same variant as us eg SLP, CS, '' regular, etc..
+            v_me = cls._ver2int(cls._my_version())
+            v_server = cls._ver2int(cls._parse_version(version_msg))
+            return v_server > v_me
+        return False
+
+    def _update_view(self, latest_version):
+        if latest_version == self._error_val:
+            self.heading_label.setText('<h2>' + _("Update check failed") + '</h2>')
+            self.detail_label.setText(_("Sorry, but we were unable to check for updates. Please try again later."))
+            self.cancel_or_check_button.setText(_("Check Again"))
+            self.cancel_or_check_button.setEnabled(True)
+
+            self.pb.hide()
+        elif latest_version:
+            self.pb.hide()
+            self.cancel_or_check_button.setText(_("Check Again"))
+            self.latest_version_label.setText(_("Latest version: {}".format("<b>" + latest_version + "</b>")))
+            if self.is_newer(latest_version):
+                self.heading_label.setText('<h2>' + _("There is a new update available") + '</h2>')
+                url = '<a href="{u}">{u}</a>'.format(u=UpdateChecker.download_url)
+                self.detail_label.setText(_("You can download the new version from:<br>{}").format(url))
+                self.cancel_or_check_button.setEnabled(False)
+            else:
+                self.heading_label.setText('<h2>' + _("Already up to date") + '</h2>')
+                self.detail_label.setText(_("You are already on the latest version of Electron Cash."))
+                self.cancel_or_check_button.setEnabled(True)
+        else:
+            self.pb.show()
+            self.pb.setValue(0)
+            self.cancel_or_check_button.setText(_("Cancel"))
+            self.cancel_or_check_button.setEnabled(True)
+            self.latest_version_label.setText("")
+            self.heading_label.setText('<h2>' + _("Checking for updates...") + '</h2>')
+            self.detail_label.setText(_("Please wait while Electron Cash checks for available updates."))
+
+    def cancel_active(self):
+        if self.active_reply:
+            self.active_reply.abort()
+            self.active_reply = None
+
+    def cancel_or_check(self):
+        if self.active_reply:
+            self.cancel_active()
+        else:
+            self.do_check(force=True)
+
+    # Note: it's guaranteed that every call to do_check() will either result
+    # in a 'checked' signal or a 'failed' signal to be emitted.
+    def do_check(self, force=False):
+        if force:
+            self.cancel_active() # no-op if none active
+        if not self.active_reply:
+            self._update_view(None)
+            req = QNetworkRequest(QUrl(self.url))
+            req.setMaximumRedirectsAllowed(2)
+            req.setAttribute(QNetworkRequest.EmitAllUploadProgressSignalsAttribute, QVariant(True))
+            req.setAttribute(QNetworkRequest.CacheLoadControlAttribute, QVariant(QNetworkRequest.AlwaysNetwork))
+            req.setAttribute(QNetworkRequest.RedirectPolicyAttribute, QVariant(QNetworkRequest.NoLessSafeRedirectPolicy))
+            self.active_reply = reply = self.network_access_manager.get(req)
+            self.active_reply.downloadProgress.connect(lambda bytes_read, bytes_total: self.on_reply_downloading(reply, bytes_read, bytes_total))
+

--- a/gui/qt/update_checker.py
+++ b/gui/qt/update_checker.py
@@ -60,7 +60,7 @@ class UpdateChecker(QWidget, PrintError):
     got_new_version = pyqtSignal(object) # emitted in tandem with 'checked' above ONLY if the server gave us a (properly signed) version string we recognize as *newer*
     failed = pyqtSignal() # emitted when there is an exception, network error, or verify error on version check.
 
-    url = "https://www.c3-soft.com/downloads/BitcoinCash/Electron-Cash/update_check"
+    url = "https://raw.github.com/cculianu/electrum/update_checker/contrib/update_checker/releases.json"
     download_url = "https://electroncash.org/#download"
 
     VERSION_ANNOUNCEMENT_SIGNING_ADDRESSES = (

--- a/gui/qt/update_checker.py
+++ b/gui/qt/update_checker.py
@@ -60,7 +60,8 @@ class UpdateChecker(QWidget, PrintError):
     got_new_version = pyqtSignal(object) # emitted in tandem with 'checked' above ONLY if the server gave us a (properly signed) version string we recognize as *newer*
     failed = pyqtSignal() # emitted when there is an exception, network error, or verify error on version check.
 
-    url = "https://raw.github.com/cculianu/electrum/update_checker/contrib/update_checker/releases.json"
+    #url = "https://www.c3-soft.com/downloads/BitcoinCash/Electron-Cash/update_check" # Testing URL
+    url = "https://raw.github.com/Electron-Cash/Electron-Cash/master/contrib/update_checker/releases.json" # Release URL
     download_url = "https://electroncash.org/#download"
 
     VERSION_ANNOUNCEMENT_SIGNING_ADDRESSES = (
@@ -126,9 +127,9 @@ class UpdateChecker(QWidget, PrintError):
         if reply is self.active_reply:
             self.on_reply_finished(reply)
             self.active_reply = None
-            self.print_error("was the active reply, set to None")
+            self.print_error("active reply finished, set to None")
         else:
-            self.print_error("was NOT the active reply")
+            self.print_error("was NOT the active reply, ignored.")
         reply.deleteLater()
 
     def on_reply_downloading(self, reply, bytesReceived, bytesTotal):
@@ -145,7 +146,8 @@ class UpdateChecker(QWidget, PrintError):
         if not reply.error():
             try:
                 data = bytes(reply.readAll()).decode('utf-8')
-                self.print_error("got data\n" + str(data)) # comment this out for release
+                #self.print_error("got data\n" + str(data)) # comment this out for release
+                self.print_error("got data {} bytes".format(len(data)))
                 data = json.loads(data)
                 newver = self._process_server_reply(data)
             except:

--- a/gui/qt/update_checker.py
+++ b/gui/qt/update_checker.py
@@ -65,6 +65,7 @@ class UpdateChecker(QWidget, PrintError):
 
     VERSION_ANNOUNCEMENT_SIGNING_ADDRESSES = (
         address.Address.from_string("bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82", net=MainNet), # Calin's key
+        address.Address.from_string("bitcoincash:qqy9myvyt7qffgye5a2mn2vn8ry95qm6asy40ptgx2", net=MainNet), # Mark Lundeberg's key
     )
 
     def __init__(self, parent=None):

--- a/ios/ElectronCash/electroncash_gui/ios_native/network_dialog.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/network_dialog.py
@@ -36,7 +36,6 @@ from electroncash.i18n import _
 import socket
 from collections import namedtuple
 
-from electroncash.networks import NetworkConstants
 from electroncash.network import serialize_server, deserialize_server
 
 TAG_HELP_STATUS = 112

--- a/ios/ElectronCash/electroncash_gui/ios_native/receive.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/receive.py
@@ -11,7 +11,6 @@ from .amountedit import BTCAmountEdit, FiatAmountEdit, BTCkBEdit  # Makes sure O
 from electroncash import WalletStorage, Wallet
 from electroncash.util import timestamp_to_datetime, format_time
 from electroncash.i18n import _, language
-from electroncash.networks import NetworkConstants
 from electroncash.address import Address, ScriptOutput
 from electroncash.paymentrequest import PR_UNPAID, PR_EXPIRED, PR_UNKNOWN, PR_PAID
 from electroncash import bitcoin

--- a/ios/ElectronCash/electroncash_gui/ios_native/send.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/send.py
@@ -15,7 +15,7 @@ from electroncash.transaction import Transaction
 from electroncash.i18n import _
 from .custom_objc import *
 from .uikit_bindings import *
-from electroncash.networks import NetworkConstants
+from electroncash import networks
 from electroncash.address import Address, ScriptOutput
 from electroncash.paymentrequest import PaymentRequest
 from electroncash import bitcoin
@@ -610,7 +610,7 @@ class SendVC(SendBase):
         
         if len(lines) == 1:
             data = lines[0]
-            if data.lower().startswith(NetworkConstants.CASHADDR_PREFIX + ":"):
+            if data.lower().startswith(networks.net.CASHADDR_PREFIX + ":"):
                 self.isMax = False
                 if not parent().pay_to_URI(data, showErr = False):
                     self.qrScanErr = True

--- a/ios/make_ios_project.sh
+++ b/ios/make_ios_project.sh
@@ -63,6 +63,8 @@ if [ ! -d ../lib/locale ]; then
 	fi
 fi
 cp -fpR ../lib ${compact_name}/electroncash
+echo "Removing lib/tests..."
+rm -fr ${compact_name}/electroncash/tests
 find ${compact_name} -name \*.pyc -exec rm -f {} \; 
 
 echo ""
@@ -245,6 +247,9 @@ cp -fva ${compact_name}/electroncash/*.proto iOS/app/${compact_name}/electroncas
 if [ "$?" != "0" ]; then
 	echo "** WARNING: Failed to copy google protobuf .proto file to app lib dir!"
 fi
+
+# Clean up no-longer-needed electroncash/ dir that is outside of Xcode project
+rm -fr ${compact_name}/electroncash/*
 
 echo ''
 echo '**************************************************************************'

--- a/ios/recompile_python.sh
+++ b/ios/recompile_python.sh
@@ -13,6 +13,7 @@ fi
 
 if [ "$1" == "-k" ]; then
 	find "$dir1" "$dir2" -type d -name __pycache__ -exec rm -fvr {} \; 
+	find "$dir1" "$dir2" -type f -name \*.pyc -exec rm -fvr {} \;
 elif [ -n "$1" ]; then
 	echo "Usage: $0 [-k]"
 	echo "    -k   Klean.  That is, remove all __pycache__ dirs that were created by this script."

--- a/lib/address.py
+++ b/lib/address.py
@@ -27,11 +27,10 @@ from collections import namedtuple
 import hashlib
 import struct
 
-from . import cashaddr
+from . import cashaddr, networks
 from .enum import Enumeration
 from .bitcoin import EC_KEY, is_minikey, minikey_to_private_key
 from .util import cachedproperty
-from .networks import NetworkConstants
 
 _sha256 = hashlib.sha256
 _new_hash = hashlib.new
@@ -143,16 +142,17 @@ class PublicKey(namedtuple("PublicKeyTuple", "pubkey")):
         return cls(to_bytes(pubkey))
 
     @classmethod
-    def privkey_from_WIF_privkey(cls, WIF_privkey):
+    def privkey_from_WIF_privkey(cls, WIF_privkey, *, net=None):
         '''Given a WIF private key (or minikey), return the private key as
         binary and a boolean indicating whether it was encoded to
         indicate a compressed public key or not.
         '''
+        if net is None: net = networks.net
         if is_minikey(WIF_privkey):
             # The Casascius coins were uncompressed
             return minikey_to_private_key(WIF_privkey), False
         raw = Base58.decode_check(WIF_privkey)
-        if not raw or raw[0] != NetworkConstants.WIF_PREFIX:
+        if not raw or raw[0] != net.WIF_PREFIX:
             raise ValueError('private key has invalid WIF prefix')
         if len(raw) == 34 and raw[-1] == 1:
             return raw[1:33], True
@@ -321,9 +321,10 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         cls.FMT_UI = cls.FMT_CASHADDR if on else cls.FMT_LEGACY
 
     @classmethod
-    def from_cashaddr_string(cls, string):
+    def from_cashaddr_string(cls, string, *, net=None):
         '''Construct from a cashaddress string.'''
-        prefix = NetworkConstants.CASHADDR_PREFIX
+        if net is None: net = networks.net
+        prefix = net.CASHADDR_PREFIX
         if string.upper() == string:
             prefix = prefix.upper()
         if not string.startswith(prefix + ':'):
@@ -340,11 +341,12 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
             raise AddressError('address has unexpected kind {}'.format(kind))
 
     @classmethod
-    def from_string(cls, string):
+    def from_string(cls, string, *, net=None):
         '''Construct from an address string.'''
+        if net is None: net = networks.net
         if len(string) > 35:
             try:
-                return cls.from_cashaddr_string(string)
+                return cls.from_cashaddr_string(string, net=net)
             except ValueError as e:
                 raise AddressError(str(e))
 
@@ -358,11 +360,11 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
             raise AddressError('invalid address: {}'.format(string))
 
         verbyte, hash160 = raw[0], raw[1:]
-        if verbyte in [NetworkConstants.ADDRTYPE_P2PKH,
-                       NetworkConstants.ADDRTYPE_P2PKH_BITPAY]:
+        if verbyte in [net.ADDRTYPE_P2PKH,
+                       net.ADDRTYPE_P2PKH_BITPAY]:
             kind = cls.ADDR_P2PKH
-        elif verbyte in [NetworkConstants.ADDRTYPE_P2SH,
-                         NetworkConstants.ADDRTYPE_P2SH_BITPAY]:
+        elif verbyte in [net.ADDRTYPE_P2SH,
+                         net.ADDRTYPE_P2SH_BITPAY]:
             kind = cls.ADDR_P2SH
         else:
             raise AddressError('unknown version byte: {}'.format(verbyte))
@@ -378,9 +380,10 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
             return False
 
     @classmethod
-    def from_strings(cls, strings):
+    def from_strings(cls, strings, *, net=None):
         '''Construct a list from an iterable of strings.'''
-        return [cls.from_string(string) for string in strings]
+        if net is None: net = networks.net
+        return [cls.from_string(string, net=net) for string in strings]
 
     @classmethod
     def from_pubkey(cls, pubkey):
@@ -406,78 +409,88 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         return cls(hash160(script), cls.ADDR_P2SH)
 
     @classmethod
-    def to_strings(cls, fmt, addrs):
+    def to_strings(cls, fmt, addrs, *, net=None):
         '''Construct a list of strings from an iterable of Address objects.'''
-        return [addr.to_string(fmt) for addr in addrs]
+        if net is None: net = networks.net
+        return [addr.to_string(fmt, net=net) for addr in addrs]
 
-    def to_cashaddr(self):
+    def to_cashaddr(self, *, net=None):
+        if net is None: net = networks.net
         if self.kind == self.ADDR_P2PKH:
             kind  = cashaddr.PUBKEY_TYPE
         else:
             kind  = cashaddr.SCRIPT_TYPE
-        return cashaddr.encode(NetworkConstants.CASHADDR_PREFIX, kind,
-                               self.hash160)
+        return cashaddr.encode(net.CASHADDR_PREFIX, kind, self.hash160)
 
-    def to_string(self, fmt):
+    def to_string(self, fmt, *, net=None):
         '''Converts to a string of the given format.'''
-        try:
-            cached = self._addr2str_cache[fmt]
-            if cached:
-                return cached
-        except (IndexError, TypeError):
-            raise AddressError('unrecognised format')
+        if net is None: net = networks.net
+        if net is networks.net:
+            try:
+                cached = self._addr2str_cache[fmt]
+                if cached:
+                    return cached
+            except (IndexError, TypeError):
+                raise AddressError('unrecognised format')
 
         if fmt == self.FMT_CASHADDR:
-            cached = self.to_cashaddr()
-            self._addr2str_cache[fmt] = cached
+            cached = self.to_cashaddr(net=net)
+            if net is networks.net:
+                self._addr2str_cache[fmt] = cached
             return cached
 
         if fmt == self.FMT_LEGACY:
             if self.kind == self.ADDR_P2PKH:
-                verbyte = NetworkConstants.ADDRTYPE_P2PKH
+                verbyte = net.ADDRTYPE_P2PKH
             else:
-                verbyte = NetworkConstants.ADDRTYPE_P2SH
+                verbyte = net.ADDRTYPE_P2SH
         elif fmt == self.FMT_BITPAY:
             if self.kind == self.ADDR_P2PKH:
-                verbyte = NetworkConstants.ADDRTYPE_P2PKH_BITPAY
+                verbyte = net.ADDRTYPE_P2PKH_BITPAY
             else:
-                verbyte = NetworkConstants.ADDRTYPE_P2SH_BITPAY
+                verbyte = net.ADDRTYPE_P2SH_BITPAY
         else:
             # This should never be reached due to cache-lookup check above. But leaving it in as it's a harmless sanity check.
             raise AddressError('unrecognised format')
 
         cached = Base58.encode_check(bytes([verbyte]) + self.hash160)
-        self._addr2str_cache[fmt] = cached
+        if net is networks.net:
+            self._addr2str_cache[fmt] = cached
         return cached
 
-    def to_full_string(self, fmt):
+    def to_full_string(self, fmt, *, net=None):
         '''Convert to text, with a URI prefix for cashaddr format.'''
-        text = self.to_string(fmt)
+        if net is None: net = networks.net
+        text = self.to_string(fmt, net=net)
         if fmt == self.FMT_CASHADDR:
-            text = ':'.join([NetworkConstants.CASHADDR_PREFIX, text])
+            text = ':'.join([net.CASHADDR_PREFIX, text])
         return text
 
-    def to_ui_string(self):
+    def to_ui_string(self, *, net=None):
         '''Convert to text in the current UI format choice.'''
-        return self.to_string(self.FMT_UI)
+        if net is None: net = networks.net
+        return self.to_string(self.FMT_UI, net=net)
 
-    def to_full_ui_string(self):
+    def to_full_ui_string(self, *, net=None):
         '''Convert to text, with a URI prefix if cashaddr.'''
-        return self.to_full_string(self.FMT_UI)
+        if net is None: net = networks.net
+        return self.to_full_string(self.FMT_UI, net=net)
 
-    def to_URI_components(self):
+    def to_URI_components(self, *, net=None):
         '''Returns a (scheme, path) pair for building a URI.'''
-        scheme = NetworkConstants.CASHADDR_PREFIX
-        path = self.to_ui_string()
+        if net is None: net = networks.net
+        scheme = net.CASHADDR_PREFIX
+        path = self.to_ui_string(net=net)
         # Convert to upper case if CashAddr
         if self.FMT_UI == self.FMT_CASHADDR:
             scheme = scheme.upper()
             path = path.upper()
         return scheme, path
 
-    def to_storage_string(self):
+    def to_storage_string(self, *, net=None):
         '''Convert to text in the storage format.'''
-        return self.to_string(self.FMT_LEGACY)
+        if net is None: net = networks.net
+        return self.to_string(self.FMT_LEGACY, net=net)
 
     def to_script(self):
         '''Return a binary script to pay to the address.'''
@@ -518,7 +531,7 @@ def _match_ops(ops, pattern):
     return True
 
 
-class Script(object):
+class Script:
 
     @classmethod
     def P2SH_script(cls, hash160):
@@ -607,7 +620,7 @@ class Base58Error(Exception):
     '''Exception used for Base58 errors.'''
 
 
-class Base58(object):
+class Base58:
     '''Class providing base 58 functionality.'''
 
     chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -30,7 +30,7 @@ from . import bitcoin
 from .bitcoin import *
 
 from .address import Address, PublicKey
-from .networks import NetworkConstants
+from . import networks
 from .mnemonic import Mnemonic, load_wordlist
 from .plugins import run_hook
 from .util import PrintError, InvalidPassword, hfu
@@ -737,7 +737,7 @@ is_bip32_key = lambda x: is_xprv(x) or is_xpub(x)
 
 def bip44_derivation(account_id):
     bip  = 44
-    coin = 1 if NetworkConstants.TESTNET else 0
+    coin = 1 if networks.net.TESTNET else 0
     return "m/%d'/%d'/%d'" % (bip, coin, int(account_id))
 
 def bip44_derivation_145(account_id):

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -34,76 +34,108 @@ def read_json_dict(filename):
         r = {}
     return r
 
+class AbstractNet:
+    TESTNET = False
+
+
+class MainNet(AbstractNet):
+    TESTNET = False
+    WIF_PREFIX = 0x80
+    ADDRTYPE_P2PKH = 0
+    ADDRTYPE_P2PKH_BITPAY = 28
+    ADDRTYPE_P2SH = 5
+    ADDRTYPE_P2SH_BITPAY = 40
+    CASHADDR_PREFIX = "bitcoincash"
+    HEADERS_URL = "http://bitcoincash.com/files/blockchain_headers"
+    GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+    DEFAULT_PORTS = {'t': '50001', 's': '50002'}
+    DEFAULT_SERVERS = read_json_dict('servers.json') # this may get modified by Network class
+    HARDCODED_DEFAULT_SERVERS = DEFAULT_SERVERS.copy() # this is the original servers.json. Do not modify
+    TITLE = 'Electron Cash'
+
+    # Bitcoin Cash fork block specification
+    BITCOIN_CASH_FORK_BLOCK_HEIGHT = 478559
+    BITCOIN_CASH_FORK_BLOCK_HASH = "000000000000000000651ef99cb9fcbe0dadde1d424bd9f15ff20136191a5eec"
+
+    # Note to Jonald or anyone reading this: the below is misleadingly named.  It's not a simple
+    # MERKLE_ROOT but a MERKLE_PROOF which is basically the hashes of all MERKLE_ROOTS up until and including
+    # this block. Consult the ElectrumX documentation.
+    # To get this value you need to connect to an ElectrumX server you trust and issue it a protocol command.
+    # blockchain.block.header (see ElectrumX docs)
+    VERIFICATION_BLOCK_MERKLE_ROOT = "b8f9b1649d0bba75e2c2ea4be73395a0967397003f33a40653caca0ec6a73baa"
+    VERIFICATION_BLOCK_HEIGHT = 560644
+
+    # Version numbers for BIP32 extended keys
+    # standard: xprv, xpub
+    XPRV_HEADERS = {
+        'standard': 0x0488ade4,
+    }
+
+    XPUB_HEADERS = {
+        'standard': 0x0488b21e,
+    }
+
+
+class TestNet(AbstractNet):
+    TESTNET = True
+    WIF_PREFIX = 0xef
+    ADDRTYPE_P2PKH = 111
+    ADDRTYPE_P2PKH_BITPAY = 111  # Unsure
+    ADDRTYPE_P2SH = 196
+    ADDRTYPE_P2SH_BITPAY = 196  # Unsure
+    CASHADDR_PREFIX = "bchtest"
+    HEADERS_URL = "http://bitcoincash.com/files/testnet_headers"
+    GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
+    DEFAULT_PORTS = {'t':'51001', 's':'51002'}
+    DEFAULT_SERVERS = read_json_dict('servers_testnet.json')
+    HARDCODED_DEFAULT_SERVERS = DEFAULT_SERVERS.copy()
+    TITLE = 'Electron Cash Testnet'
+
+    # Bitcoin Cash fork block specification
+    BITCOIN_CASH_FORK_BLOCK_HEIGHT = 1155876
+    BITCOIN_CASH_FORK_BLOCK_HASH = "00000000000e38fef93ed9582a7df43815d5c2ba9fd37ef70c9a0ea4a285b8f5"
+
+    VERIFICATION_BLOCK_MERKLE_ROOT = "c3cc7a7b6fe5e0ff19b750ae200ae93664b3abf09bf510e26e15ba338afe1f1a"
+    VERIFICATION_BLOCK_HEIGHT = 1273800
+
+    # Version numbers for BIP32 extended keys
+    # standard: tprv, tpub
+    XPRV_HEADERS = {
+        'standard': 0x04358394,
+    }
+
+    XPUB_HEADERS = {
+        'standard': 0x043587cf,
+    }
+
+
+
+def _instancer(cls):
+    return cls()
+
+@_instancer
 class NetworkConstants:
-    @classmethod
-    def set_mainnet(cls):
-        cls.TESTNET = False
-        cls.WIF_PREFIX = 0x80
-        cls.ADDRTYPE_P2PKH = 0
-        cls.ADDRTYPE_P2PKH_BITPAY = 28
-        cls.ADDRTYPE_P2SH = 5
-        cls.ADDRTYPE_P2SH_BITPAY = 40
-        cls.CASHADDR_PREFIX = "bitcoincash"
-        cls.HEADERS_URL = "http://bitcoincash.com/files/blockchain_headers"
-        cls.GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
-        cls.DEFAULT_PORTS = {'t': '50001', 's': '50002'}
-        cls.DEFAULT_SERVERS = read_json_dict('servers.json') # this may get modified by Network class
-        cls.HARDCODED_DEFAULT_SERVERS = cls.DEFAULT_SERVERS.copy() # this is the original servers.json. Do not modify
-        cls.TITLE = 'Electron Cash'
+    ''' Compatibility class for old code & plugins.
 
-        # Bitcoin Cash fork block specification
-        cls.BITCOIN_CASH_FORK_BLOCK_HEIGHT = 478559
-        cls.BITCOIN_CASH_FORK_BLOCK_HASH = "000000000000000000651ef99cb9fcbe0dadde1d424bd9f15ff20136191a5eec"
+    Client code can just do things like:
+    NetworkConstants.ADDRTYPE_P2PKH, NetworkConstants.DEFAULT_PORTS, etc.
 
-        # Note to Jonald or anyone reading this: the below is misleadingly named.  It's not a simple
-        # MERKLE_ROOT but a MERKLE_PROOF which is basically the hashes of all MERKLE_ROOTS up until and including
-        # this block. Consult the ElectrumX documentation.
-        # To get this value you need to connect to an ElectrumX server you trust and issue it a protocol command.
-        # blockchain.block.header (see ElectrumX docs)
-        cls.VERIFICATION_BLOCK_MERKLE_ROOT = "b8f9b1649d0bba75e2c2ea4be73395a0967397003f33a40653caca0ec6a73baa"
-        cls.VERIFICATION_BLOCK_HEIGHT = 560644
+    We plan to transition away from this class and have client code use the
+    'net' global variable above. '''
+    def __getattribute__(self, name):
+        return getattr(net, name)
 
-        # Version numbers for BIP32 extended keys
-        # standard: xprv, xpub
-        cls.XPRV_HEADERS = {
-            'standard': 0x0488ade4,
-        }
-        cls.XPUB_HEADERS = {
-            'standard': 0x0488b21e,
-        }
+    def __setattr__(self, name, value):
+        raise RuntimeError('NetworkConstants does not support setting attributes! ({}={})'.format(name,value))
+        setattr(net, name, value)
 
-    @classmethod
-    def set_testnet(cls):
-        cls.TESTNET = True
-        cls.WIF_PREFIX = 0xef
-        cls.ADDRTYPE_P2PKH = 111
-        cls.ADDRTYPE_P2PKH_BITPAY = 111  # Unsure
-        cls.ADDRTYPE_P2SH = 196
-        cls.ADDRTYPE_P2SH_BITPAY = 196  # Unsure
-        cls.CASHADDR_PREFIX = "bchtest"
-        cls.HEADERS_URL = "http://bitcoincash.com/files/testnet_headers"
-        cls.GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
-        cls.DEFAULT_PORTS = {'t':'51001', 's':'51002'}
-        cls.DEFAULT_SERVERS = read_json_dict('servers_testnet.json')
-        cls.HARDCODED_DEFAULT_SERVERS = cls.DEFAULT_SERVERS.copy()
-        cls.TITLE = 'Electron Cash Testnet'
+# All new code should access this for current network config.
+net = MainNet
 
-        # Bitcoin Cash fork block specification
-        cls.BITCOIN_CASH_FORK_BLOCK_HEIGHT = 1155876
-        cls.BITCOIN_CASH_FORK_BLOCK_HASH = "00000000000e38fef93ed9582a7df43815d5c2ba9fd37ef70c9a0ea4a285b8f5"
-        
-        cls.VERIFICATION_BLOCK_MERKLE_ROOT = "c3cc7a7b6fe5e0ff19b750ae200ae93664b3abf09bf510e26e15ba338afe1f1a"
-        cls.VERIFICATION_BLOCK_HEIGHT = 1273800
+def set_mainnet():
+    global net
+    net = MainNet
 
-        # Version numbers for BIP32 extended keys
-        # standard: tprv, tpub
-        cls.XPRV_HEADERS = {
-            'standard': 0x04358394,
-        }
-        cls.XPUB_HEADERS = {
-            'standard': 0x043587cf,
-        }
-
-
-
-NetworkConstants.set_mainnet()
+def set_testnet():
+    global net
+    net = TestNet

--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -13,7 +13,7 @@ from ..bitcoin import (
     verify_message, deserialize_privkey, serialize_privkey,
     is_minikey, is_compressed, is_xpub,
     xpub_type, is_xprv, is_bip32_derivation, seed_type)
-from ..networks import NetworkConstants
+from ..networks import set_mainnet, set_testnet
 from ..util import bfh
 
 try:
@@ -154,12 +154,12 @@ class Test_bitcoin_testnet(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        NetworkConstants.set_testnet()
+        set_testnet()
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        NetworkConstants.set_mainnet()
+        set_mainnet()
 
 
 class Test_xprv_xpub(unittest.TestCase):

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -21,7 +21,8 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from .util import ThreadJob, bh2u
-from .bitcoin import Hash, hash_decode, hash_encode, NetworkConstants
+from .bitcoin import Hash, hash_decode, hash_encode
+from .networks import net
 from .transaction import Transaction
 
 class InnerNodeOfSpvProofIsValidTx(Exception): pass
@@ -60,7 +61,7 @@ class SPV(ThreadJob):
             # if it's in the checkpoint region, we still might not have the header
             header = blockchain.read_header(tx_height)
             if header is None:
-                if tx_height <= NetworkConstants.VERIFICATION_BLOCK_HEIGHT:
+                if tx_height <= net.VERIFICATION_BLOCK_HEIGHT:
                     # Per-header requests might be a lot heavier.
                     # Also, they're not supported as header requests are
                     # currently designed for catching up post-checkpoint headers.

--- a/lib/version.py
+++ b/lib/version.py
@@ -8,3 +8,19 @@ SEED_PREFIX      = '01'      # Standard wallet
 def seed_prefix(seed_type):
     assert seed_type == 'standard'
     return SEED_PREFIX
+
+def parse_package_version(pvstr):
+    """
+    Parse a package version string e.g.:
+        '3.3.5CS' -> (3, 3, 5, 'CS')
+        '3.4.5_iOS' -> (3, 4, 5, '_iOS')
+        '3.3.5' -> (3, 3, 5, '')
+        '3.3' -> (3, 3, 0, '')
+        etc...
+    """
+    import re
+    m = re.search('(\d+)[.](\d+)[.]?(\d*)\s*(\S*)', pvstr)
+    if not m: return None
+    major, minor, rev, variant = int(m.group(1)), int(m.group(2)), m.group(3), m.group(4)
+    rev = int(rev) if rev else 0
+    return major, minor, rev, variant

--- a/lib/version.py
+++ b/lib/version.py
@@ -20,7 +20,8 @@ def parse_package_version(pvstr):
     """
     import re
     m = re.search('(\d+)[.](\d+)[.]?(\d*)\s*(\S*)', pvstr)
-    if not m: return None
+    if not m:
+        raise ValueError('Failed to parse package version for: ' + str(pvstr))
     major, minor, rev, variant = int(m.group(1)), int(m.group(2)), m.group(3), m.group(4)
     rev = int(rev) if rev else 0
     return major, minor, rev, variant

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -46,7 +46,7 @@ from .address import Address, Script, ScriptOutput, PublicKey
 from .bitcoin import *
 from .version import *
 from .keystore import load_keystore, Hardware_KeyStore, Imported_KeyStore, BIP32_KeyStore, xpubkey_to_address
-from .networks import NetworkConstants
+from . import networks
 from .storage import multisig_type
 
 from . import transaction
@@ -1343,7 +1343,7 @@ class Abstract_Wallet(PrintError):
         out = copy.copy(r)
         addr_text = addr.to_ui_string()
         amount_text = format_satoshis(r['amount'])
-        out['URI'] = '{}:{}?amount={}'.format(NetworkConstants.CASHADDR_PREFIX,
+        out['URI'] = '{}:{}?amount={}'.format(networks.net.CASHADDR_PREFIX,
                                               addr_text, amount_text)
         status, conf = self.get_request_status(addr)
         out['status'] = status

--- a/lib/web.py
+++ b/lib/web.py
@@ -30,7 +30,7 @@ import urllib
 
 from .address import Address
 from . import bitcoin
-from .networks import NetworkConstants
+from . import networks
 from .util import format_satoshis_plain
 
 
@@ -64,7 +64,7 @@ testnet_block_explorers = {
 }
 
 def BE_info():
-    if NetworkConstants.TESTNET:
+    if networks.net.TESTNET:
         return testnet_block_explorers
     return mainnet_block_explorers
 
@@ -117,8 +117,8 @@ def parse_URI(uri, on_pr=None):
 
     u = urllib.parse.urlparse(uri)
     # The scheme always comes back in lower case
-    if u.scheme != NetworkConstants.CASHADDR_PREFIX:
-        raise Exception("Not a {} URI".format(NetworkConstants.CASHADDR_PREFIX))
+    if u.scheme != networks.net.CASHADDR_PREFIX:
+        raise Exception("Not a {} URI".format(networks.net.CASHADDR_PREFIX))
     address = u.path
 
     # python for android fails to parse query

--- a/plugins/cosigner_pool/qt.py
+++ b/plugins/cosigner_pool/qt.py
@@ -163,14 +163,16 @@ class Plugin(BasePlugin):
     def __init__(self, parent, config, name):
         BasePlugin.__init__(self, parent, config, name)
         self.windows = []
+        self.initted = False
 
     @hook
     def init_qt(self, gui):
-        if self.windows: return # already initted
+        if self.initted: return # already initted
         self.print_error("Initializing...")
         for window in gui.windows:
             self.on_new_window(window)
         Plugin.Instance_ref = Weak.ref(self)
+        self.initted = True
 
     @hook
     def on_new_window(self, window):
@@ -222,6 +224,7 @@ class Plugin(BasePlugin):
         for w in self.windows.copy():
             self.on_close_window(w)
         self.windows = []
+        self.initted = False
         super().on_close()
 
     def update(self, window):


### PR DESCRIPTION
# Electron Cash Update Checker

![photo_2019-01-28 21 26 25](https://user-images.githubusercontent.com/266627/51860858-62dde100-2343-11e9-8405-beb2fe1ac5ec.jpeg)

This facility was inspired by a recent Electrum commit, and was also discussed in issue #1126 .

The purpose of this facility is merely as a convenience for users who aren't on reddit or aren't constantly refreshing our website to be able to find out when a new version is available.

It hopefully will decrease the number of users running very old versions of Electron Cash.

#### Overview

1. When the user selects "Check for updates...", Electron Cash connects to the URL hard-coded in `gui/qt/update_checker.py`. Currently: https://raw.github.com/Electron-Cash/Electron-Cash/master/contrib/update_checker/releases.json -- which is in this very repository!
2. It downloads `releases.json` 
3. It checks the versions seen in `releases.json` -- if they are newer than the version in the running app, and if the signed message is valid and is signed with one of the addresses hard-coded in `update_checker.py`, it then informs the user that an update is available.

*No automatic updating is performed* and the user must manually click on the URL hard-coded in the app to go to https://electroncash.org/#download.

#### Signatures

The `releases.json` file downloaded contains a dictionary of version strings mapped to bitocoin addresses and a signature.  The signature is **of** the version string itself.

The code in `update_checker.py` has a list of hard-coded bitcoin addresses for which it accepts a signature.  If the `releases.json` file's data is not properly signed, the checker presents the user with an error message. This is to avoid potential man-in-the-middle attacks or someone taking over this github repo and issuing bogus update announcements to Electron Cash.

The list hard-coded in this commit is:

```
       bitcoincash:qphax4cg8sxuc0qnzk6sx25939ma7y877uz04s2z82 # Calin's key
       bitcoincash:qqy9myvyt7qffgye5a2mn2vn8ry95qm6asy40ptgx2 # Mark Lundeberg's key
       bitcoincash:qz4wq9m860zr5p2nfdpttm5ymdqdyt3psc95qjagae # electroncash.org donation address
```

Let me know if I should change these or add more keys as signers!

---

This commit also contains a good bit of refactoring of `networks.py` because this facility requires access to MainNet constants even if in testnet mode (so the update checker signature verifier works even if in testnet).  

The refactoring I did is essentially updating this code to do what Electrum is now doing in their most recent commits.

Other bits of code here and there were also altered and improved.  Got rid of a bunch of cruft and simplified some things.

