### PR TITLE
Commands: Add -R / --relax_warnings command line argument

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -305,7 +305,7 @@ class ElectrumGui(QObject, PrintError):
             try:
 
                 if not self.windows:
-                    self.warn_if_no_secp()
+                    self.warn_if_no_secp(startup=True)
 
                 try:
                     wallet = self.daemon.load_wallet(path, None)
@@ -437,7 +437,7 @@ class ElectrumGui(QObject, PrintError):
             return True
         return False
 
-    def warn_if_no_secp(self, parent=None, message=None, icon=QMessageBox.Warning):
+    def warn_if_no_secp(self, parent=None, message=None, icon=QMessageBox.Warning, startup=False):
         ''' Returns True if it DID warn: ie if there's no secp and ecc operations
         are slow, otherwise returns False if we have secp.
 
@@ -448,6 +448,12 @@ class ElectrumGui(QObject, PrintError):
         has_secp = ecc_fast.is_using_fast_ecc()
         if has_secp:
             return False
+
+        # When relaxwarn is set return True without showing the warning
+        from electroncash import get_config
+        if startup and get_config().cmdline_options["relaxwarn"]:
+            return True
+
         # else..
         howto_url='https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/secp_HOWTO.md#libsecp256k1-0-for-electron-cash'
         template = '''

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -893,6 +893,7 @@ def get_parser():
         # Hack to support forcing QT_OPENGL env var. See #1255. This allows us
         # to perhaps add a custom installer shortcut to force software rendering
         parser_gui.add_argument("-O", "--qt_opengl", dest="qt_opengl", default=None, help="(Windows only) If using Qt gui, override the QT_OPENGL env-var with this value (angle,software,desktop are possible overrides)")
+    parser_gui.add_argument("-R", "--relax_warnings", action="store_true", dest="relaxwarn", default=False, help="Disables certain warnings that might be annoying during development and/or testing")
     add_network_options(parser_gui)
     add_global_options(parser_gui)
     # daemon


### PR DESCRIPTION
To suppress certain warnings that can get annoying. For now we only make this affect the libsecp256k1 warning.

See #1297