### PR TITLE
Option to disable libsecp256k1 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,17 +62,31 @@ if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
     ]
 
 class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
-  """Does some custom stuff before calling super().run()."""
+    """Does some custom stuff before calling super().run()."""
 
-  def run(self):
-    """Run command."""
-    #self.announce("Running make_locale...")
-    #0==os.system("contrib/make_locale") or sys.exit("Could not make locale, aborting")
-    #self.announce("Running make_packages...")
-    #0==os.system("contrib/make_packages") or sys.exit("Could not make locale, aborting")
-    self.announce("Running make_secp...")
-    0==os.system("contrib/make_secp") or sys.exit("Could not build libsecp256k1")
-    super().run()
+    user_options = setuptools.command.sdist.sdist.user_options + [
+        ("disable-secp", None, "Disable libsecp256k1 complilation.")
+    ]
+
+    def initialize_options(self):
+        self.disable_secp = None
+        super().initialize_options()
+
+    def finalize_options(self):
+        if self.disable_secp is None:
+            self.disable_secp = False # Default to build secp
+        super().finalize_options()
+
+    def run(self):
+        """Run command."""
+        #self.announce("Running make_locale...")
+        #0==os.system("contrib/make_locale") or sys.exit("Could not make locale, aborting")
+        #self.announce("Running make_packages...")
+        #0==os.system("contrib/make_packages") or sys.exit("Could not make locale, aborting")
+        if not self.disable_secp:
+            self.announce("Running make_secp...")
+            0==os.system("contrib/make_secp") or sys.exit("Could not build libsecp256k1")
+        super().run()
 
 setup(
     cmdclass={


### PR DESCRIPTION
This essentially adds an option to **not** build the `libsecp256k1.so` library by using the `--disable-secp` flag while running `python setup.py sdist`. The default is still to build the library, so the expected functionality hasn't changed. I also indented the edited class to fit the rest of the file.

This is useful for some build systems (specifically the Arch Linux AUR package for me), as:
* libsecp256k1 can be required as a dependency through the package manager, so it's redundant to build it again for Electron Cash
* The build for Arch Linux is currently being done from GitHub release tars rather than syncing the whole source tree, and `make_secp` requires the source tree.