### PR TITLE
Windows: Add missing opengl libs to support software rendering and ANGLE

### DIFF
--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -30,7 +30,7 @@ binaries += [('C:/tmp/libsecp256k1.dll', '.')]
 binaries += [
     ('C:/python*/libEGL.dll', '.'),
     ('C:/python*/libGLESv2.dll', '.'),
-    ('C:/python*/d3dcompiler_47.dll', '.'),
+    ('C:/python*/d3dcompiler_*.dll', '.'),
 ]
 
 # Workaround for "Retro Look":

--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -26,6 +26,13 @@ binaries = [("c:/tmp/libusb-1.0.dll", ".")]
 # Add secp library
 binaries += [('C:/tmp/libsecp256k1.dll', '.')]
 
+# Add Windows OpenGL and D3D implementation DLLs (see #1255 and #1253)
+binaries += [
+    ('C:/python*/libEGL.dll', '.'),
+    ('C:/python*/libGLESv2.dll', '.'),
+    ('C:/python*/d3dcompiler_47.dll', '.'),
+]
+
 # Workaround for "Retro Look":
 binaries += [b for b in collect_dynamic_libs('PyQt5') if 'qwindowsvista' in b[0]]
 

--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -31,6 +31,7 @@ binaries += [
     ('C:/python*/libEGL.dll', '.'),
     ('C:/python*/libGLESv2.dll', '.'),
     ('C:/python*/d3dcompiler_*.dll', '.'),
+    ('C:/python*/opengl32sw.dll', '.'),
 ]
 
 # Workaround for "Retro Look":
@@ -83,7 +84,8 @@ for d in a.datas:
 
 # Strip out parts of Qt that we never use. Reduces binary size by tens of MBs. see #4815
 qt_bins2remove=('qt5web', 'qt53d', 'qt5game', 'qt5designer', 'qt5quick',
-                'qt5location', 'qt5test', 'qt5xml', r'pyqt5\qt\qml\qtquick')
+                'qt5location', 'qt5test', 'qt5xml', r'pyqt5\qt\qml\qtquick',
+                'qt5qml')
 print("Removing Qt binaries:", *qt_bins2remove)
 for x in a.binaries.copy():
     for r in qt_bins2remove:
@@ -100,6 +102,11 @@ for x in a.datas.copy():
 
 # hotfix for #3171 (pre-Win10 binaries)
 a.binaries = [x for x in a.binaries if not x[1].lower().startswith(r'c:\windows')]
+
+# DEBUG
+print("**** BINARIES TO ADD:", a.binaries)
+print("**** DATAS TO ADD:", a.datas)
+# /DEBUG
 
 pyz = PYZ(a.pure)
 

--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -1,4 +1,4 @@
-# -*- mode: python -*-
+# -*- mode: python3 -*-
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs
 
@@ -85,14 +85,17 @@ for d in a.datas:
 # Strip out parts of Qt that we never use. Reduces binary size by tens of MBs. see #4815
 qt_bins2remove=('qt5web', 'qt53d', 'qt5game', 'qt5designer', 'qt5quick',
                 'qt5location', 'qt5test', 'qt5xml', r'pyqt5\qt\qml\qtquick',
-                'qt5qml')
+                'qt5qml', 'qt5printsupport', )
 print("Removing Qt binaries:", *qt_bins2remove)
 for x in a.binaries.copy():
     for r in qt_bins2remove:
         if x[0].lower().startswith(r):
             a.binaries.remove(x)
             print('----> Removed x =', x)
-qt_data2remove=(r'pyqt5\qt\translations\qtwebengine_locales', )
+qt_data2remove=(r'pyqt5\qt\translations\qtwebengine_locales',
+                r'pyqt5\qt\plugins\printsupport',
+                r'pyqt5\qt\plugins\platforms\qwebgl',
+                r'pyqt5\qt\plugins\platforms\qminimal', )
 print("Removing Qt datas:", *qt_data2remove)
 for x in a.datas.copy():
     for r in qt_data2remove:
@@ -102,11 +105,6 @@ for x in a.datas.copy():
 
 # hotfix for #3171 (pre-Win10 binaries)
 a.binaries = [x for x in a.binaries if not x[1].lower().startswith(r'c:\windows')]
