### PR TITLE
Network: 'updated' callback split into: 'wallet_updated' , 'blockchain_updated'

### DIFF
--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -469,7 +469,7 @@ class ElectrumWindow(App):
             activity.bind(on_new_intent=self.on_new_intent)
         # connect callbacks
         if self.network:
-            interests = ['blockchain_updated', 'wallet_updated', 'status', 'new_transaction', 'verified', 'interfaces']
+            interests = ['blockchain_updated', 'wallet_updated', 'status', 'new_transaction', 'verified2', 'interfaces']
             self.network.register_callback(self.on_network_event, interests)
             self.network.register_callback(self.on_quotes, ['on_quotes'])
             self.network.register_callback(self.on_history, ['on_history'])
@@ -620,7 +620,7 @@ class ElectrumWindow(App):
             tx, wallet = args
             if wallet == self.wallet:
                 self._trigger_update_wallet()
-        elif event == 'verified':
+        elif event == 'verified2':
             self._trigger_update_wallet()
 
     @profiler

--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -150,11 +150,11 @@ class ElectrumWindow(App):
         if self.history_screen:
             self.history_screen.update()
 
-    def on_quotes(self, d):
+    def on_quotes(self, *d):
         Logger.info("on_quotes")
         self._trigger_update_history()
 
-    def on_history(self, d):
+    def on_history(self, *d):
         Logger.info("on_history")
         self._trigger_update_history()
 
@@ -469,7 +469,7 @@ class ElectrumWindow(App):
             activity.bind(on_new_intent=self.on_new_intent)
         # connect callbacks
         if self.network:
-            interests = ['updated', 'status', 'new_transaction', 'verified', 'interfaces']
+            interests = ['blockchain_updated', 'wallet_updated', 'status', 'new_transaction', 'verified', 'interfaces']
             self.network.register_callback(self.on_network_event, interests)
             self.network.register_callback(self.on_quotes, ['on_quotes'])
             self.network.register_callback(self.on_history, ['on_history'])
@@ -611,7 +611,7 @@ class ElectrumWindow(App):
         Logger.info('network event: '+ event)
         if event == 'interfaces':
             self._trigger_update_interfaces()
-        elif event == 'updated':
+        elif event.endswith('updated'):  # blockchain_updated & wallet_updated
             self._trigger_update_wallet()
             self._trigger_update_status()
         elif event == 'status':

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -201,8 +201,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         if self.network:
             self.network_signal.connect(self.on_network_qt)
-            interests = ['updated', 'new_transaction', 'status',
-                         'banner', 'verified2', 'fee']
+            interests = ['blockchain_updated', 'wallet_updated',
+                         'new_transaction', 'status', 'banner', 'verified2',
+                         'fee']
             # To avoid leaking references to "self" that prevent the
             # window from being GC-ed when closed, callbacks should be
             # methods of this class only, and specifically not be
@@ -219,7 +220,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.fetch_alias()
 
     def on_history(self, event, *args):
-        # NB: event should always be 'history'
+        # NB: event should always be 'on_history'
         if not args or args[0] is self.wallet:
             self.new_fx_history_signal.emit()
 
@@ -309,14 +310,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.show_error(str(exc_info[1]))
 
     def on_network(self, event, *args):
-        if event == 'updated':
-            if not args or args[0] is self.wallet:
-                # NB there are two types 'updated' callbacks as of version 3.3.6
-                # 1. wallet-specific (from synchronizer) : args = (wallet,)
-                # 2. global (from network) : args = ()
-                # For (1) above we filter out events not for our wallet
-                # For (2) above we always accept.
+        #self.print_error("on_network:", event, *args)
+        if event == 'wallet_updated':
+            if args[0] is self.wallet:
                 self.need_update.set()
+        elif event == 'blockchain_updated':
+            self.need_update.set()
         elif event == 'new_transaction':
             self.tx_update_mgr.notif_add(args)  # added only if this wallet's tx
         elif event == 'verified2':

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -52,10 +52,11 @@ class NetworkDialog(QDialog, MessageBoxMixin):
         vbox.addLayout(self.nlayout.layout())
         vbox.addLayout(Buttons(CloseButton(self)))
         self.network_updated_signal.connect(self.on_update)
-        network.register_callback(self.on_network, ['updated', 'interfaces'])
+        network.register_callback(self.on_network, ['blockchain_updated', 'interfaces', 'status'])
 
     def on_network(self, event, *args):
         ''' This may run in network thread '''
+        #print_error("[NetworkDialog] on_network:",event,*args)
         self.network_updated_signal.emit() # this enqueues call to on_update in GUI thread
 
     @rate_limited(0.333) # limit network window updates to max 3 per second. More frequent isn't that useful anyway -- and on large wallets/big synchs the network spams us with events which we would rather collapse into 1

