### PR TITLE
Console: Only show completions when tab is pressed without modifier keys

### DIFF
--- a/gui/qt/console.py
+++ b/gui/qt/console.py
@@ -235,8 +235,8 @@ class Console(QtWidgets.QPlainTextEdit):
         self.set_json(False)
 
 
-    def keyPressEvent(self, event):
-        if event.key() == QtCore.Qt.Key_Tab:
+    def keyPressEvent(self, event: QtGui.QKeyEvent):
+        if event.key() == QtCore.Qt.Key_Tab and event.modifiers() == QtCore.Qt.NoModifier:
             self.completions()
             return
 


### PR DESCRIPTION
Ctrl+Tab / Ctrl+Shift+Tab can be used to navigate the main window tabs, but as soon as the console is shown you can not switch to another tab. This is because the console consumes all tab key events, even those with modifiers. This patch makes the console ignore tab presses with modifier keys.