### PR TITLE
[Qt] Performance improvement for the 5 major tab widgets

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -42,7 +42,7 @@ class AddressList(MyTreeWidget):
     filter_columns = [0, 1, 2]  # Address, Label, Balance
 
     def __init__(self, parent=None):
-        super().__init__(parent, self.create_menu, [], 2)
+        super().__init__(parent, self.create_menu, [], 2, deferred_updates=True)
         self.refresh_headers()
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
@@ -232,6 +232,8 @@ class AddressList(MyTreeWidget):
             super().keyPressEvent(event)
 
     def update_labels(self):
+        if self.should_defer_update_incr():
+            return
         def update_recurse(root):
             child_count = root.childCount()
             for i in range(child_count):

--- a/gui/qt/contact_list.py
+++ b/gui/qt/contact_list.py
@@ -40,7 +40,7 @@ class ContactList(MyTreeWidget):
     filter_columns = [0, 1]  # Key, Value
 
     def __init__(self, parent):
-        MyTreeWidget.__init__(self, parent, self.create_menu, [_('Name'), _('Address')], 0, [0])
+        MyTreeWidget.__init__(self, parent, self.create_menu, [_('Name'), _('Address')], 0, [0], deferred_updates=True)
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
 

--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -51,7 +51,7 @@ class HistoryList(MyTreeWidget):
     statusIcons = {}
 
     def __init__(self, parent=None):
-        super().__init__(parent, self.create_menu, [], 3)
+        super().__init__(parent, self.create_menu, [], 3, deferred_updates=True)
         self.refresh_headers()
         self.setColumnHidden(1, True)
         self.setSortingEnabled(True)
@@ -169,6 +169,8 @@ class HistoryList(MyTreeWidget):
                 self.parent.show_transaction(tx, label)
 
     def update_labels(self):
+        if self.should_defer_update_incr():
+            return
         root = self.invisibleRootItem()
         child_count = root.childCount()
         for i in range(child_count):
@@ -186,6 +188,8 @@ class HistoryList(MyTreeWidget):
             if icon: item.setIcon(0, icon)
             item.setData(0, SortableTreeWidgetItem.DataRole, (status, conf))
             item.setText(2, status_str)
+        elif self.should_defer_update_incr():
+            return False
         return bool(item)  # indicate to client code whether an actual update occurred
 
     def create_menu(self, position):

--- a/gui/qt/request_list.py
+++ b/gui/qt/request_list.py
@@ -39,7 +39,7 @@ class RequestList(MyTreeWidget):
 
 
     def __init__(self, parent):
-        MyTreeWidget.__init__(self, parent, self.create_menu, [_('Date'), _('Address'), '', _('Description'), _('Amount'), _('Status')], 3)
+        MyTreeWidget.__init__(self, parent, self.create_menu, [_('Date'), _('Address'), '', _('Description'), _('Amount'), _('Status')], 3, deferred_updates=True)
         self.currentItemChanged.connect(self.item_changed)
         self.itemClicked.connect(self.item_changed)
         self.setSortingEnabled(True)

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -524,7 +524,7 @@ class MyTreeWidget(QTreeWidget):
             # Now do any pending updates
             if self.editor is None and self.pending_update:
                 self.pending_update = False
-                self.on_update()
+                self.update()
 
     def on_edited(self, item, column, prior):
         '''Called only when the text actually changes'''

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -433,7 +433,7 @@ class ElectrumItemDelegate(QStyledItemDelegate):
 class MyTreeWidget(QTreeWidget):
 
     def __init__(self, parent, create_menu, headers, stretch_column=None,
-                 editable_columns=None):
+                 editable_columns=None, *, deferred_updates=False):
         QTreeWidget.__init__(self, parent)
         self.parent = parent
         self.config = self.parent.config
@@ -444,6 +444,8 @@ class MyTreeWidget(QTreeWidget):
         # extend the syntax for consistency
         self.addChild = self.addTopLevelItem
         self.insertChild = self.insertTopLevelItem
