### PR TITLE
Add make_secp to python3 setup.py for bundling libseck256k1.so.0 

### DIFF
--- a/contrib/make_secp
+++ b/contrib/make_secp
@@ -3,11 +3,7 @@
 function fail {
     RED='\033[0;31m'
     printf "\r🗯 ${RED}ERROR:${NC} ${1}\n"
-    if [ -z "$2" ]; then
-        exit 1
-    else
-        exit "$2"
-    fi
+    exit 1
 }
 
 contrib=$(dirname "$0")
@@ -43,7 +39,7 @@ if [ "$uname" = "Darwin" ]; then
 elif [ "$uname" = "Linux" ]; then
     libsec_lib="libsecp256k1.so.0"
 else
-    fail "Unknown OS! Please manually copy the library produced in .libs/ and put it in the ../../lib folder (top level folder)" 0
+    fail "Unknown OS! Please manually copy the library produced in .libs/ and put it in the ../../lib folder (top level folder)"
 fi
 cp -fpv .libs/$libsec_lib ../../lib || fail "Could not copy the secp256k1 binary to its destination"
 git checkout master  # Undo the previous explicit checkout to this hash

--- a/contrib/make_secp
+++ b/contrib/make_secp
@@ -47,3 +47,4 @@ git clean -f -x -q
 popd
 
 echo "libsecp256k1.0.so has been placed in the electroncash 'lib' folder."
+

--- a/contrib/make_secp
+++ b/contrib/make_secp
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+function fail {
+    RED='\033[0;31m'
+    printf "\r🗯 ${RED}ERROR:${NC} ${1}\n"
+    exit 1
+}
+
+contrib=$(dirname "$0")
+test -n "$contrib" -a -d "$contrib" || fail "Could not find the contrib/ directory"
+
+whereis git || fail "Git is required to proceed"
+
+echo "Refreshing submodules..."
+git submodule init
+git submodule update
+
+echo "Building libsecp256k1..."
+LIBSECP_VERSION="a1d5a30364d2ca8ed8bb3ef3dd345cc75708a8b2"  # According to Mark B. Lundeberg, using a commit hash guarantees no repository man-in-the-middle funny business as git is secure when verifying hashes.
+
+pushd "$contrib"/secp256k1 || fail "Could not chdir to ${contrib}/secp256k1"
+git checkout $LIBSECP_VERSION || fail "Could not check out secp256k1 $LIBSECP_VERSION"
+git clean -f -x -q
+./autogen.sh || fail "Could not run autogen for secp256k1"
+./configure \
+    --enable-module-recovery \
+    --enable-experimental \
+    --enable-module-ecdh \
+    --disable-jni \
+    --with-bignum=no \
+    --enable-module-schnorr \
+    --disable-tests \
+    --disable-static \
+    --enable-shared || fail "Could not configure secp256k1"
+make -j4 || fail "Could not build secp256k1"
+uname=`uname`
+if [ "$uname" = "Darwin" ]; then
+    libsec_lib="libsecp256k1.0.dylib"
+elif [ "$uname" = "Linux" ]; then
+    libsec_lib="libsecp256k1.so.0"
+else
+    fail "Unknown OS! Please manually copy the library produced in .libs/ and put it in the ../../lib folder (top level folder)"
+fi
+cp -fpv .libs/$libsec_lib ../../lib || fail "Could not copy the secp256k1 binary to its destination"
+git checkout master  # Undo the previous explicit checkout to this hash
+git clean -f -x -q
+popd
+
+echo "libsecp256k1.0.so has been placed in the electroncash 'lib' folder."

--- a/contrib/make_secp
+++ b/contrib/make_secp
@@ -3,7 +3,11 @@
 function fail {
     RED='\033[0;31m'
     printf "\r🗯 ${RED}ERROR:${NC} ${1}\n"
-    exit 1
+    if [ -z "$2" ]; then
+        exit 1
+    else
+        exit "$2"
+    fi
 }
 
 contrib=$(dirname "$0")
@@ -33,7 +37,7 @@ git clean -f -x -q
     --disable-static \
     --enable-shared || fail "Could not configure secp256k1"
 make -j4 || fail "Could not build secp256k1"
-uname=`uname`
+uname=`uname -s`
 if [ "$uname" = "Darwin" ]; then
     libsec_lib="libsecp256k1.0.dylib"
 elif [ "$uname" = "Linux" ]; then

--- a/contrib/make_secp
+++ b/contrib/make_secp
@@ -43,7 +43,7 @@ if [ "$uname" = "Darwin" ]; then
 elif [ "$uname" = "Linux" ]; then
     libsec_lib="libsecp256k1.so.0"
 else
