### PR TITLE
Addition of Wallet -> Scan beyond gap

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -557,6 +557,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.import_address_menu = wallet_menu.addAction(_("Import addresses"), self.import_addresses)
         wallet_menu.addSeparator()
         self._rebuild_history_action = wallet_menu.addAction(_("&Rebuild history"), self.rebuild_history)
+        self._scan_beyond_gap_action = wallet_menu.addAction(_("&Scan beyond gap..."), self.scan_beyond_gap)
+        self._scan_beyond_gap_action.setEnabled(self.wallet.is_deterministic())
         wallet_menu.addSeparator()
 
         labels_menu = wallet_menu.addMenu(_("&Labels"))
@@ -3619,6 +3621,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.wallet.rebuild_history()
             except RuntimeError as e:
                 self.show_error(str(e))
+
+    def scan_beyond_gap(self):
+        from .scan_beyond_gap import ScanBeyondGap
+        d = ScanBeyondGap(self)
+        d.exec_()
+        d.setParent(None)  # help along Python by dropping refct to 0
+
 
 class TxUpdateMgr(QObject, PrintError):
     ''' Manages new transaction notifications and transaction verified

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -558,7 +558,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         wallet_menu.addSeparator()
         self._rebuild_history_action = wallet_menu.addAction(_("&Rebuild history"), self.rebuild_history)
         self._scan_beyond_gap_action = wallet_menu.addAction(_("&Scan beyond gap..."), self.scan_beyond_gap)
-        self._scan_beyond_gap_action.setEnabled(self.wallet.is_deterministic())
+        self._scan_beyond_gap_action.setEnabled(bool(self.wallet.is_deterministic() and self.network))
         wallet_menu.addSeparator()
 
         labels_menu = wallet_menu.addMenu(_("&Labels"))
@@ -3623,6 +3623,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.show_error(str(e))
 
     def scan_beyond_gap(self):
+        if self.gui_object.warn_if_no_network(self):
+            return
         from .scan_beyond_gap import ScanBeyondGap
         d = ScanBeyondGap(self)
         d.exec_()

--- a/gui/qt/scan_beyond_gap.py
+++ b/gui/qt/scan_beyond_gap.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Electron Cash - lightweight Bitcoin Cash client
+# Copyright (C) 2019 calin.culianu@gmail.com
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from PyQt5.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import *
+
+from .util import *
+from electroncash.util import PrintError
+from electroncash.i18n import _
+
+class ScanBeyondGap(WindowModalDialog, PrintError):
+
+    def __init__(self, main_window):
+        super().__init__(parent=main_window, title=_("Scan Beyond Gap"))
+        self.resize(450, 400)
+        self.main_window = main_window
+        vbox = QVBoxLayout(self)
+        l = QLabel(
+            "<p><font size=+1><b><i>" + _("Scan Beyond Gap") + "</i></b></font></p><p>"
+            + _("Normally, when you (re)generate a wallet from seed, your addresses are added to the wallet until a block of addresses are found without a history.")
+            + "</p><p>" + _("Addresses beyond this gap are not scanned for a balance.")
+            + "</p><p>"
+            + _("Use this tool to scan for an address history past your current address gap, and if any history is found, those addresses will be added to your wallet.")
+            + "</p>")
+        l.setWordWrap(True)
+        vbox.addWidget(l)
+        vbox.addStretch(1)
+        hbox = QHBoxLayout()
+        l = QLabel(_("Number of addresses to scan:"))
+        hbox.addWidget(l)
+        self.num_sb = QSpinBox(); self.num_sb.setMinimum(1); self.num_sb.setMaximum(1000000);
+        self.num_sb.setValue(100)
+        hbox.addWidget(self.num_sb)
+        self.which_cb = QComboBox()
+        self.which_cb.addItem(_("Scan Both Change & Receiving"))
+        self.which_cb.addItem(_("Change Addresses Only"))
+        self.which_cb.addItem(_("Receiving Addresses Only"))
+        self.which_cb.setCurrentIndex(0)
+        hbox.addWidget(self.which_cb)
+        hbox.addStretch(1)
+        vbox.addLayout(hbox)
+        self.prog = QProgressBar(); self.prog.setMinimum(0); self.prog.setMaximum(100);
+        vbox.addWidget(self.prog)
+        self.prog_label = QLabel()
+        vbox.addWidget(self.prog_label)
+        self.found_label = QLabel()
+        vbox.addWidget(self.found_label)
+        vbox.addStretch(1)
+        self.cancel_but = QPushButton(_("Cancel"))
+        self.scan_but = QPushButton(_("Start Scan"))
+        vbox.addLayout(Buttons(self.cancel_but, self.scan_but))
+
+        self.cancel_but.clicked.connect(self.cancel)
+        self.scan_but.clicked.connect(self.scan)
+
+    def cancel(self):
+        self.prog_label.setText(_("Canceled"))
+        self.reject()
+
+    def scan(self):
+        self.scan_but.setDisabled(True)
+        self.prog_label.setVisible(True)
+        self.found_label.setVisible(False)
+        total = self.num_sb.value()
+        self.prog_label.setText(_("Scanning {} of {} addresses ...").format(0, total))
+        self.found_label.setText('')

--- a/gui/qt/scan_beyond_gap.py
+++ b/gui/qt/scan_beyond_gap.py
@@ -153,7 +153,7 @@ class ScanBeyondGap(WindowModalDialog, PrintError):
         if found:
             found, added = found # decompose the tuple passed in
         if added:
-            self.show_message(_("{} address(es) with a history discovered and {} in-between address(es) were added to your wallet.").format(len(found), added))
+            self.show_message(_("{} address(es) with a history and {} in-between address(es) were added to your wallet.").format(len(found), added))
         else:
             self.show_message(_("No addresses with transaction histories were found in the specified scan range."))
         self.accept()

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1604,6 +1604,10 @@ class Abstract_Wallet(PrintError):
     def can_delete_address(self):
         return False
 
+    def is_multisig(self):
+        # Subclass Multisig_Wallet overrides this
+        return False
+
     def add_address(self, address):
         assert isinstance(address, Address)
         self._addr_bal_cache.pop(address, None)  # paranoia, not really necessary -- just want to maintain the invariant that when we modify address history below we invalidate cache.
@@ -2167,6 +2171,9 @@ class Multisig_Wallet(Deterministic_Wallet):
         # we need n place holders
         txin['signatures'] = [None] * self.n
         txin['num_sig'] = self.m
+
+    def is_multisig(self):
+        return True
 
 
 wallet_types = ['standard', 'multisig', 'imported']


### PR DESCRIPTION
Addresses #1193 in a more user-friendly (and hopefully useful) manner.

To test this, create a testnet wallet using this xpub:

tpubD6NzVbkrYhZ4YRDtddy5nLmvdH7Qn6oR7euDpjqnZdniaJDTbaL17Gq86bsVNhKMkYwGvSvhamz5QkouzGJ4e2rkyHWbF5mHGX5Up377zBM

After the wallet synchs (it's a big wallet so be patient), you can use Wallet -> Scan beyond gap... and it should find 4 addresses past the gap limit (2 change and 2 receiving) which have a tx history, and it will add them to the wallet.


See a screenshot of it in action:

<img width="992" alt="Screen Shot 2019-03-19 at 12 06 23 PM" src="https://user-images.githubusercontent.com/266627/54598014-4eaf8980-4a40-11e9-9035-4d9750d82148.png">

This option is obviously only enabled for deterministic wallets (watching-only & multisig tested and work).
