### PR TITLE
Add Basic Schnorr Capability For Transactions with secp256k1

### DIFF
--- a/lib/schnorr.py
+++ b/lib/schnorr.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import traceback
+import ctypes
+from ctypes.util import find_library
+from ctypes import (
+    byref, c_byte, c_int, c_uint, c_char_p, c_size_t, c_void_p, create_string_buffer, CFUNCTYPE, POINTER
+)
+ 
+
+from .util import print_stderr, print_error, print_msg
+
+
+SECP256K1_FLAGS_TYPE_MASK = ((1 << 8) - 1)
+SECP256K1_FLAGS_TYPE_CONTEXT = (1 << 0)
+SECP256K1_FLAGS_TYPE_COMPRESSION = (1 << 1)
+# /** The higher bits contain the actual data. Do not use directly. */
+SECP256K1_FLAGS_BIT_CONTEXT_VERIFY = (1 << 8)
+SECP256K1_FLAGS_BIT_CONTEXT_SIGN = (1 << 9)
+SECP256K1_FLAGS_BIT_COMPRESSION = (1 << 8)
+
+# /** Flags to pass to secp256k1_context_create. */
+SECP256K1_CONTEXT_VERIFY = (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_VERIFY)
+SECP256K1_CONTEXT_SIGN = (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_SIGN)
+SECP256K1_CONTEXT_NONE = (SECP256K1_FLAGS_TYPE_CONTEXT)
+
+SECP256K1_EC_COMPRESSED = (SECP256K1_FLAGS_TYPE_COMPRESSION | SECP256K1_FLAGS_BIT_COMPRESSION)
+SECP256K1_EC_UNCOMPRESSED = (SECP256K1_FLAGS_TYPE_COMPRESSION)
+
+
+def load_library():
+    if sys.platform == 'darwin':
+        library_paths = ('libsecp256k1.0.dylib',  # on Mac it's in the pyinstaller top level folder, which is in libpath
+                         os.path.join(os.path.dirname(__file__), 'libsecp256k1.0.dylib'))  # fall back to "running from source" mode lib/ folder
+    elif sys.platform in ('windows', 'win32'):
+        library_paths = ('libsecp256k1.dll',  # on Windows it's in the pyinstaller top level folder, which is in the path
+                         os.path.join(os.path.dirname(__file__), 'libsecp256k1.dll'))  # does running from source even make sense on Windows? Enquiring minds want to know.
+    elif 'ANDROID_DATA' in os.environ:
+        library_paths = 'libsecp256k1.so',
+    else:
+        library_paths = (os.path.join(os.path.dirname(__file__), 'libsecp256k1.so.0'),  # on linux we install it alongside the python scripts.
+                         'libsecp256k1.so.0')  # fall back to system lib, if any
+
+    for lp in library_paths:
+        try:
+            secp256k1 = ctypes.cdll.LoadLibrary(lp)
+        except:
+            continue
+        if secp256k1:
+            break
+    if not secp256k1:
+        print_stderr('[schnorr] warning: libsecp256k1 library failed to load')
+        return None
+
+    try:
+        secp256k1.secp256k1_context_create.argtypes = [c_uint]
+        secp256k1.secp256k1_context_create.restype = c_void_p 
+
+        secp256k1.secp256k1_context_randomize.argtypes = [c_void_p, c_char_p]
+        secp256k1.secp256k1_context_randomize.restype = c_int
+
+        secp256k1.secp256k1_schnorr_sign.argtypes = [ c_void_p, c_char_p, c_char_p, c_char_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_schnorr_sign.restype = c_int 
+
+        secp256k1.ctx = secp256k1.secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY)
+        r = secp256k1.secp256k1_context_randomize(secp256k1.ctx, os.urandom(32))
+        if r:
+            return secp256k1
+        else:
+            print_stderr('[schnorr] warning: secp256k1_context_randomize failed')
+            return None
+    except (OSError, AttributeError):
+        #traceback.print_exc(file=sys.stderr)
+        print_stderr('[schnorr] warning: libsecp256k1 library was found and loaded but there was an error when using it')
+        return None 
+
+try:
+    _libsecp256k1 = load_library()
+except:
+    _libsecp256k1 = None
+    #traceback.print_exc(file=sys.stderr)
+
+def sign_schnorr(message,privkey):
+    
+    # Error handling in case of libsec failure:
+    wefailed= False 
+    try:
+        _libsecp256k1 = load_library()
+    except:
+        _libsecp256k1 = None
+        wefailed= True
+    if wefailed:
+        return bytes.fromhex("00")  #Will be handled by reversion to ECDSA upon return
+   
+    # Normally, proceed...
+    secp256k1=load_library()
+    schnorr_signature = create_string_buffer(64)
+    dummyvariable = _libsecp256k1.secp256k1_schnorr_sign(secp256k1.ctx,schnorr_signature,message,privkey,None,None)
+    retval=bytes.fromhex(schnorr_signature.raw.hex())
+    return retval
+

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -29,6 +29,7 @@
 
 from .util import print_error, profiler
 
+from .schnorr import *
 from .bitcoin import *
 from .address import (PublicKey, Address, Script, ScriptOutput, hash160,
                       UnknownAddress, OpCodes as opcodes)
@@ -755,8 +756,24 @@ class Transaction:
                     secexp = pkey.secret
                     private_key = MySigningKey.from_secret_exponent(secexp, curve = SECP256k1)
                     public_key = private_key.get_verifying_key()
-                    sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
-                    assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
+   
+                    use_Schnorr_Sigs = False
+                    Schnorr_Fail = False
+
+                    # Turn on for DEBUG:
+                    # use_Schnorr_Sigs = True
+
+                    if use_Schnorr_Sigs:
+                        schnorr_pkey=bytes.fromhex(private_key.to_string().hex())
+                        schnorr_msg = bytes.fromhex(pre_hash.hex())
+                        sig = sign_schnorr(schnorr_msg,schnorr_pkey)
+                        if len(sig) < 64:
+                            Schnorr_Fail = True
+
+                    #this if normally would always execute for ECDSA:
+                    if not use_Schnorr_Sigs or Schnorr_Fail:
+                        sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
+                        assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
                     txin['signatures'][j] = bh2u(sig) + int_to_hex(self.nHashType() & 255, 1)
                     txin['pubkeys'][j] = pubkey # needed for fd keys
                     self._inputs[i] = txin


### PR DESCRIPTION
This is a basic integration between the Schnorr library and the transaction layer in the wallet.  Hopefully I didn't make too many awful mistakes.  The schnorr code was unit tested with one of Mark's test examples.

Currently the code is in a dormant state and must be turned on by a developer to be used.