### PR TITLE
fix utxo_list context menu

### DIFF
--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -123,10 +123,16 @@ class UTXOList(MyTreeWidget):
         menu.addAction(_("Spend"), lambda: self.parent.spend_coins(spendable_coins)).setEnabled(bool(spendable_coins))
         if len(selected) == 1:
             # "Copy ..."
-            idx = self.indexAt(position)
-            col = idx.column()
+            item = self.itemAt(position)
+            if not item:
+                return
+
+            col = self.currentColumn()
             column_title = self.headerItem().text(col)
-            copy_text = (self.model().data(idx) if col != self.col_output_point else tuple(selected.keys())[0]).strip()
+            if col == self.col_output_point:
+                copy_text = item.data(0, Qt.UserRole)
+            else:
+                copy_text = item.text(col)
             menu.addAction(_("Copy {}").format(column_title), lambda: self.parent.app.clipboard().setText(copy_text))
 
             # single selection, offer them the "Details" option and also coin/address "freeze" status, if any


### PR DESCRIPTION
Code was throwing `AttributeError: 'NoneType' object has no attribute 'strip'`, if I right-clicked on empty space when a single item was selected.

New code based on address_list.py's menu function.

Same problem exists in shuffle plugin, FWIW