-
-# DEBUG
-print("**** BINARIES TO ADD:", a.binaries)
-print("**** DATAS TO ADD:", a.datas)
-# /DEBUG
 
 pyz = PYZ(a.pure)
 

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -2,6 +2,7 @@
 ;Include Modern UI
   !include "TextFunc.nsh" ;Needed for the $GetSize fuction. I know, doesn't sound logical, it isn't.
   !include "MUI2.nsh"
+  !include "LogicLib.nsh" ;For flow control ${If}, ${FileExists}, etc
 
 ;--------------------------------
 ;Variables
@@ -102,11 +103,23 @@ Function .onInit
 	${EndIf}
 FunctionEnd
 
+; Ask the user if they want to blow away an existing directory
+Function RemoveAskIfExists
+    ${If} ${FileExists} "${INSTDIR}\*"
+            MessageBox MB_YESNO `"${INSTDIR}" already exists, delete its content and continue installing?` IDYES yes IDNO no
+        no:
+            Abort "Select a different install destination and try again."
+        yes:
+            RMDir /r "${INSTDIR}\*.*"
+    ${EndIf}
+FunctionEnd
+
 Section
   SetOutPath $INSTDIR
 
   ;Uninstall previous version files
-  RMDir /r "$INSTDIR\*.*"
+  ;RMDir /r "$INSTDIR\*.*"
+  Call RemoveAskIfExists
   Delete "$DESKTOP\${PRODUCT_NAME}.lnk"
   Delete "$SMPROGRAMS\${PRODUCT_NAME}\*.*"
 

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -104,7 +104,7 @@ FunctionEnd
 
 ; Ask the user if they want to blow away an existing directory
 Function RemoveAskIfExists
-    IfFileExists "${INSTDIR}\*" DoesExist DoesNotExist
+    IfFileExists "${INSTDIR}\*.*" DoesExist DoesNotExist
     DoesExist:
         MessageBox MB_YESNO `"${INSTDIR}" already exists, delete its content and continue installing?` IDYES yes IDNO no
             no:

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -130,6 +130,8 @@ Section
   CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
   CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall.lnk" "$INSTDIR\Uninstall.exe" "" "$INSTDIR\Uninstall.exe" 0
   CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" "" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" 0
+  ;See #1255 where some users have bad opengl drivers and need to use software-only rendering. Requires we package openglsw32.dll with the app.
+  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME} (Software OpenGL).lnk" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" "--qt_opengl software" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" 0
   CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME} Testnet.lnk" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" "--testnet" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" 0
 
 

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -103,12 +103,12 @@ Function .onInit
 FunctionEnd
 
 Section
-  SetOutPath $INSTDIR
-
   ;Uninstall previous version files
-  ;RMDir /r "$INSTDIR\*.*"
   Push $INSTDIR
   Call RemoveAskIfExists
+
+  SetOutPath $INSTDIR ; side-effect is it creates dir if not exist
+
   Delete "$DESKTOP\${PRODUCT_NAME}.lnk"
   Delete "$SMPROGRAMS\${PRODUCT_NAME}\*.*"
 

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -102,24 +102,12 @@ Function .onInit
 	${EndIf}
 FunctionEnd
 
-; Ask the user if they want to blow away an existing directory
-Function RemoveAskIfExists
-    IfFileExists "${INSTDIR}\*.*" DoesExist DoesNotExist
-    DoesExist:
-        MessageBox MB_YESNO `"${INSTDIR}" already exists, delete its content and continue installing?` IDYES yes IDNO no
-            no:
-                Abort "Select a different install destination and try again."
-            yes:
-                RMDir /r "${INSTDIR}\*.*"
-    DoesNotExist:
-        Return
-FunctionEnd
-
 Section
   SetOutPath $INSTDIR
 
   ;Uninstall previous version files
   ;RMDir /r "$INSTDIR\*.*"
+  Push $INSTDIR
   Call RemoveAskIfExists
   Delete "$DESKTOP\${PRODUCT_NAME}.lnk"
   Delete "$SMPROGRAMS\${PRODUCT_NAME}\*.*"
@@ -168,6 +156,20 @@ Section
   IntFmt $0 "0x%08X" $0
   WriteRegDWORD HKCU "${PRODUCT_UNINST_KEY}" "EstimatedSize" "$0"
 SectionEnd
