### PR TITLE
Hw Wallets: Retry pairing when pressing the settings dialog button

### DIFF
--- a/plugins/hw_wallet/qt.py
+++ b/plugins/hw_wallet/qt.py
@@ -224,6 +224,11 @@ class QtPluginBase(object):
             except UserCancelled:
                 return
             device_id = info.device.id_
+
+            # Check that no pairing thread is still running
+            if keystore.thread.tasks.empty():
+                # Retry the pairing
+                keystore.thread.add(partial(self.get_client, keystore))
         return device_id
 
     def show_settings_dialog(self, window, keystore):


### PR DESCRIPTION
Check if the device is paired and if not it starts a new get_client thread

needs #1246 to work properly

closes #1243 