### PR TITLE
take coinucopia off default servers list

### DIFF
--- a/lib/servers.json
+++ b/lib/servers.json
@@ -46,12 +46,6 @@
         "t": "50001",
         "version": "1.4"
     },
-    "electron.coinucopia.io": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.4"
-    },
     "electron.jochen-hoenicke.de": {
         "pruning": "-",
         "s": "51002",


### PR DESCRIPTION
lots of people are getting
"the transaction was rejected by network rules.
 66: insufficient priority"
when connected to this server -- they don't accept fees around ~1 sat/byte apparently