### PR TITLE
Build: Allow overriding the github repository

### DIFF
--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -93,7 +93,8 @@ function retry() {
 export PYTHONHASHSEED=22
 PYTHON_VERSION=3.6.8  # Windows, OSX & Linux AppImage use this to determine what to download/build
 PYTHON_SRC_TARBALL_HASH="35446241e995773b1bed7d196f4b624dadcadc8429f26282e756b2fb8a351193"  # If you change PYTHON_VERSION above, update this by downloading the tarball manually and doing a sha256sum on it.
-GIT_REPO_ACCT=https://github.com/Electron-Cash  # NOTE: this account should have electrum_local as a repository for the winodws build to work!
-GIT_REPO=$GIT_REPO_ACCT/Electron-Cash
+if [ -z "$GIT_REPO" ] ; then
+    GIT_REPO=https://github.com/Electron-Cash/Electron-Cash
+fi
 GIT_DIR_NAME=`basename $GIT_REPO`
 PACKAGE=$GIT_DIR_NAME  # Modify this if you like -- Windows and MacOS build scripts read this


### PR DESCRIPTION
This patch removes the `GIT_REPO_ACCT` variable which is unused. It also allows to override `GIT_REPO` from environment, allowing a different git repository to be built. This way you can build a local repository for example with:

```
GIT_REPO=~/src/Electron-Cash ./contrib/build-wine/build.sh master
```