### PR TITLE
Fix #1223

### DIFF
--- a/gui/qt/external_plugins_window.py
+++ b/gui/qt/external_plugins_window.py
@@ -33,7 +33,7 @@ from PyQt5.QtWidgets import *
 
 from electroncash.i18n import _
 from electroncash.plugins import ExternalPluginCodes, run_hook
-from .util import MyTreeWidget, MessageBoxMixin, WindowModalDialog, Buttons, CloseButton
+from .util import MyTreeWidget, MessageBoxMixin, WindowModalDialog, AppModalDialog, Buttons, CloseButton
 
 
 INSTALL_ERROR_MESSAGES = {
@@ -54,7 +54,7 @@ INSTALL_ERROR_MESSAGES = {
 
 class ExternalPluginsPreviewDialog(WindowModalDialog):
     def __init__(self, plugin_dialog, main_window, title, plugin_path=None, plugin_metadata=None):
-        WindowModalDialog.__init__(self, main_window.top_level_window(), title)
+        WindowModalDialog.__init__(self, parent=main_window.top_level_window(), title=title)
 
         self.is_preview = plugin_metadata is None
 
@@ -246,9 +246,9 @@ class ExternalPluginsPreviewDialog(WindowModalDialog):
         self.plugin_dialog.install_plugin_confirmed(self.plugin_path)
 
 
-class ExternalPluginsDialog(WindowModalDialog, MessageBoxMixin):
+class ExternalPluginsDialog(AppModalDialog, MessageBoxMixin):
     def __init__(self, parent, title):
-        WindowModalDialog.__init__(self, parent.top_level_window(), title)
+        AppModalDialog.__init__(self, parent=parent.top_level_window(), title=title)
 
         self.main_window = parent
         self.config = parent.config

--- a/gui/qt/external_plugins_window.py
+++ b/gui/qt/external_plugins_window.py
@@ -33,7 +33,7 @@ from PyQt5.QtWidgets import *
 
 from electroncash.i18n import _
 from electroncash.plugins import ExternalPluginCodes, run_hook
-from .util import MyTreeWidget, MessageBoxMixin, WindowModalDialog, AppModalDialog, Buttons, CloseButton
+from .util import MyTreeWidget, MessageBoxMixin, WindowModalDialog, Buttons, CloseButton
 
 
 INSTALL_ERROR_MESSAGES = {
@@ -246,9 +246,9 @@ class ExternalPluginsPreviewDialog(WindowModalDialog):
         self.plugin_dialog.install_plugin_confirmed(self.plugin_path)
 
 
-class ExternalPluginsDialog(AppModalDialog, MessageBoxMixin):
+class ExternalPluginsDialog(WindowModalDialog, MessageBoxMixin):
     def __init__(self, parent, title):
-        AppModalDialog.__init__(self, parent=parent.top_level_window(), title=title)
+        WindowModalDialog.__init__(self, parent=parent.top_level_window(), title=title)
 
         self.main_window = parent
         self.config = parent.config

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -541,7 +541,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.gui_object.start_new_window(full_path, None)
 
     def init_menubar(self):
-        menubar = QMenuBar()
+        menubar = self.menuBar()
         menubar.setObjectName(self.diagnostic_name() + ".QMenuBar")
         destroyed_print_error(menubar)
 
@@ -603,8 +603,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         # Settings / Preferences are all reserved keywords in OSX using this as work around
         tools_menu.addAction(_("Electron Cash preferences") if sys.platform == 'darwin' else _("Preferences"), self.settings_dialog)
         gui_object = self.gui_object
-        weakSelf = Weak(self)
-        tools_menu.addAction(_("&Network"), lambda: gui_object.show_network_dialog(weakSelf))
+        weakSelf = Weak.ref(self)
+        tools_menu.addAction(_("&Network"), lambda: gui_object.show_network_dialog(weakSelf()))
         tools_menu.addAction(_("Optional &Features"), self.internal_plugins_dialog)
         tools_menu.addAction(_("Installed &Plugins"), self.external_plugins_dialog)
         tools_menu.addSeparator()
@@ -632,7 +632,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         help_menu.addSeparator()
         help_menu.addAction(_("&Donate to server"), self.donate_to_server)
 
-        self.setMenuBar(menubar)
 
     def donate_to_server(self):
         d = self.network.get_donation_address()
@@ -2282,9 +2281,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         sb.addPermanentWidget(StatusBarButton(QIcon(":icons/preferences.png"), _("Preferences"), self.settings_dialog ) )
         self.seed_button = StatusBarButton(QIcon(":icons/seed.png"), _("Seed"), self.show_seed_dialog )
         sb.addPermanentWidget(self.seed_button)
-        weakSelf = Weak(self)
+        weakSelf = Weak.ref(self)
         gui_object = self.gui_object
-        self.status_button = StatusBarButton(QIcon(":icons/status_disconnected.png"), _("Network"), lambda: gui_object.show_network_dialog(weakSelf))
+        self.status_button = StatusBarButton(QIcon(":icons/status_disconnected.png"), _("Network"), lambda: gui_object.show_network_dialog(weakSelf()))
         sb.addPermanentWidget(self.status_button)
         run_hook('create_status_bar', sb)
         self.setStatusBar(sb)
@@ -3709,7 +3708,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             # NB: reentrance here is possible due to the way the window menus work on MacOS.. so guard against it
             self.internalpluginsdialog.raise_()
             return
-        d = WindowModalDialog(self.top_level_window(), _('Optional Features'))
+        d = AppModalDialog(parent=self, title=_('Optional Features'))
         weakD = Weak.ref(d)
 
         gui_object = self.gui_object
@@ -3909,26 +3908,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if res == 0:
                 self.toggle_cashshuffle()
 
-    _restart_timer = None
-    def restart_cashshuffle(self, msg = None):
-        def ask_then_restart():
-            self._restart_timer.deleteLater(); self._restart_timer = None
-            self.raise_()
-            if self.question("{}{}".format(msg + "\n\n" if msg else "", _("Restart the CashShuffle plugin now?"))):
-                p = self.cashshuffle_plugin_if_loaded()
-                if p:
-                    p.restart_all()
-                    self.notify(_("CashShuffle restarted"))
-                else:
-                    self.notify(_("CashShuffle could not be restarted"))
-        if self._restart_timer:
-            self._restart_timer.stop()
-            self._restart_timer.deleteLater()
-        self._restart_timer = QTimer(self); self._restart_timer.setSingleShot(True)
-        self._restart_timer.timeout.connect(ask_then_restart)
-        self._restart_timer.start(100)
-        if self.internalpluginsdialog and self.internalpluginsdialog.isVisible():
-            self.internalpluginsdialog.reject()
+    def restart_cashshuffle(self, msg = None, parent = None):
+        if (parent or self).question("{}{}".format(msg + "\n\n" if msg else "", _("Restart the CashShuffle plugin now?")),
+                                     app_modal=True):
+            p = self.cashshuffle_plugin_if_loaded()
+            if p:
+                p.restart_all()
+                self.notify(_("CashShuffle restarted"))
+            else:
+                self.notify(_("CashShuffle could not be restarted"))
 
     _cash_shuffle_flag = 0
     def cashshuffle_set_flag(self, flag):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3708,7 +3708,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             # NB: reentrance here is possible due to the way the window menus work on MacOS.. so guard against it
             self.internalpluginsdialog.raise_()
             return
-        d = AppModalDialog(parent=self, title=_('Optional Features'))
+        d = WindowModalDialog(parent=self, title=_('Optional Features'))
         weakD = Weak.ref(d)
 
         gui_object = self.gui_object

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -40,7 +40,7 @@ from .util import *
 protocol_names = ['TCP', 'SSL']
 protocol_letters = 'ts'
 
-class NetworkDialog(QDialog, MessageBoxMixin):
+class NetworkDialog(MessageBoxMixin, QDialog):
     network_updated_signal = pyqtSignal()
 
     def __init__(self, network, config):

--- a/plugins/shuffle/qt.py
+++ b/plugins/shuffle/qt.py
@@ -40,7 +40,7 @@ from electroncash.bitcoin import COINBASE_MATURITY
 from electroncash.transaction import Transaction
 from electroncash.simple_config import SimpleConfig, get_config
 from electroncash.wallet import Abstract_Wallet
-from electroncash_gui.qt.util import EnterButton, CancelButton, Buttons, CloseButton, HelpLabel, OkButton, WindowModalDialog, rate_limited, ColorScheme, destroyed_print_error
+from electroncash_gui.qt.util import EnterButton, CancelButton, Buttons, CloseButton, HelpLabel, OkButton, rate_limited, ColorScheme, destroyed_print_error, AppModalDialog
 from electroncash_gui.qt.password_dialog import PasswordDialog
 from electroncash_gui.qt.main_window import ElectrumWindow
 from electroncash_gui.qt.amountedit import BTCAmountEdit
@@ -529,7 +529,7 @@ class Plugin(BasePlugin):
         if not nd: return
         self.print_error("OnNetworkDialog", str(nd))
         if not hasattr(nd, "__shuffle_settings__") or not nd.__shuffle_settings__:
-            nd.__shuffle_settings__ = st = SettingsTab(nd.nlayout.tabs, None, nd.nlayout.config)
+            nd.__shuffle_settings__ = st = SettingsTab(parent=nd.nlayout.tabs, config=nd.nlayout.config)
             nd.nlayout.tabs.addTab(st, _("CashShuffle"))
             st.applyChanges.connect(Plugin.try_to_apply_network_dialog_settings)
         elif nd.__shuffle_settings__:
@@ -919,7 +919,7 @@ class Plugin(BasePlugin):
             window = window_parent(window)
         assert window and isinstance(window, ElectrumWindow)
 
-        d = SettingsDialog(None, _("CashShuffle Settings"), window.config, msg)
+        d = SettingsDialog(title=_("CashShuffle Settings"), config=window.config, message=msg)
         try:
             server_ok = False
             ns = None
@@ -966,7 +966,8 @@ class Plugin(BasePlugin):
             # NB: if no window at this point, settings will take effect next time CashShuffle is enabled for a window
             if window:
                 # window will raise itself.
-                window.restart_cashshuffle(msg = _("CashShuffle must be restarted for the server change to take effect."))
+                window.restart_cashshuffle(msg = _("CashShuffle must be restarted for the server change to take effect."),
+                                           parent = Plugin.network_dialog)
 
     @staticmethod
     def save_network_settings(config, network_settings):
@@ -1356,22 +1357,28 @@ class NetworkCheckerDelegateMixin:
     settingsChanged = pyqtSignal(dict)
     statusChanged = pyqtSignal(dict)
 
-class SettingsDialog(WindowModalDialog, PrintError, NetworkCheckerDelegateMixin):
+class SettingsDialogMixin(NetworkCheckerDelegateMixin, PrintError):
+    ''' Abstrat Base class -- do not instantiate this as it will raise errors
+    because the pyqtSignal cannot be bound to a non-QObject.
+
+    Instead, use SettingsDialog and/or SettingsTab which interit from this and
+    are proper QObject subclasses.
+
+    Also call __init__ on the QObject/QWidget first before calling this
+    class's __init__ method.'''
     # from base: settingsChanged = pyqtSignal(dict)
     # from base: statusChanged = pyqtSignal(dict)
     formChanged = pyqtSignal()
 
     _DEFAULT_HOST_SUBSTR = "shuffle.servo.cash"  # on fresh install, prefer this server as default (substring match)
 
-    def __init__(self, parent, title, config, message=None):
-        super().__init__(parent, title)
+    def __init__(self, config, message=None):
+        assert config
+        assert isinstance(self, QWidget)
         self.config = config
         self.networkChecker = None
         self.serverOk = None
         self._vpLastStatus = dict()
-        if not isinstance(self, SettingsTab):
-            self.setWindowModality(Qt.ApplicationModal)
-            self.setMinimumSize(400, 350)
         self.setup(message)
 
         #DEBUG
@@ -1379,15 +1386,20 @@ class SettingsDialog(WindowModalDialog, PrintError, NetworkCheckerDelegateMixin)
 
     #def __del__(self):
     #    self.print_error("(Instance deleted)")
-
+    def _qwidget_base(self):
+        mytype = type(self)
+        classes = mytype.__mro__
+        for c in classes:
+            if issubclass(c, QWidget) and c is not mytype and c is not SettingsDialogMixin:
+                return c
     def showEvent(self, e):
-        super().showEvent(e)
+        self._qwidget_base().showEvent(self, e)
         self.startNetworkChecker()
     def hideEvent(self, e):
-        super().hideEvent(e)
+        self._qwidget_base().hideEvent(self, e)
         self.stopNetworkChecker()
     def closeEvent(self, e):
-        super().closeEvent(e)
+        self._qwidget_base().closeEvent(self, e)
     def from_combobox(self):
         d = self.cb.currentData()
         if isinstance(d, dict):
@@ -1613,8 +1625,42 @@ class SettingsDialog(WindowModalDialog, PrintError, NetworkCheckerDelegateMixin)
             self.networkChecker = None
             self.print_error("Stopped network checker.")
     # /
+# /SettingsDialogMixin
+class SettingsDialog(SettingsDialogMixin, AppModalDialog):
+    ''' Concrete class for the stand-alone Settings window you get when
+    you right-click and get "CashShuffle Settings..." from the CashShuffle status
+    button context menu '''
+    def __init__(self, title, config, message=None, windowFlags=None):
+        AppModalDialog.__init__(self, title=title, windowFlags=windowFlags, parent=None)
+        self.setMinimumSize(400, 350)
+        SettingsDialogMixin.__init__(self, config=config, message=message)
 # /SettingsDialog
-class NetworkChecker(QThread, PrintError):
+class SettingsTab(SettingsDialogMixin, QWidget):
+    # Apparently if you inherit from a C++ object first it creates problems.
+    # You are supposed to inherit from the mixins in Python first, then the
+    # Qt C++ object last. Who knew. All of Electron Cash codebase apparently
+    # is doing it wrong.
+    # See this: http://python.6.x6.nabble.com/Issue-with-multiple-inheritance-td5207771.html
+    # So we inherit from our mixin first. (Note I had problems with overriding
+    # __init__ here and Qt's C++ calling the wrong init here.)
+    applyChanges = pyqtSignal(object)
+
+    def __init__(self, parent, config, message=None):
+        QWidget.__init__(self, parent=parent)
+        SettingsDialogMixin.__init__(self, config=config, message=message)
+        # add the "Apply" button to the bottom
+        self.apply = QPushButton(_("Apply"), self)
+        hbox = QHBoxLayout()
+        self.vbox.addLayout(hbox)
+        self.vbox.addStretch()
+        hbox.addStretch(1)
+        hbox.addWidget(self.apply)
+        self.apply.clicked.connect(lambda: self.applyChanges.emit(self))
+    def _vpOnPoolsBut(self):
+        w = PoolsWinMgr.show(self._vpLastStatus, self.get_form(), self.config, modal=False, parent_window=self)
+# /SettingsTab
+
+class NetworkChecker(PrintError, QThread):
     ''' Runs in a separate thread, checks the server automatically when the settings form changes
         and publishes results to GUI thread. '''
     pollTimeSecs = 15.0
@@ -1725,25 +1771,6 @@ class NetworkChecker(QThread, PrintError):
             del c
     # / run
 # / NetworkChecker
-
-class SettingsTab(SettingsDialog):
-    applyChanges = pyqtSignal(object)
-
-    def __init__(self, parent, title, config, message=None):
-        super().__init__(parent, title, config, message)
-        self.setWindowModality(Qt.NonModal)
-        self.setWindowFlags(Qt.Widget) # force non-dialog
-        # add the "Apply" button to the bottom
-        self.apply = QPushButton(_("Apply"), self)
-        hbox = QHBoxLayout()
-        self.vbox.addLayout(hbox)
-        self.vbox.addStretch()
-        hbox.addStretch(1)
-        hbox.addWidget(self.apply)
-        self.apply.clicked.connect(lambda: self.applyChanges.emit(self))
-    def _vpOnPoolsBut(self):
-        w = PoolsWinMgr.show(self._vpLastStatus, self.get_form(), self.config, modal=False, parent_window=self)
-# /SettingsTab
 
 class PoolsWinMgr(QObject, PrintError):
     simpleChangedSig = pyqtSignal()
@@ -2010,26 +2037,12 @@ class PoolsWindow(QWidget, PrintError, NetworkCheckerDelegateMixin):
             self.print_error("Stopped network checker.")
 # /PoolsWindow
 
-class AppModalDialog(WindowModalDialog):
-    ''' Convenience class -- like the WindowModalDialog but is app-modal.
-    Has all the MessageBoxMixin convenience methods.  Is always top-level and
-    parentless.'''
-    def __init__(self, title=None, windowFlags=None):
-        dummy_parent = QWidget()  # this is here because WindowModalDialog forces a parent with an assert.
-        super().__init__(parent=dummy_parent, title=title)
-        self.setParent(None)
-        self.setWindowModality(Qt.ApplicationModal)
-        del dummy_parent
-        if windowFlags is not None:
-            self.setWindowFlags(windowFlags)
-# /AppModalDialog
-
 class CoinSelectionSettingsWindow(AppModalDialog, PrintError):
     ''' The pop-up window to manage minimum/maximum coin amount settings.
     Accessible from a link in the "CashShuffle Settings.." window or Network
     Dialog tab. '''
     def __init__(self, title=None):
-        super().__init__(title=title or _("CashShuffle - Coin Selection Settings"))
+        super().__init__(title=title or _("CashShuffle - Coin Selection Settings"), parent=None)
         vbox = QVBoxLayout(self)
         lbl = QLabel(_("Specify minimum and maximum coin amounts to select for shuffling:"))
         lbl.setWordWrap(True)


### PR DESCRIPTION
It turns out that QTimer that rejects the internalpluginsdialog stuff in main_window.py was the likely culprit.  

I also discovered that if you use Mixin classes with PyQt, it's best to inherit from QObjects last in the inheritance list. 

I refactored the code a bit and I think the bug is gone now (at least I cannot reproduce it easily).

Note that there still are quirks on macOS only related to the shared app menu (top menu bar) that you get on macOS -- but those were always there.

I am curious if this is fixed on Linux and Windows.  I tested it on Linux and was unable to reproduce the bug again after these changes.

I'm hoping that's the case for Windows too.  I'm building Windows now and will test on it.

@zquestz  -- can you test too and confirm it's gone?