-    fail "Unknown OS! Please manually copy the library produced in .libs/ and put it in the ../../lib folder (top level folder)"
+    fail "Unknown OS! Please manually copy the library produced in .libs/ and put it in the ../../lib folder (top level folder)" 0
 fi
 cp -fpv .libs/$libsec_lib ../../lib || fail "Could not copy the secp256k1 binary to its destination"
 git checkout master  # Undo the previous explicit checkout to this hash

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ if sys.version_info[:3] < (3, 5, 2):
 data_files = []
 
 if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
+    0==os.system("contrib/make_locale") or sys.exit("Could not make locale")
+    0==os.system("contrib/make_packages") or sys.exit("Could not make locale")
+    0==os.system("contrib/make_secp") or sys.exit("Could not make locale")
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('--user', dest='is_user', action='store_true', default=False)
     parser.add_argument('--system', dest='is_user', action='store_false', default=False)
@@ -96,6 +99,7 @@ setup(
             'currencies.json',
             'www/index.html',
             'wordlist/*.txt',
+            'libsecp256k1*',
             'locale/*/LC_MESSAGES/electron-cash.mo',
         ],
         'electroncash_plugins.shuffle' : [

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 
 from setuptools import setup
 import setuptools.command.sdist
-import setuptools.command.build_py
 import os
 import sys
 import platform

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 
 from setuptools import setup
 import setuptools.command.sdist
+import setuptools.command.build_py
 import os
 import sys
 import platform
@@ -61,7 +62,7 @@ if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
         (os.path.join(share_dir, 'metainfo/'), ['org.electroncash.ElectronCash.appdata.xml']),
     ]
 
-class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
+class MakeAllBeforeMixin:
   """Does some custom stuff before calling super().run()."""
 
   def run(self):
@@ -74,10 +75,16 @@ class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
     0==os.system("contrib/make_secp") or self.announce("Could not make libsecp256k1, continuing anyway...")
     super().run()
 
+class MakAllBeforeSdist(setuptools.command.sdist.sdist, MakeAllBeforeMixin):
+    pass
+
+class MakAllBeforeBuild(setuptools.command.build_py.build_py, MakeAllBeforeMixin):
+    pass
 
 setup(
     cmdclass={
         'sdist': MakeAllBeforeSdist,
+        'build': MakAllBeforeBuild
     },
     name="Electron Cash",
     version=version.PACKAGE_VERSION,

--- a/setup.py
+++ b/setup.py
@@ -75,16 +75,16 @@ class MakeAllBeforeMixin:
     0==os.system("contrib/make_secp") or self.announce("Could not make libsecp256k1, continuing anyway...")
     super().run()
 
-class MakAllBeforeSdist(setuptools.command.sdist.sdist, MakeAllBeforeMixin):
+class MakeAllBeforeSdist(setuptools.command.sdist.sdist, MakeAllBeforeMixin):
     pass
 
-class MakAllBeforeBuild(setuptools.command.build_py.build_py, MakeAllBeforeMixin):
+class MakeAllBeforeBuild(setuptools.command.build_py.build_py, MakeAllBeforeMixin):
     pass
 
 setup(
     cmdclass={
         'sdist': MakeAllBeforeSdist,
-        'build': MakAllBeforeBuild
+        'build': MakeAllBeforeBuild
     },
     name="Electron Cash",
     version=version.PACKAGE_VERSION,

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
         (os.path.join(share_dir, 'metainfo/'), ['org.electroncash.ElectronCash.appdata.xml']),
     ]
 
-class MakeAllBeforeMixin:
+class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
   """Does some custom stuff before calling super().run()."""
 
   def run(self):
@@ -72,19 +72,12 @@ class MakeAllBeforeMixin:
     self.announce("Running make_packages...")
     0==os.system("contrib/make_packages") or sys.exit("Could not make locale, aborting")
     self.announce("Running make_secp...")
-    0==os.system("contrib/make_secp") or self.announce("Could not make libsecp256k1, continuing anyway...")
+    0==os.system("contrib/make_secp") or sys.exit("Could not build libsecp256k1")
     super().run()
-
-class MakeAllBeforeSdist(setuptools.command.sdist.sdist, MakeAllBeforeMixin):
-    pass
-
-class MakeAllBeforeBuild(setuptools.command.build_py.build_py, MakeAllBeforeMixin):
-    pass
 
 setup(
     cmdclass={
         'sdist': MakeAllBeforeSdist,
-        'build': MakeAllBeforeBuild
     },
     name="Electron Cash",
     version=version.PACKAGE_VERSION,


### PR DESCRIPTION
`python3 setup.py sdist` now does 3 things automatically:

1. Runs `contrib/make_local`
2. Runs `contrib/make_packages`
3. Runs `contrib/make_secp`

And finally, as it always did before:

4. It does all the other stuff for building the `.tar.gz` and/or `.zip` 

The libseck256k1.so.0 library is bundled in the lib/ folder of Electron Cash.

Mac and Windows users will have to run the .dmg/.exe or build secp256k1 themselves using `contrib/make_secp`, of course.

