### PR TITLE
add cash account support.

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -191,6 +191,8 @@ class AddressList(MyTreeWidget):
                 copy_text = addr.to_full_ui_string()
             else:
                 copy_text = item.text(col)
+
+            menu.addAction(_("Register Cash Account"), lambda: self.parent.show_cash_account_register_dialog(addr))
             menu.addAction(_("Copy {}").format(column_title), lambda: self.parent.app.clipboard().setText(copy_text.strip()))
             menu.addAction(_('Details'), lambda: self.parent.show_address(addr))
             if col in self.editable_columns:

--- a/gui/qt/cashacct_await_conf_dialog.py
+++ b/gui/qt/cashacct_await_conf_dialog.py
@@ -75,6 +75,8 @@ class AwaitConfirmationDialog(WindowModalDialog):
                 collision = self.calculate_cash_acct_collision(hash, self._txid)
                 basic_identity = self.block_height - 563620
                 cash_account = self.get_cash_account(self._username, basic_identity.__str__(), collision.__str__()).__str__()
+                # It is recommended before saving the cash account here to remove the semi-colon
+                # attached at the end by the lookup server.
                 print(cash_account)
                 thread.cancel()
 

--- a/gui/qt/cashacct_await_conf_dialog.py
+++ b/gui/qt/cashacct_await_conf_dialog.py
@@ -77,7 +77,6 @@ class AwaitConfirmationDialog(WindowModalDialog):
                 cash_account = self.get_cash_account(self._username, basic_identity.__str__(), collision.__str__()).__str__()
                 print(cash_account)
                 thread.cancel()
-                self.close()
 
         if self.block_height.__eq__(-1):
             run_check()

--- a/gui/qt/cashacct_await_conf_dialog.py
+++ b/gui/qt/cashacct_await_conf_dialog.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2012 thomasv@gitorious
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from electroncash.i18n import _
+from electroncash.address import Address
+
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
+
+from .util import *
+from .history_list import HistoryList
+from .qrtextedit import ShowQRTextEdit
+
+
+class AwaitConfirmationDialog(WindowModalDialog):
+
+    def __init__(self, parent, txid, username):
+        WindowModalDialog.__init__(self, parent, _("Awaiting Confirmation"))
+        self.parent = parent
+        self._txid = txid
+        self._username = username
+        self.block_height = -1
+        self.setMinimumWidth(700)
+        vbox = QVBoxLayout()
+        self.setLayout(vbox)
+
+        vbox.addWidget(QLabel(_("Awaiting confirmation for username: " + username)))
+        vbox.addWidget(QLabel(_("Transaction id: " + txid)))
+
+        self.begin_checking()
+
+    def exec_(self):
+        ''' Overrides super class and does some cleanup after exec '''
+        retval = super().exec_()
+        import gc
+        QTimer.singleShot(10, lambda: gc.collect()) # run GC in 10 ms. Otherwise this window sticks around in memory for way too long
+        return retval
+
+    def begin_checking(self):
+        import threading
+
+        def run_check():
+            thread = threading.Timer(5.0, run_check)
+            thread.start()
+            self.block_height = self.check_for_block()
+
+            if self.block_height.__eq__(-1):
+                print(self.block_height)
+                print("Running check again...")
+            else:
+                hash = self.get_block_hash()
+                collision = self.calculate_cash_acct_collision(hash, self._txid)
+                basic_identity = self.block_height - 563620
+                cash_account = self.get_cash_account(self._username, basic_identity.__str__(), collision.__str__()).__str__()
+                print(cash_account)
+                thread.cancel()
+                self.close()
+
+        if self.block_height.__eq__(-1):
+            run_check()
+
+    def check_for_block(self):
+        import urllib.request
+        import json
+        block_explorer_url = "https://bch-chain.api.btc.com/v3/tx/"
+        txid_str = self._txid
+        url = block_explorer_url + txid_str
+        print("Checking for block of tx " + txid_str)
+
+        response = urllib.request.urlopen(url)
+        block_data = json.loads(response.read().decode())
+
+        if 'err_msg' not in block_data:
+            if block_data['data']['block_height'] == -1:
+                return -1
+            else:
+                return block_data['data']['block_height']
+        else:
+            return -1
+
+    def get_block_hash(self):
+        import urllib.request
+        import json
+        block_explorer_url = "https://bch-chain.api.btc.com/v3/tx/"
+        txid_str = self._txid
+        url = block_explorer_url + txid_str
+        print("Getting block hash of tx " + txid_str)
+
+        response = urllib.request.urlopen(url)
+        block_data = json.loads(response.read().decode())
+
+        if 'err_msg' not in block_data:
+            if block_data['data']['block_height'] == -1:
+                return "???"
+            else:
+                return block_data['data']['block_hash']
+        else:
+            return "???"
+
+    def calculate_cash_acct_collision(self, block_hash, tx_hash):
+        from hashlib import sha256
+        concatenated_string = block_hash.__str__().lower() + tx_hash.__str__().lower()
+        print(concatenated_string)
+        import codecs
+
+        decode_hex = codecs.getdecoder("hex_codec")
+        decoded_concatenated = decode_hex(concatenated_string)[0]
+
+        hashed_string = sha256(decoded_concatenated).hexdigest()
+        print(hashed_string)
+
+        first_four_bytes = hashed_string[:8]
+        print(first_four_bytes)
+
+        decimal_notation = int(first_four_bytes, 16).__str__()
+        print(decimal_notation)
+
+        reverse_decimal = decimal_notation[::-1]
+        print(reverse_decimal)
+
+        padded_decimal = reverse_decimal.ljust(10, '0')
+        print(padded_decimal)
+
+        return padded_decimal
+
+    def get_cash_account(self, username, block, collision):
+        import urllib.request
+        import json
+        lookup_url = "https://api.cashaccount.info/account/" + block + "/" + username + "/" + collision
+        response = urllib.request.urlopen(lookup_url)
+        account_data = json.loads(response.read().decode())
+
+        if 'error' not in account_data:
+            return account_data['identifier']
+        else:
+            return account_data['error']

