### PR TITLE
Ledger: Add Nano-X USB device ids

### DIFF
--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -528,7 +528,8 @@ class LedgerPlugin(HW_PluginBase):
                    (0x2581, 0x3b7c), # HW.1 ledger production
                    (0x2581, 0x4b7c), # HW.1 ledger test
                    (0x2c97, 0x0000), # Blue
-                   (0x2c97, 0x0001)  # Nano-S
+                   (0x2c97, 0x0001), # Nano-S
+                   (0x2c97, 0x0004)  # Nano-X
                  ]
 
     def __init__(self, parent, config, name):


### PR DESCRIPTION
This is untested by me, but I don't see any reason why it wouldn't work.