### PR TITLE
Hw Wallets: Show proper error message when trying to sign a tx with OP_RETURN

### DIFF
--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -542,7 +542,8 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
 
             # Build pubkeyarray from outputs
             for _type, address, amount in tx.outputs():
-                assert _type == TYPE_ADDRESS
+                if not _type == TYPE_ADDRESS:
+                    self.give_error(_("Only address outputs are supported by {}").format(self.name))
                 info = tx.output_info.get(address)
                 if info is not None:
                     index, xpubs, m = info

--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -383,7 +383,8 @@ class Ledger_KeyStore(Hardware_KeyStore):
         # Recognize outputs - only one output and one change is authorized
         if not p2shTransaction:
             for _type, address, amount in tx.outputs():
-                assert _type == TYPE_ADDRESS
+                if not _type == TYPE_ADDRESS:
+                    self.give_error(_("Only address outputs are supported by {}").format(self.name))
                 info = tx.output_info.get(address)
                 if (info is not None) and (len(tx.outputs()) != 1):
                     index, xpubs, m = info


### PR DESCRIPTION
Same problem as in #1129 exists with `ledger` and `digitalbitbox` plugins. Instead of using an assert this now uses `give_error` function with a proper error message.