+
+; Ask the user if they want to blow away an existing directory
+Function RemoveAskIfExists
+    Pop $R0
+    IfFileExists "$R0\*.*" DoesExist DoesNotExist
+    DoesExist:
+        MessageBox MB_YESNO `"$R0" already exists, delete its content and continue installing?` IDYES yes IDNO no
+            no:
+                Abort "Select a different install destination and try again."
+            yes:
+                RMDir /r "$R0\*.*"
+    DoesNotExist:
+        Return
+FunctionEnd
 
 ;--------------------------------
 ;Descriptions

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -2,7 +2,6 @@
 ;Include Modern UI
   !include "TextFunc.nsh" ;Needed for the $GetSize fuction. I know, doesn't sound logical, it isn't.
   !include "MUI2.nsh"
-  !include "LogicLib.nsh" ;For flow control ${If}, ${FileExists}, etc
 
 ;--------------------------------
 ;Variables
@@ -105,13 +104,15 @@ FunctionEnd
 
 ; Ask the user if they want to blow away an existing directory
 Function RemoveAskIfExists
-    ${If} ${FileExists} "${INSTDIR}\*"
-            MessageBox MB_YESNO `"${INSTDIR}" already exists, delete its content and continue installing?` IDYES yes IDNO no
-        no:
-            Abort "Select a different install destination and try again."
-        yes:
-            RMDir /r "${INSTDIR}\*.*"
-    ${EndIf}
+    IfFileExists "${INSTDIR}\*" DoesExist DoesNotExist
+    DoesExist:
+        MessageBox MB_YESNO `"${INSTDIR}" already exists, delete its content and continue installing?` IDYES yes IDNO no
+            no:
+                Abort "Select a different install destination and try again."
+            yes:
+                RMDir /r "${INSTDIR}\*.*"
+    DoesNotExist:
+        Return
 FunctionEnd
 
 Section

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -873,6 +873,10 @@ def get_parser():
     parser_gui.add_argument("-o", "--offline", action="store_true", dest="offline", default=False, help="Run offline")
     parser_gui.add_argument("-m", action="store_true", dest="hide_gui", default=False, help="hide GUI on startup")
     parser_gui.add_argument("-L", "--lang", dest="language", default=None, help="default language used in GUI")
+    if sys.platform in ('windows', 'win32'):
+        # Hack to support forcing QT_OPENGL env var. See #1255. This allows us
+        # to perhaps add a custom installer shortcut to force software rendering
+        parser_gui.add_argument("-O", "--qt_opengl", dest="qt_opengl", default=None, help="(Windows only) If using Qt gui, override the QT_OPENGL env-var with this value (angle,software,desktop are possible overrides)")
     add_network_options(parser_gui)
     add_global_options(parser_gui)
     # daemon

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -25,6 +25,7 @@
 import ast
 import os
 import time
+import sys
 
 # from jsonrpc import JSONRPCResponseManager
 import jsonrpclib
@@ -309,6 +310,16 @@ class Daemon(DaemonThread):
         gui_name = config.get('gui', 'qt')
         if gui_name in ['lite', 'classic']:
             gui_name = 'qt'
+        if (sys.platform in ('windows', 'win32')
+            and config.get('qt_opengl') and gui_name == 'qt'):
+            # Hack to force QT_OPENGL env var. See #1255
+            #
+            # Note if the user provides a bad override here.. the app may crash
+            # or not run properly on windows. We don't do anything about that
+            # since this command line option is ultimately intended to just
+            # be used for an installer-generated shortcut.
+            #
+            os.environ['QT_OPENGL'] = str(config.get('qt_opengl'))
         gui = __import__('electroncash_gui.' + gui_name, fromlist=['electroncash_gui'])
         self.gui = gui.ElectrumGui(config, self, plugins)
         self.gui.main()


### PR DESCRIPTION
Closes #1255 , Addresses #1253 . Also Closes #1259 .

- Also thin the windows binary a little by removing some unused libs (but ANGLE and SW rendering overall made it fatter)
- Adds the command-line option (windows only) -O/--qt_opengl which basically can be one of the accepted QT_OPENGL env vars: desktop, angle, software -- it will force Qt to try and use the specified mode (Qt by default is 'dynamic' and it tries to auto-detect a mode but some buggy windows drivers fail).
- Adds a shortcut to the windows installed version "Electron Cash (Software OpenGL)" which opens up electroncash with "--qt_opengl software"
- Adds some logic to warn if blowing away existing directory on install (#1259)