### PR TITLE
fix relative imports

### DIFF
--- a/lib/caches.py
+++ b/lib/caches.py
@@ -5,7 +5,7 @@ import threading
 import queue
 import weakref
 from collections import defaultdict
-from electroncash.util import PrintError
+from .util import PrintError
 
 class ExpiringCache:
     ''' A fast cache useful for storing tens of thousands of lightweight items.

--- a/lib/plot.py
+++ b/lib/plot.py
@@ -1,10 +1,10 @@
 from PyQt5.QtGui import *
-from electroncash.i18n import _
+from .i18n import _
 
 
 import datetime
 from collections import defaultdict
-from electroncash.bitcoin import COIN
+from .bitcoin import COIN
 
 import matplotlib
 matplotlib.use('Qt5Agg')


### PR DESCRIPTION
Sometimes I like to run IPython in the electroncash repo directory and do things like `from lib import bitcoin`, just to play with the functions ... using relative imports makes sure this works.