--- a/gui/stdio.py
+++ b/gui/stdio.py
@@ -37,7 +37,7 @@ class ElectrumGui:
         self.wallet.start_threads(self.network)
         self.contacts = self.wallet.contacts
 
-        self.network.register_callback(self.on_network, ['updated', 'banner'])
+        self.network.register_callback(self.on_network, ['wallet_updated', 'blockchain_updated', 'banner'])
         self.commands = [_("[h] - displays this help text"), \
                          _("[i] - display transaction history"), \
                          _("[o] - enter payment order"), \
@@ -50,7 +50,7 @@ class ElectrumGui:
         self.num_commands = len(self.commands)
 
     def on_network(self, event, *args):
-        if event == 'updated':
+        if event.endswith('updated'):  # blockchain_updated & wallet_updated
             self.updated()
         elif event == 'banner':
             self.print_banner()

--- a/gui/text.py
+++ b/gui/text.py
@@ -59,7 +59,7 @@ class ElectrumGui:
         self.history = None
 
         if self.network:
-            self.network.register_callback(self.update, ['updated'])
+            self.network.register_callback(self.update, ['wallet_updated', 'blockchain_updated'])
 
         self.tab_names = [_("History"), _("Send"), _("Receive"), _("Addresses"), _("Contacts"), _("Banner")]
         self.num_tabs = len(self.tab_names)
@@ -86,7 +86,7 @@ class ElectrumGui:
         self.set_cursor(0)
         return s
 
-    def update(self, event):
+    def update(self, event, *args):
         self.update_history()
         if self.tab == 0:
             self.print_history()

--- a/ios/ElectronCash/app.py
+++ b/ios/ElectronCash/app.py
@@ -21,7 +21,7 @@ def main():
             'cwd': os.getcwd(),
     }
 
-    set_verbosity(config_options.get('verbose'), timestamps=False)
+    set_verbosity(config_options.get('verbose'), timestamps=False, thread_id=False)
     NSLogSuppress(not config_options.get('verbose'))
 
     MonkeyPatches.patch()

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -359,8 +359,9 @@ class ElectrumGui(PrintError):
         if self.daemon.network:
             self.daemon.network.register_callback(self.on_history, ['on_history'])
             self.daemon.network.register_callback(self.on_quotes, ['on_quotes'])
-            interests = ['updated', 'new_transaction', 'status',
-                         'banner', 'verified', 'fee', 'interfaces']
+            interests = ['wallet_updated', 'blockchain_updated',
+                         'new_transaction', 'status', 'banner', 'verified2',
+                         'fee', 'interfaces']
             # To avoid leaking references to "self" that prevent the
             # window from being GC-ed when closed, callbacks should be
             # methods of this class only, and specifically not be
@@ -509,27 +510,27 @@ class ElectrumGui(PrintError):
         #    self.show_downloading_notif()
         pass
 
-    def on_history(self, b):
-        utils.NSLog("ON HISTORY (IsMainThread: %s)",str(NSThread.currentThread.isMainThread))
+    def on_history(self, event, *args):
+        utils.NSLog("ON HISTORY '%s' (IsMainThread: %s)",event,str(NSThread.currentThread.isMainThread))
         assert self.walletsVC is not None
         self.refresh_components('history', 'helper')
 
     def on_quotes(self, event, *args):
-        utils.NSLog("ON QUOTES (IsMainThread: %s)",str(NSThread.currentThread.isMainThread))
+        utils.NSLog("ON QUOTES '%s' (IsMainThread: %s)",event,str(NSThread.currentThread.isMainThread))
         #if self.daemon.fx.history_used_spot: #TODO: this is from qt gui.. figure out what this means.. does it help rate-limit?
         self.refresh_components('history', 'addresses', 'helper', 'requests')
 
     def on_network(self, event, *args):
-        utils.NSLog("ON NETWORK: %s (IsMainThread: %s)",event,str(NSThread.currentThread.isMainThread))
+        utils.NSLog("ON NETWORK: '%s' (IsMainThread: %s)",event,str(NSThread.currentThread.isMainThread))
         if not self.daemon:
             utils.NSLog("(Returning early.. daemon stopped)")
             return
         assert self.walletsVC is not None
-        if event == 'updated':
+        if event == 'blockchain_updated':
             self.refresh_components('helper', 'network')
         elif event == 'new_transaction':
             tx, wallet = args
-            if wallet == self.wallet:
+            if wallet is self.wallet:
                 self.tx_notifications.append(tx)
                 self.refresh_components('history', 'addresses', 'helper')
         elif event == 'banner':
@@ -538,12 +539,12 @@ class ElectrumGui(PrintError):
         elif event == 'status':
             #todo: handle status update here
             self.refresh_components('helper')
