### PR TITLE
Fully close wallet + Many PyQt memory leaks fixed

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -91,7 +91,7 @@ class ElectrumGui(QObject, PrintError):
         self.update_checker.got_new_version.connect(lambda x: self.show_update_checker(parent=None, skip_check=True))
         # init tray
         self.dark_icon = self.config.get("dark_icon", False)
-        self.tray = QSystemTrayIcon(self.tray_icon(), None)
+        self.tray = QSystemTrayIcon(self.tray_icon(), self)
         self.tray.setToolTip('Electron Cash')
         self.tray.activated.connect(self.tray_activated)
         self.build_tray_menu()
@@ -143,13 +143,21 @@ class ElectrumGui(QObject, PrintError):
         return False
 
     def build_tray_menu(self):
-        # Avoid immediate GC of old menu when window closed via its action
-        if self.tray.contextMenu() is None:
-            m = QMenu()
-            self.tray.setContextMenu(m)
-        else:
-            m = self.tray.contextMenu()
-            m.clear()
+        ''' Rebuild the tray menu by tearing it down and building it new again '''
+        m_old = self.tray.contextMenu()
+        if m_old is not None:
+            # Tray does NOT take ownership of menu, so we are tasked with
+            # deleting the old one. Note that we must delete the old one rather
+            # than just clearing it because otherwise the old sub-menus stick
+            # around in Qt. You can try calling qApp.topLevelWidgets() to
+            # convince yourself of this.  Doing it this way actually cleans-up
+            # the menus and they do not leak.
+            m_old.clear()
+            m_old.deleteLater()  # C++ object and its children will be deleted later when we return to the event loop
+        m = QMenu()
+        m.setObjectName("SysTray.QMenu")
+        self.tray.setContextMenu(m)
+        destroyed_print_error(m)
         for window in self.windows:
             submenu = m.addMenu(window.wallet.basename())
             submenu.addAction(_("Show/Hide"), window.show_or_hide)
@@ -277,6 +285,8 @@ class ElectrumGui(QObject, PrintError):
             # things like a transaction dialog or the network dialog were still
             # up.
             __class__._quit_after_last_window()  # checks if qApp.quitOnLastWindowClosed() is True, and if so, calls qApp.quit()
