### PR TITLE
Plugins DevMgr: Fix devices not being closed when their id is not in xpub_ids

### DIFF
--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -863,10 +863,11 @@ class DeviceMgr(ThreadJob, PrintError):
                     connected[client] = pair
                 else:
                     disconnected_ids.append(pair[1])
-            self.clients = connected
 
-        # Unpair disconnected devices
-        for id_ in disconnected_ids:
-            self.unpair_id(id_)
+            # Unpair disconnected devices
+            for id_ in disconnected_ids:
+                self.unpair_id(id_)
+
+            self.clients = connected
 
         return devices


### PR DESCRIPTION
As mentioned in #1243 