### PR TITLE
Console: Restore correct focus policy

### DIFF
--- a/gui/qt/console.py
+++ b/gui/qt/console.py
@@ -191,7 +191,7 @@ class Console(QtWidgets.QWidget):
             self.warningOverlay = ConsoleWarningOverlay(self)
             self.warningOverlay.resize(self.size())
 
-            fp = self.focusPolicy()
+            fp = self.editor.focusPolicy()
             blur_effect = QtWidgets.QGraphicsBlurEffect()
             blur_effect.setBlurRadius(7)
             self.editor.setGraphicsEffect(blur_effect)


### PR DESCRIPTION
Follow up to #1308 

The focus policy that is restored to self.editor is wrong, the backup was made from self.