--- a/gui/qt/cashacct_register_dialog.py
+++ b/gui/qt/cashacct_register_dialog.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2012 thomasv@gitorious
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from electroncash.i18n import _
+from electroncash.address import Address
+
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
+
+from .util import *
+from .history_list import HistoryList
+from .qrtextedit import ShowQRTextEdit
+
+
+class RegisterCashAcctDialog(WindowModalDialog):
+
+    def __init__(self, parent, address):
+        assert isinstance(address, Address)
+        WindowModalDialog.__init__(self, parent, _("Register Cash Account"))
+        self.address = address
+        self.parent = parent
+        self.config = parent.config
+        self.wallet = parent.wallet
+        self.app = parent.app
+        self.saved = True
+        self.setMinimumWidth(700)
+        vbox = QVBoxLayout()
+        self.setLayout(vbox)
+
+        vbox.addWidget(QLabel(_("Desired username:")))
+        self.cashacct_e = ButtonsLineEdit()
+        vbox.addWidget(self.cashacct_e)
+
+        vbox.addWidget(QLabel(_("Address:")))
+        self.addr_e = ButtonsLineEdit()
+        self.addr_e.addCopyButton()
+        self.addr_e.setReadOnly(True)
+        vbox.addWidget(self.addr_e)
+        self.update_addr()
+
+        vbox.addLayout(Buttons(RegisterCashAcctButton(self)))
+        vbox.addLayout(Buttons(CloseButton(self)))
+
+    def update_addr(self):
+        self.addr_e.setText(self.address.to_full_ui_string())
+
+    def show_qr(self):
+        text = self.address.to_full_ui_string()
+        try:
+            self.parent.show_qrcode(text, 'Address', parent=self)
+        except Exception as e:
+            self.show_message(str(e))
+
+    def exec_(self):
+        ''' Overrides super class and does some cleanup after exec '''
+        retval = super().exec_()
+        import gc
+        QTimer.singleShot(10, lambda: gc.collect()) # run GC in 10 ms. Otherwise this window sticks around in memory for way too long
+        return retval

--- a/gui/qt/console.py
+++ b/gui/qt/console.py
@@ -183,6 +183,8 @@ class ConsoleTextEdit(QtWidgets.QPlainTextEdit):
             return
         elif event.key() == QtCore.Qt.Key_L and event.modifiers() == QtCore.Qt.ControlModifier:
             self.parent().clear()
+        elif event.key() == QtCore.Qt.Key_Insert and event.modifiers() == QtCore.Qt.NoModifier:
+            self.setOverwriteMode(not self.overwriteMode())
 
         super(ConsoleTextEdit, self).keyPressEvent(event)
 

--- a/gui/qt/console.py
+++ b/gui/qt/console.py
@@ -183,8 +183,6 @@ class ConsoleTextEdit(QtWidgets.QPlainTextEdit):
             return
         elif event.key() == QtCore.Qt.Key_L and event.modifiers() == QtCore.Qt.ControlModifier:
             self.parent().clear()
-        elif event.key() == QtCore.Qt.Key_Insert and event.modifiers() == QtCore.Qt.NoModifier:
-            self.setOverwriteMode(not self.overwriteMode())
 
         super(ConsoleTextEdit, self).keyPressEvent(event)
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1197,6 +1197,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.show_receive_tab()
         self.update_receive_address_widget()
 
