### PR TITLE
Console: Fix font reset when moving between screens

### DIFF
--- a/gui/qt/console.py
+++ b/gui/qt/console.py
@@ -194,7 +194,7 @@ class Console(QtWidgets.QWidget):
         self.editor.resize(self.size())
         self.editor.setWordWrapMode(QtGui.QTextOption.WrapAnywhere)
         self.editor.setUndoRedoEnabled(False)
-        self.editor.document().setDefaultFont(QtGui.QFont(MONOSPACE_FONT, 10, QtGui.QFont.Normal))
+        self.editor.setFont(QtGui.QFont(MONOSPACE_FONT, 10, QtGui.QFont.Normal))
 
         self.showMessage(startup_message)
 


### PR DESCRIPTION
When the console was moved between screen boundaries with different scaling settings, the font was reset. This is because QPlainTextEdit sets the documents default font back to its own font property when Qt has a font change event. This patch sets the font property of the editor instead of the document.

closes #1314