-        elif event in ['verified']:
+        elif event in ('verified2', 'wallet_updated'):
             self.refresh_components('history', 'addresses', 'helper')
         elif event == 'fee':
             # todo: handle fee stuff here
             pass
-        elif event in ['interfaces']:
+        elif event in ('interfaces',):
             self.refresh_components('network')
         else:
             self.print_error("unexpected network message:", event, args)
@@ -620,7 +621,7 @@ class ElectrumGui(PrintError):
             #icon = "status_disconnected.png"
 
         elif self.daemon.network.is_connected():
-            lh, sh = self.daemon.network.get_status_value('updated')
+            lh, sh = self.daemon.network.get_status_value('blockchain_updated')
             # lh = local_height, sh = server_height
             if self.lastHeightSeen != lh:
                 self.lastHeightSeen = lh
@@ -687,7 +688,7 @@ class ElectrumGui(PrintError):
                 ShowSplitNotify()
                 self.lastSplitNotify = time.time()
 
- 
+
             '''utils.NSLog("lh=%d sh=%d is_up_to_date=%d Wallet Network is_up_to_date=%d is_connecting=%d is_connected=%d",
                         int(lh), int(sh),
                         int(self.wallet.up_to_date),
@@ -2351,4 +2352,3 @@ class ElectrumGui(PrintError):
         self.createAndShowUI()
 
         self.setup_key_enclave(lambda: self.start_daemon())
-

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -540,7 +540,9 @@ class ElectrumGui(PrintError):
             #todo: handle status update here
             self.refresh_components('helper')
         elif event in ('verified2', 'wallet_updated'):
-            self.refresh_components('history', 'addresses', 'helper')
+            wallet = args[0]
+            if wallet is self.wallet:  # this should always be the case. But we check anyway in case in the future we support multiple wallets open at once.
+                self.refresh_components('history', 'addresses', 'helper')
         elif event == 'fee':
             # todo: handle fee stuff here
             pass

--- a/lib/network.py
+++ b/lib/network.py
@@ -292,8 +292,8 @@ class Network(util.DaemonThread):
         with self.lock:
             for event in events:
                 self.callbacks[event].append(callback)
-                if event == 'updated':
-                    self._warn_updated_deprecated()
+                if event in self._deprecated_alternatives:
+                    self._warn_deprecated_callback(event)
 
     def unregister_callback(self, callback):
         with self.lock:
@@ -315,15 +315,27 @@ class Network(util.DaemonThread):
             # still rely on this event existing. There are some external
             # electron cash plugins that still use this event, as does android,
             # and we need to keep this hack here so they don't break
-            # on new EC versions.  Such technical debt. Much wow.
-            self.trigger_callback('updated')  # this function will re-enter with event = 'updated'.
-        elif event == 'updated':
-            # if we see an updated event come through here, warn deprecated
-            # Note that the above clause will also trigger this callpath
-            self._warn_updated_deprecated()
+            # on new EC versions.  "Technical debt" :)
+            self.trigger_callback('updated')  # we will re-enter this function with event == 'updated' (triggering the warning in the elif clause below)
+        elif event == 'verified2' and 'verified' in self.callbacks:
+            # pop off the 'wallet' arg as the old bad 'verified' callback lacked it.
+            self.trigger_callback('verified', args[1:])  # we will re-enter this function with event == 'verified' (triggering the warning in the elif clause below)
+        elif event in ('updated', 'verified'):
+            # If we see updated or verified events come through here, warn:
+            # deprecated. Note that the above 2 clauses will also trigger this
+            # execution path.
+            self._warn_deprecated_callback(event)
 
-    def _warn_updated_deprecated(self):
-        self.print_error("Warning: Legacy 'updated' callback is deprecated, use the 'blockchain_updated' and/or 'wallet_updated' callbacks instead. Please update your code.")
+    _deprecated_alternatives = {
+        'updated' : "'blockchain_updated' and/or 'wallet_updated'",
+        'verified': "'verified2'",
+    }
+    def _warn_deprecated_callback(self, which):
+        alt = self._deprecated_alternatives.get(which)
+        if alt:
+            self.print_error("Warning: Legacy '{}' callback is deprecated, it is recommended that you instead use: {}. Please update your code.".format(which, alt))
+        else:
+            self.print_error("Warning: Legacy '{}' callback is deprecated. Please update your code.".format(which))
 
     def recent_servers_file(self):
         return os.path.join(self.config.path, "recent-servers")
@@ -447,7 +459,7 @@ class Network(util.DaemonThread):
             value = (self.get_local_height(), self.get_server_height())
         elif key == 'updated':
             value = (self.get_local_height(), self.get_server_height())
-            self._warn_updated_deprecated()
+            self._warn_deprecated_callback(key)
         elif key == 'servers':
             value = self.get_servers()
         elif key == 'interfaces':

--- a/lib/network.py
+++ b/lib/network.py
@@ -320,7 +320,7 @@ class Network(util.DaemonThread):
         elif event == 'verified2' and 'verified' in self.callbacks:
             # pop off the 'wallet' arg as the old bad 'verified' callback lacked it.
             self.trigger_callback('verified', args[1:])  # we will re-enter this function with event == 'verified' (triggering the warning in the elif clause below)
-        elif event in ('updated', 'verified'):
+        elif event in self._deprecated_alternatives:
             # If we see updated or verified events come through here, warn:
             # deprecated. Note that the above 2 clauses will also trigger this
             # execution path.

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -196,8 +196,7 @@ class Synchronizer(ThreadJob):
         # callbacks
         self.network.trigger_callback('new_transaction', tx, self.wallet)
         if not self.requested_tx:
-            # New in 3.3.6: 'updated' callbacks from synchronizer always specify which wallet, so GUI can ignore irrelevant 'updated' events
-            self.network.trigger_callback('updated', self.wallet)
+            self.network.trigger_callback('wallet_updated', self.wallet)
 
 
     def request_missing_txs(self, hist):
@@ -247,8 +246,7 @@ class Synchronizer(ThreadJob):
             up_to_date = self.is_up_to_date()
             if up_to_date != self.wallet.is_up_to_date():
                 self.wallet.set_up_to_date(up_to_date)
-                # New in 3.3.6: 'updated' callbacks from synchronizer always specify which wallet, so GUI can ignore irrelevant 'updated' events
-                self.network.trigger_callback('updated', self.wallet)
+                self.network.trigger_callback('wallet_updated', self.wallet)
         except InvalidXKeyFormat:
             # Workaround to buggy testnet wallets that had the wrong xpub..
             # This is here so that the network thread doesn't get blown up when

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -148,7 +148,7 @@ class SPV(ThreadJob):
         self.wallet.add_verified_tx(tx_hash, (tx_height, header.get('timestamp'), pos))
         if self.is_up_to_date() and self.wallet.is_up_to_date() and not self.qbusy:
             self.wallet.save_verified_tx(write=True)
-            self.network.trigger_callback('updated', self.wallet)  # This callback will happen very rarely.. mostly right as the last tx is verified. It's to ensure GUI is updated fully.
+            self.network.trigger_callback('wallet_updated', self.wallet)  # This callback will happen very rarely.. mostly right as the last tx is verified. It's to ensure GUI is updated fully.
 
     @classmethod
     def hash_merkle_root(cls, merkle_s, target_hash, pos):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -453,7 +453,6 @@ class Abstract_Wallet(PrintError):
             self.unverified_tx.pop(tx_hash, None)
             self.verified_tx[tx_hash] = info  # (tx_height, timestamp, pos)
             height, conf, timestamp = self.get_tx_height(tx_hash)
-        self.network.trigger_callback('verified', tx_hash, height, conf, timestamp)
         self.network.trigger_callback('verified2', self, tx_hash, height, conf, timestamp)
 
     def get_unverified_txs(self):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1647,7 +1647,7 @@ class Abstract_Wallet(PrintError):
         self.save_verified_tx()
         self.storage.write()
         self.start_threads(network)
-        self.network.trigger_callback('updated', self)
+        self.network.trigger_callback('wallet_updated', self)
 
 
 class Simple_Wallet(Abstract_Wallet):


### PR DESCRIPTION
This is a much needed change.  The 'updated' callback was overloaded to
indicate the wallet history was updated as well as the blockchain was
updated.

This was too large a granularity for what we need.

Since the Qt gui can have multiple wallet windows open, this led to a
situation where the GUI wallet windows were updating themselves multiple
times per wallet that got a new history, even if the update didn't
concern their particular wallet.

So -- we split up the ambiguous 'updated' event into 'blockchain_updated'
and 'wallet_updated'.

blockchain_updated -- callbacks receive 2 ints a parameters (local_height,
server_height).  Usually they are equal but local_height may be larger
than server_height if the server we are connected to is lagging behind
other servers in terms of the latest blockchain blocks it's seen.

wallet_updated -- callbacks receive the 'wallet' instance as a
parameter. Client code can look at this instance parameter and ignore
the notification if the update was for a different wallet.

The old 'updated' event will still be sent if callbacks have asked for it --
but the code will issue deprecated warnings using print_error each time
this happens.

Old plugins will continue to function as will legacy code, but with
warnings.

This change will allow client code to better be informed about the
state changes of the wallet vs/ blockchain.

FWIW -- Electrum has done this also long ago.

Also changed:

the 'status' event now also sends a string 'status' as a parameter
(previously it sent no parameters).

I grep'd through all the code and fixed everything to work with the new
API.

Note that Android still is using the old 'updated' scheme and thus it
needs to be migrated over else it will issue deprecated warnings.