### PR TITLE
CashShuffle: Implemented Coin -> Reshuffle

### DIFF
--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -178,6 +178,8 @@ class UTXOList(MyTreeWidget):
                 # they have some address-level frozen in the selection, so add the menu action "Unfreeze addresses"
                 menu.addAction(_("Unfreeze Addresses"), lambda: self.set_frozen_addresses_for_coins(list(selected.keys()), False))
 
+        run_hook('utxo_list_context_menu_setup', self, menu, selected)
+
         menu.exec_(self.viewport().mapToGlobal(position))
 
     def on_permit_edit(self, item, column):

--- a/plugins/shuffle/coin_utils.py
+++ b/plugins/shuffle/coin_utils.py
@@ -387,6 +387,13 @@ class CoinUtils(PrintError):
                     pass
 
 
+    @staticmethod
+    def coin_name_to_dict(coin_name):
+        tok = coin_name.split(':')
+        return {
+            'prevout_hash' : tok[0],
+            'prevout_n'    : int(tok[1])
+        }
 
     @staticmethod
     def is_coin_shuffled(wallet, coin, txs_in=None):


### PR DESCRIPTION
Right Click on a Shuffled coin in the coins tab (or a set of shuffled coins) and you get a new context menu option "Reshuffle Coin"

This allows you to increase privacy for yourself and/or provide liquidity for others by shuffling a coin that was already shuffled.

Rules/Caveats:

- The option sets and in-memory flag that is reset the next time the wallet is restarted -- so you can schedule a coin to be reshuffled but if you restart that coin will go back to the "Shuffled" status unconditionally

- If the shuffled coin happened to have another coin on that address, that coin will now be frozen after the shuffled coin is reshuffled.  The user will have to manually resolve the situation (if they unfreeze the coin typically it will just get queued for shuffling)

- It's possible to cancel a reshuffle flag on a coin or coins simply by right-clicking on it/them again and you will see the option in the context menu.

- This option is only available for CashShuffle :)

See screenshots:

<img width="1129" alt="Screen Shot 2019-03-29 at 9 36 24 PM" src="https://user-images.githubusercontent.com/266627/55258169-bfd61480-526a-11e9-939f-e1254271fdea.png">

<img width="1145" alt="Screen Shot 2019-03-29 at 9 37 07 PM" src="https://user-images.githubusercontent.com/266627/55258203-dc724c80-526a-11e9-852b-49dd4e81d14f.png">