+
+        window.deleteLater()
 
     def gc_schedule(self):
         ''' Schedule garbage collection to happen in the near future.

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -78,7 +78,6 @@ class ElectrumGui(QObject, PrintError):
         self.daemon = daemon
         self.plugins = plugins
         self.windows = []
-        self.weak_windows = []
         self.app = QApplication(sys.argv)
         self.app.installEventFilter(self)
         self.timer = QTimer(self); self.timer.setSingleShot(False); self.timer.setInterval(500) #msec
@@ -204,11 +203,7 @@ class ElectrumGui(QObject, PrintError):
     def create_window_for_wallet(self, wallet):
         w = ElectrumWindow(self, wallet)
         self.windows.append(w)
-        dname = w.diagnostic_name()
-        def onFinalized(wr,dname=dname):
-            print_error("[{}] finalized".format(dname))
-            self.weak_windows.remove(wr)
-        self.weak_windows.append(Weak.ref(w,onFinalized))
+        Weak.finalization_print_error(w, "[{}] finalized".format(w.diagnostic_name()))
         self.build_tray_menu()
         # FIXME: Remove in favour of the load_wallet hook
         run_hook('on_new_window', w)

--- a/gui/qt/exception_window.py
+++ b/gui/qt/exception_window.py
@@ -191,7 +191,6 @@ class Exception_Hook(QObject):
     
     _report_exception = QtCore.pyqtSignal(object, object, object, object)
     _instance = None
-    _weak_instances = []
 
     def __init__(self, config):
         super().__init__(None) # Top-level Object
@@ -204,12 +203,7 @@ class Exception_Hook(QObject):
         sys.excepthook = self.handler # yet another strong reference. We really won't die unless uninstall() is called
         self._report_exception.connect(_show_window)
         print_error("[{}] Installed.".format(__class__.__qualname__))
-        Exception_Hook._weak_instances.append(Weak.ref(self, Exception_Hook.finalized))
-
-    @staticmethod
-    def finalized(wr):
-        print_error("[{}] Finalized.".format(__class__.__qualname__))
-        Exception_Hook._weak_instances.remove(wr)
+        Weak.finalization_print_error(self, "[{}] Finalized.".format(__class__.__qualname__))
 
     @staticmethod
     def uninstall():

--- a/gui/qt/exception_window.py
+++ b/gui/qt/exception_window.py
@@ -40,6 +40,7 @@ import sys
 from electroncash import PACKAGE_VERSION
 from electroncash.util import Weak, print_error
 from .main_window import ElectrumWindow
+from .util import destroyed_print_error
 
 
 issue_template = """<h2>Traceback</h2>
@@ -204,6 +205,7 @@ class Exception_Hook(QObject):
         self._report_exception.connect(_show_window)
         print_error("[{}] Installed.".format(__class__.__qualname__))
         Weak.finalization_print_error(self, "[{}] Finalized.".format(__class__.__qualname__))
+        destroyed_print_error(self)
 
     @staticmethod
     def uninstall():

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -283,8 +283,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         return self.top_level_window_recurse(override)
 
     def diagnostic_name(self):
-        return "%s/%s" % (PrintError.diagnostic_name(self),
-                          self.wallet.basename() if self.wallet else "None")
+        return "%s%s" % (PrintError.diagnostic_name(self),
+                         ("/"+self.wallet.basename()) if getattr(self, 'wallet', None) else "")
 
     def is_hidden(self):
         return self.isMinimized() or self.isHidden()
@@ -531,6 +531,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def init_menubar(self):
         menubar = QMenuBar()
+        menubar.setObjectName(self.diagnostic_name() + ".QMenuBar")
+        destroyed_print_error(menubar)
 
         file_menu = menubar.addMenu(_("&File"))
         self.recently_visited_menu = file_menu.addMenu(_("&Recently open"))

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -377,7 +377,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.request_list.update()
         self.tabs.show()
         self.init_geometry()
-        if self.config.get('hide_gui') and self.gui_object.tray.isVisible():
+        if self.config.get('hide_gui') and self.tray.isVisible():
             self.hide()
         else:
             self.show()
@@ -2258,12 +2258,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         wallet_path = self.wallet.storage.path
         basename = os.path.basename(wallet_path)
         r = self.gui_object.daemon.delete_wallet(wallet_path)  # implicitly also calls stop_wallet
-        self.close()
         self.update_recently_visited(wallet_path) # this ensures it's deleted from the menu
         if r:
             self.show_error(_("Wallet removed: {}").format(basename))
         else:
             self.show_error(_("Wallet file not found: {}").format(basename))
+        self.close()
 
     @protected
     def show_seed_dialog(self, password):
@@ -3399,6 +3399,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         # Removing child widgets forcefully to speed up Python's own GC of this window.
         self.clean_up_connections()
         self.clean_up_children()
+
+        # And finally, print when we are destroyed by C++ for debug purposes
+        # We must call this here as above calls disconnected all signals
+        # involving this widget.
+        destroyed_print_error(self)
 
 
     def internal_plugins_dialog(self):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3388,6 +3388,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         except TypeError: pass # defensive programming: this can happen if we got an exception before the timer action was connected
 
         self.gui_object.close_window(self) # implicitly runs the hook: on_close_window
+        # Now, actually STOP the wallet's synchronizer and verifiers and remove
+        # it from the daemon. Note that its addresses will still stay
+        # 'subscribed' to the ElectrumX server until we connect to a new server,
+        # (due to ElectrumX protocol limitations).. but this is harmless.
+        self.gui_object.daemon.stop_wallet(self.wallet.storage.path)
 
         # At this point all plugins should have removed any references to this window.
         # Now, just to be paranoid, do some active destruction of signal/slot connections as well as

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -935,6 +935,30 @@ def rate_limited(rate, *, classlevel=False, ts_after=False):
         return wrapper
     return wrapper0
 
+def destroyed_print_error(qobject, msg=None):
+    ''' Supply a message to be printed via print_error when obj is
+    destroyed (Qt C++ deleted). This is useful for debugging memory leaks. '''
+    assert isinstance(qobject, QObject), "destroyed_print_error can only be used on QObject instances!"
+    if msg is None:
+        # Generate a useful message if none is supplied.
+        name = qobject.objectName() or ""
+        if not name:
+            if isinstance(qobject, QAction) and qobject.text():
+                name = "Action: " + qobject.text()
+            elif isinstance(qobject, QMenu) and qobject.title():
+                name = "QMenu: " + qobject.title()
+            elif isinstance(qobject, PrintError):
+                name = qobject.diagnostic_name()
+            else:
+                try:
+                    name = (qobject.parent().objectName() or qobject.parent().__class__.__qualname__) + "."
+                except:
+                    pass  # some of the code in this project overrites .parent or it may nothave a parent
+                name += qobject.objectName() or qobject.__class__.__qualname__
+        msg = "[{}] destroyed".format(name)
+    def printer(x=None): print_error(msg)
+    qobject.destroyed.connect(printer)
+
 
 if __name__ == "__main__":
     app = QApplication([])

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -954,7 +954,7 @@ def destroyed_print_error(qobject, msg=None):
                     name = (qobject.parent().objectName() or qobject.parent().__class__.__qualname__) + "."
                 except:
                     pass  # some of the code in this project overrites .parent or it may not have a parent
-                name += qobject.objectName() or qobject.__class__.__qualname__
+                name += qobject.__class__.__qualname__
         msg = "[{}] destroyed".format(name)
     def printer(x=None): print_error(msg)
     qobject.destroyed.connect(printer)

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -953,7 +953,7 @@ def destroyed_print_error(qobject, msg=None):
                 try:
                     name = (qobject.parent().objectName() or qobject.parent().__class__.__qualname__) + "."
                 except:
-                    pass  # some of the code in this project overrites .parent or it may nothave a parent
+                    pass  # some of the code in this project overrites .parent or it may not have a parent
                 name += qobject.objectName() or qobject.__class__.__qualname__
         msg = "[{}] destroyed".format(name)
     def printer(x=None): print_error(msg)

--- a/lib/network.py
+++ b/lib/network.py
@@ -400,7 +400,7 @@ class Network(util.DaemonThread):
             else:
                 # If a wallet was closed, we stayed subscribed to its scripthashes
                 # (there is no way to unsubscribe from a scripthash, unfortunately)
-                # However, now what we are connecting to a new server, use this
+                # However, now that we are connecting to a new server, use this
                 # opportunity to clean house and not subscribe to scripthashes
                 # for closed wallets.  We know a scripthash is defunct if it is
                 # missing a callback (no entry in self.subscriptions dict).
@@ -816,7 +816,9 @@ class Network(util.DaemonThread):
         '''Unsubscribe a callback to free object references to enable GC.'''
         # Note: we can't unsubscribe from the server, so if we receive
         # subsequent notifications, they will be safely ignored as
-        # no callbacks will exist to process them.
+        # no callbacks will exist to process them. For subscriptions we will
+        # however cache the 'result' hash and feed it back in case a wallet that
+        # was closed gets reopened (self.sub_cache).
         ct = 0
         with self.lock:  # FIXME: still have possible race conditions here with network thread
             for k,v in self.subscriptions.copy().items():
@@ -835,7 +837,7 @@ class Network(util.DaemonThread):
         '''Remove a callback to free object references to enable GC.'''
         # If the interface ends up answering these requests, they will just
         # be safely ignored. This is better than the alternative which is to
-        # keep references to an object that declared itself cleaned-up.
+        # keep references to an object that declared itself defunct.
         ct = 0
         # FIXME: race conditions here with network thread since this is usually
         # called from the main thread.

--- a/lib/network.py
+++ b/lib/network.py
@@ -378,7 +378,6 @@ class Network(util.DaemonThread):
         return message_id
 
     def send_subscriptions(self):
-        self.print_error('sending subscriptions to', self.interface.server, len(self.unanswered_requests), len(self.subscribed_addresses))
         self.sub_cache.clear()
         # Resend unanswered requests
         old_reqs = self.unanswered_requests
@@ -391,8 +390,25 @@ class Network(util.DaemonThread):
         self.queue_request('server.peers.subscribe', [])
         self.request_fee_estimates()
         self.queue_request('blockchain.relayfee', [])
-        for h in self.subscribed_addresses:
-            self.queue_request('blockchain.scripthash.subscribe', [h])
+        n_defunct = 0
+        method = 'blockchain.scripthash.subscribe'
+        for h in self.subscribed_addresses.copy():
+            params = [h]
+            k = self.get_index(method, params)
+            if self.subscriptions.get(k, None):
+                self.queue_request(method, params)
+            else:
+                # If a wallet was closed, we stayed subscribed to its scripthashes
+                # (there is no way to unsubscribe from a scripthash, unfortunately)
+                # However, now what we are connecting to a new server, use this
+                # opportunity to clean house and not subscribe to scripthashes
+                # for closed wallets.  We know a scripthash is defunct if it is
+                # missing a callback (no entry in self.subscriptions dict).
+                #self.print_error("removing defunct subscription", h)
+                self.subscribed_addresses.discard(h)
+                self.subscriptions.pop(k, None)  # it may be an empty list (or missing), so pop it just in case it's a list.
+                n_defunct += 1
+        self.print_error('sent subscriptions to', self.interface.server, len(old_reqs),"reqs", len(self.subscribed_addresses), "subs (did not send", n_defunct,"defunct subs)")
 
     def request_fee_estimates(self):
         self.config.requested_fee_estimates()
@@ -775,10 +791,9 @@ class Network(util.DaemonThread):
                 if method.endswith('.subscribe'):
                     k = self.get_index(method, params)
                     # add callback to list
-                    l = self.subscriptions.get(k, [])
+                    l = self.subscriptions[k] # <-- it's a defaultdict(list)
                     if callback not in l:
                         l.append(callback)
-                    self.subscriptions[k] = l
                     # check cached response for subscriptions
                     r = self.sub_cache.get(k)
                 if r is not None:

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -73,8 +73,11 @@ class Synchronizer(ThreadJob):
                 and not self.requested_hashes)
 
     def release(self):
-        self.network.unsubscribe(self.on_address_status)
         self.cleaned_up = True
+        self.network.unsubscribe(self.on_address_status)
+        self.network.cancel_requests(self.on_address_status)
+        self.network.cancel_requests(self.on_address_history)
+        self.network.cancel_requests(self.tx_response)
 
     def add(self, address):
         '''This can be called from the proxy or GUI threads.'''

--- a/lib/util.py
+++ b/lib/util.py
@@ -725,9 +725,11 @@ class Weak:
     finalize = weakref.finalize # alias
 
     _weak_refs_for_print_error = []
-    def finalization_print_error(obj, msg):
+    def finalization_print_error(obj, msg=None):
         ''' Supply a message to be printed via print_error when obj is
         finalized (Python GC'd). This is useful for debugging memory leaks. '''
+        if msg is None:
+            msg = "[{}] finalized".format(obj.__class__.__qualname__)
         def finalizer(x):
             if x in __class__._weak_refs_for_print_error:
                 __class__._weak_refs_for_print_error.remove(x)

--- a/lib/util.py
+++ b/lib/util.py
@@ -728,6 +728,7 @@ class Weak:
     def finalization_print_error(obj, msg=None):
         ''' Supply a message to be printed via print_error when obj is
         finalized (Python GC'd). This is useful for debugging memory leaks. '''
+        assert not isinstance(obj, type), "finaliztion_print_error can only be used on instance objects!"
         if msg is None:
             msg = "[{}] finalized".format(obj.__class__.__qualname__)
         def finalizer(x):

--- a/lib/util.py
+++ b/lib/util.py
@@ -724,6 +724,18 @@ class Weak:
     Method = weakref.WeakMethod # alias
     finalize = weakref.finalize # alias
 
+    _weak_refs_for_print_error = []
+    def finalization_print_error(obj, msg):
+        ''' Supply a message to be printed via print_error when obj is
+        finalized (Python GC'd). This is useful for debugging memory leaks. '''
+        def finalizer(x):
+            if x in __class__._weak_refs_for_print_error:
+                __class__._weak_refs_for_print_error.remove(x)
+                print_error(msg)
+        wr = Weak.ref(obj, finalizer)
+        __class__._weak_refs_for_print_error.append(wr)
+
+
     class MethodProxy(weakref.WeakMethod):
         ''' Direct-use of this class is discouraged (aside from assigning to
             its print_func attribute). Instead use of the wrapper class 'Weak'

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -37,6 +37,10 @@ class SPV(ThreadJob):
         self.merkle_roots = {}  # txid -> merkle root (once it has been verified)
         self.requested_merkle = set()  # txid set of pending requests
         self.qbusy = False
+        self.cleaned_up = False
+
+    def release(self):
+        self.cleaned_up = True
 
     def run(self):
         interface = self.network.interface
@@ -85,7 +89,7 @@ class SPV(ThreadJob):
             self.undo_verifications()
 
     def verify_merkle(self, response):
-        if self.wallet.verifier is None:
+        if self.cleaned_up:
             return  # we have been killed, this was just an orphan callback
         if response.get('error'):
             # FIXME: tx will never verify now until server reconnect.

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -41,6 +41,7 @@ class SPV(ThreadJob):
 
     def release(self):
         self.cleaned_up = True
+        self.network.cancel_requests(self.verify_merkle)
 
     def run(self):
         interface = self.network.interface

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1133,6 +1133,7 @@ class Abstract_Wallet(PrintError):
         if self.network:
             self.network.remove_jobs([self.synchronizer, self.verifier])
             self.synchronizer.release()
+            self.verifier.release()
             self.synchronizer = None
             self.verifier = None
             # Now no references to the syncronizer or verifier

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -159,8 +159,6 @@ class Abstract_Wallet(PrintError):
 
     max_change_outputs = 3
 
-    _weak_wallets = []
-
     def __init__(self, storage):
         self.electrum_version = PACKAGE_VERSION
         self.storage = storage
@@ -224,13 +222,7 @@ class Abstract_Wallet(PrintError):
         self.contacts = Contacts(self.storage)
 
         # Print debug message on finalization
-        dname = "{}/{}".format(__class__.__name__, self.diagnostic_name())
-        def finalized(wr):
-            if wr in __class__._weak_wallets:
-                __class__._weak_wallets.remove(wr)
-                print_error("[{}] finalized".format(dname))
-        weakSelf = Weak.ref(self, finalized)
-        Abstract_Wallet._weak_wallets.append(weakSelf)
+        Weak.finalization_print_error(self, "[{}/{}] finalized".format(__class__.__name__, self.diagnostic_name()))
 
 
     @classmethod

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -40,7 +40,7 @@ from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
 from functools import partial
 
 from .i18n import _
-from .util import NotEnoughFunds, ExcessiveFee, PrintError, UserCancelled, profiler, format_satoshis, format_time, Weak, print_error
+from .util import NotEnoughFunds, ExcessiveFee, PrintError, UserCancelled, profiler, format_satoshis, format_time, Weak
 
 from .address import Address, Script, ScriptOutput, PublicKey
 from .bitcoin import *
@@ -223,7 +223,6 @@ class Abstract_Wallet(PrintError):
 
         # Print debug message on finalization
         Weak.finalization_print_error(self, "[{}/{}] finalized".format(__class__.__name__, self.diagnostic_name()))
-
 
     @classmethod
     def to_Address_dict(cls, d):


### PR DESCRIPTION
On window close the wallet stays open and continues to synchronize needlessly.  This is not expected UX.  It also is a waste of resources and slows down the app.  If you had several wallets open but then closed them the app would thus leak resources.

This has now been addressed in this PR.  Closing a wallet shuts down all of its resources, including removing all of its callbacks for subscriptions and cancelling all pending network sends from that wallet (they are tracked down based on callback method supplied to the request).

Since we can't "unsubscribe" from ElectrumX due to protocol limitations, we will get harmlessly notified on tx's in the network layer for a closed wallet, but the notifications are now ignored.

When we switch servers, the subscription set sent to a new server will not include the closed wallet's addresses.

To @fyookball  do not merge this PR (yet) as I am still reviewing its code and cleaning it up.  I will merge it when done!

**Also in this PR:** I noticed when a window closes, the system tray QMenu items stick around as top level widgets (qApp.topLevelWidgets() in console reveals this).  This has been addressed, plus some other leaked resource issues on the Qt side have been addressed.