+    def show_cash_account_register_dialog(self, addr):
+        from . import cashacct_register_dialog
+        d = cashacct_register_dialog.RegisterCashAcctDialog(self, addr)
+        d.exec_()
+
+    def update_addr_label(self, address, cash_account):
+        self.wallet.set_label(Address.from_cashaddr_string(address), cash_account)
+        self.update_labels()
+
     def update_receive_qr(self):
         amount = self.receive_amount_e.get_amount()
         message = self.receive_message_e.text()
@@ -1631,7 +1640,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         return request_password
 
     def read_send_tab(self):
-
+        self.payto_e.check_text_for_cash_acct()
         isInvoice= False;
 
         if self.payment_request and self.payment_request.has_expired():

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -101,16 +101,25 @@ class PayToEdit(ScanQRTextEdit):
     def get_cash_account(self, username, block, collision):
         print("Getting cash account...")
         import urllib.request
+        import urllib.error
         import json
         lookup_url = "https://api.cashaccount.info/account/" + block + "/" + username + "/" + collision
         print(lookup_url)
-        response = urllib.request.urlopen(lookup_url)
-        account_data = json.loads(response.read().decode())
+        try:
+            response = urllib.request.urlopen(lookup_url)
+            account_data = json.loads(response.read().decode())
 
-        if 'error' not in account_data:
-            return account_data['information']['payment'][0]['address']
-        else:
-            return account_data['error']
+            if 'error' not in account_data:
+                return account_data['information']['payment'][0]['address']
+            else:
+                return account_data['error']
+        except urllib.error.HTTPError as e:
+            print('Error getting Cash Account: {}'.format(e.reason))
+
+            if collision.__eq__(""):
+                return "Cash Account not found: " + username + "#" + block
+            else:
+                return "Cash Account not found: " + username + "#" + block + "." + collision
 
     def check_text(self):
         self.errors = []

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -132,6 +132,34 @@ class CloseButton(QPushButton):
         self.clicked.connect(dialog.close)
         self.setDefault(True)
 
+class RegisterCashAcctButton(QPushButton):
+    def __init__(self, dialog):
+        QPushButton.__init__(self, _("Register"))
+        self._dialog = dialog
+        self.block_height = -1
+        self.clicked.connect(lambda: self.register_cash_account(dialog.addr_e.text(), dialog.cashacct_e.text()))
+        self.setDefault(True)
+
+    def register_cash_account(self, address=None, username=None):
+        import requests
+        addr = address + ""
+        cash_acct_name = username + ""
+
+        if '#' not in cash_acct_name:
+            postdata = {'name': cash_acct_name, 'payments': [addr]}
+
+            response = requests.post("https://api.cashaccount.info/register/", json=postdata)
+
+            print(response.json()['txid'])
+            self.begin_checking_for_account(response.json()['txid'], cash_acct_name)
+        else:
+            print('Do not include identifier!')
+
+    def begin_checking_for_account(self, txid, username):
+        from . import cashacct_await_conf_dialog
+        d = cashacct_await_conf_dialog.AwaitConfirmationDialog(self, txid, username)
+        d.exec_()
+
 class CopyButton(QPushButton):
     def __init__(self, text_getter, app=None, callback=None):
         QPushButton.__init__(self, _("Copy"))


### PR DESCRIPTION
This PR adds Cash Account (https://cashaccount.info) support.

### Registration

To register a Cash Account in Electron Cash, simply go to the Addresses tab and right click an address and select "Register Cash Account". This will display a prompt to set the desired username tied to the address you selected. Clicking "Register" then begins checking a block explorer for the transaction id provided by api.cashaccount.info. It checks every 5 seconds currently, but this can be changed as I set it to 5 seconds for debugging purposes.

**NOTE: I am terrible with UI systems typically, and I'm also not used to your codebase, so currently the Cash Account returned from the lookup server (when registration is complete and a block is found) is not saved anywhere. The desired method to save it would be to edit the label for the address in the Addresses tab, but I was not able to figure out how to edit it programmatically.**

### Sending

To send to a Cash Account, simply input the cash account name and identifier (for example: im_uname#100) in the "Pay to:" textbox in the Send tab. When clicking send, the address is grabbed from the cash account lookup server and added an output.

This also supports paying to many Cash Accounts by setting the Cash Account, and the amount.
**Example:**
im_uname#100,0.002
halo#12741.9,0.01

This is the base system in place. I intend to leave the UI polishing up to you guys as I don't know your code base that well. I spent around 5 hours last night trying to figure out how to edit the label, but wasn't able to figure it out.

This pull request is part of a lazyfox.io bounty: https://lazyfox.io/task/BZJ/implement-basic-cashaccount-functions-in-electron-cash