+        self.deferred_updates = deferred_updates
+        self.deferred_update_ct, self._forced_update = 0, False
 
         # Control which columns are editable
         self.editor = None
@@ -531,14 +533,28 @@ class MyTreeWidget(QTreeWidget):
         self.parent.wallet.set_label(key, text)
         self.parent.update_labels()
 
+    def should_defer_update_incr(self):
+        ret = (self.deferred_updates and not self.isVisible()
+               and not self._forced_update )
+        if ret:
+            self.deferred_update_ct += 1
+        return ret
+
     def update(self):
         # Defer updates if editing
         if self.editor:
             self.pending_update = True
         else:
+            # Deferred update mode won't actually update the GUI if it's
+            # not on-screen, and will instead update it the next time it is
+            # shown.  This has been found to radically speed up large wallets
+            # on initial synch or when new TX's arrive.
+            if self.should_defer_update_incr():
+                return
             self.setUpdatesEnabled(False)
             scroll_pos_val = self.verticalScrollBar().value() # save previous scroll bar position
             self.on_update()
+            self.deferred_update_ct = 0
             def restoreScrollBar():
                 self.updateGeometry()
                 self.verticalScrollBar().setValue(scroll_pos_val) # restore scroll bar to previous
@@ -548,7 +564,16 @@ class MyTreeWidget(QTreeWidget):
             self.filter(self.current_filter)
 
     def on_update(self):
+        # Reimplemented in subclasses
         pass
+
+    def showEvent(self, e):
+        super().showEvent(e)
+        if e.isAccepted() and self.deferred_update_ct:
+            self._forced_update = True
+            self.update()
+            self._forced_update = False
+            # self.deferred_update_ct will be set right after on_update is called because some subclasses use @rate_limiter on the update() method
 
     def get_leaves(self, root):
         child_count = root.childCount()

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -524,7 +524,8 @@ class MyTreeWidget(QTreeWidget):
             # Now do any pending updates
             if self.editor is None and self.pending_update:
                 self.pending_update = False
-                self.update()
+                self.on_update()
+                self.deferred_update_ct = 0
 
     def on_edited(self, item, column, prior):
         '''Called only when the text actually changes'''

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -32,7 +32,7 @@ class UTXOList(MyTreeWidget):
     col_output_point = 4  # <-- index of the 'Output point' column. make sure to update this if you modify the header below...
 
     def __init__(self, parent=None):
-        MyTreeWidget.__init__(self, parent, self.create_menu, [ _('Address'), _('Label'), _('Amount'), _('Height'), _('Output point')], 1)
+        MyTreeWidget.__init__(self, parent, self.create_menu, [ _('Address'), _('Label'), _('Amount'), _('Height'), _('Output point')], 1, deferred_updates=True)
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
         # force attributes to always be defined, even if None, at construction.
@@ -199,6 +199,8 @@ class UTXOList(MyTreeWidget):
             self.parent.set_frozen_state(list(addrs), b)
 
     def update_labels(self):
+        if self.should_defer_update_incr():
+            return
         root = self.invisibleRootItem()
         child_count = root.childCount()
         for i in range(child_count):


### PR DESCRIPTION
Address list, History list, utxo list, contacts list, and request list
now all defer their updates if they are off-screen (isVisible() ==
False), to when they are next shown.  This drastically improves GUI
responsiveness on large wallets (with many addresses or a large history)
and also increases the speed of initial wallet synch since as the
address history changes, not as much redundant GUI refreshing happens.

Instead, the refreshes happen in the showEvent() (only if there are some deferred updates in the queue).

For most use cases of the GUI the net effect is a perception of a faster GUI. Absolute CPU time is reduced on wallet synch.

The only drawback is the first time you switch to a tab, if it has a heavy update() method, you may notice a delay that didn't occur before (you paid that price instead as the wallet was synching and you paid it redundantly many times previously).

I think overall this PR is a win.

Tested thoroughly and works.