### PR TITLE
Schnorr Redux

### DIFF
--- a/lib/schnorr.py
+++ b/lib/schnorr.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import traceback
+import ctypes
+from ctypes.util import find_library
+from ctypes import (
+    byref, c_byte, c_int, c_uint, c_char_p, c_size_t, c_void_p, create_string_buffer, CFUNCTYPE, POINTER
+)
+ 
+
+from .util import print_stderr, print_error, print_msg
+
+
+SECP256K1_FLAGS_TYPE_MASK = ((1 << 8) - 1)
+SECP256K1_FLAGS_TYPE_CONTEXT = (1 << 0)
+SECP256K1_FLAGS_TYPE_COMPRESSION = (1 << 1)
+# /** The higher bits contain the actual data. Do not use directly. */
+SECP256K1_FLAGS_BIT_CONTEXT_VERIFY = (1 << 8)
+SECP256K1_FLAGS_BIT_CONTEXT_SIGN = (1 << 9)
+SECP256K1_FLAGS_BIT_COMPRESSION = (1 << 8)
+
+# /** Flags to pass to secp256k1_context_create. */
+SECP256K1_CONTEXT_VERIFY = (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_VERIFY)
+SECP256K1_CONTEXT_SIGN = (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_SIGN)
+SECP256K1_CONTEXT_NONE = (SECP256K1_FLAGS_TYPE_CONTEXT)
+
+SECP256K1_EC_COMPRESSED = (SECP256K1_FLAGS_TYPE_COMPRESSION | SECP256K1_FLAGS_BIT_COMPRESSION)
+SECP256K1_EC_UNCOMPRESSED = (SECP256K1_FLAGS_TYPE_COMPRESSION)
+
+
+def load_library():
+    if sys.platform == 'darwin':
+        library_paths = ('libsecp256k1.0.dylib',  # on Mac it's in the pyinstaller top level folder, which is in libpath
+                         os.path.join(os.path.dirname(__file__), 'libsecp256k1.0.dylib'))  # fall back to "running from source" mode lib/ folder
+    elif sys.platform in ('windows', 'win32'):
+        library_paths = ('libsecp256k1.dll',  # on Windows it's in the pyinstaller top level folder, which is in the path
+                         os.path.join(os.path.dirname(__file__), 'libsecp256k1.dll'))  # does running from source even make sense on Windows? Enquiring minds want to know.
+    elif 'ANDROID_DATA' in os.environ:
+        library_paths = 'libsecp256k1.so',
+    else:
+        library_paths = (os.path.join(os.path.dirname(__file__), 'libsecp256k1.so.0'),  # on linux we install it alongside the python scripts.
+                         'libsecp256k1.so.0')  # fall back to system lib, if any
+
+    for lp in library_paths:
+        try:
+            secp256k1 = ctypes.cdll.LoadLibrary(lp)
+        except:
+            continue
+        if secp256k1:
+            break
+    if not secp256k1:
+        print_stderr('[schnorr] warning: libsecp256k1 library failed to load')
+        return None
+
+    try:
+        secp256k1.secp256k1_context_create.argtypes = [c_uint]
+        secp256k1.secp256k1_context_create.restype = c_void_p 
+
+        secp256k1.secp256k1_context_randomize.argtypes = [c_void_p, c_char_p]
+        secp256k1.secp256k1_context_randomize.restype = c_int
+
+        secp256k1.secp256k1_schnorr_sign.argtypes = [ c_void_p, c_char_p, c_char_p, c_char_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_schnorr_sign.restype = c_int 
+
+        secp256k1.ctx = secp256k1.secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY)
+        r = secp256k1.secp256k1_context_randomize(secp256k1.ctx, os.urandom(32))
+        if r:
+            return secp256k1
+        else:
+            print_stderr('[schnorr] warning: secp256k1_context_randomize failed')
+            return None
+    except (OSError, AttributeError):
+        #traceback.print_exc(file=sys.stderr)
+        print_stderr('[schnorr] warning: libsecp256k1 library was found and loaded but there was an error when using it')
+        return None 
+
+try:
+    _libsecp256k1 = load_library()
+except:
+    _libsecp256k1 = None
+    #traceback.print_exc(file=sys.stderr)
+
+def sign_schnorr(message,privkey):
+    
+    # Error handling in case of libsec failure:
+    wefailed= False 
+    try:
+        _libsecp256k1 = load_library()
+    except:
+        _libsecp256k1 = None
+        wefailed= True
+    if wefailed:
+        return bytes.fromhex("00")  #Will be handled by reversion to ECDSA upon return
+   
+    # Normally, proceed...
+    secp256k1=load_library()
+    schnorr_signature = create_string_buffer(64)
+    dummyvariable = _libsecp256k1.secp256k1_schnorr_sign(secp256k1.ctx,schnorr_signature,message,privkey,None,None)
+    retval=bytes.fromhex(schnorr_signature.raw.hex())
+    return retval
+

--- a/lib/secp256k1.py
+++ b/lib/secp256k1.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -*- mode: python3 -*-
+'''
+secp256k1 - Maintain a single global secp256k1 context. ecc_fast.py and
+schnorr.py make use of this context to do fast ECDSA signing or Schnorr signing,
+respectively.
+'''
+import os
+import sys
+import ctypes
+from ctypes.util import find_library
+from ctypes import (
+    byref, c_byte, c_int, c_uint, c_char_p, c_size_t, c_void_p, create_string_buffer, CFUNCTYPE, POINTER
+)
+
+from .util import print_stderr
+
+SECP256K1_FLAGS_TYPE_MASK = ((1 << 8) - 1)
+SECP256K1_FLAGS_TYPE_CONTEXT = (1 << 0)
+SECP256K1_FLAGS_TYPE_COMPRESSION = (1 << 1)
+# /** The higher bits contain the actual data. Do not use directly. */
+SECP256K1_FLAGS_BIT_CONTEXT_VERIFY = (1 << 8)
+SECP256K1_FLAGS_BIT_CONTEXT_SIGN = (1 << 9)
+SECP256K1_FLAGS_BIT_COMPRESSION = (1 << 8)
+
+# /** Flags to pass to secp256k1_context_create. */
+SECP256K1_CONTEXT_VERIFY = (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_VERIFY)
+SECP256K1_CONTEXT_SIGN = (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_SIGN)
+SECP256K1_CONTEXT_NONE = (SECP256K1_FLAGS_TYPE_CONTEXT)
+
+SECP256K1_EC_COMPRESSED = (SECP256K1_FLAGS_TYPE_COMPRESSION | SECP256K1_FLAGS_BIT_COMPRESSION)
+SECP256K1_EC_UNCOMPRESSED = (SECP256K1_FLAGS_TYPE_COMPRESSION)
+
+
+def _load_library():
+    if sys.platform == 'darwin':
+        library_paths = ('libsecp256k1.0.dylib',  # on Mac it's in the pyinstaller top level folder, which is in libpath
+                         os.path.join(os.path.dirname(__file__), 'libsecp256k1.0.dylib'))  # fall back to "running from source" mode lib/ folder
+    elif sys.platform in ('windows', 'win32'):
+        library_paths = ('libsecp256k1.dll',  # on Windows it's in the pyinstaller top level folder, which is in the path
+                         os.path.join(os.path.dirname(__file__), 'libsecp256k1.dll'))  # does running from source even make sense on Windows? Enquiring minds want to know.
+    elif 'ANDROID_DATA' in os.environ:
+        library_paths = 'libsecp256k1.so',
+    else:
+        library_paths = (os.path.join(os.path.dirname(__file__), 'libsecp256k1.so.0'),  # on linux we install it alongside the python scripts.
+                         'libsecp256k1.so.0')  # fall back to system lib, if any
+
+    for lp in library_paths:
+        try:
+            secp256k1 = ctypes.cdll.LoadLibrary(lp)
+        except:
+            continue
+        if secp256k1:
+            break
+    if not secp256k1:
+        print_stderr('[secp256k1] warning: libsecp256k1 library failed to load')
+        return None
+
+    try:
+        secp256k1.secp256k1_context_create.argtypes = [c_uint]
+        secp256k1.secp256k1_context_create.restype = c_void_p
+
+        secp256k1.secp256k1_context_randomize.argtypes = [c_void_p, c_char_p]
+        secp256k1.secp256k1_context_randomize.restype = c_int
+
+        secp256k1.secp256k1_ec_pubkey_create.argtypes = [c_void_p, c_void_p, c_char_p]
+        secp256k1.secp256k1_ec_pubkey_create.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_sign.argtypes = [c_void_p, c_char_p, c_char_p, c_char_p, c_void_p, c_void_p]
+        secp256k1.secp256k1_ecdsa_sign.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_verify.argtypes = [c_void_p, c_char_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_verify.restype = c_int
+
+        secp256k1.secp256k1_ec_pubkey_parse.argtypes = [c_void_p, c_char_p, c_char_p, c_size_t]
+        secp256k1.secp256k1_ec_pubkey_parse.restype = c_int
+
+        secp256k1.secp256k1_ec_pubkey_serialize.argtypes = [c_void_p, c_char_p, c_void_p, c_char_p, c_uint]
+        secp256k1.secp256k1_ec_pubkey_serialize.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_signature_parse_compact.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_signature_parse_compact.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_signature_normalize.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_signature_normalize.restype = c_int
+
+        secp256k1.secp256k1_ecdsa_signature_serialize_compact.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ecdsa_signature_serialize_compact.restype = c_int
+
+        secp256k1.secp256k1_ec_pubkey_tweak_mul.argtypes = [c_void_p, c_char_p, c_char_p]
+        secp256k1.secp256k1_ec_pubkey_tweak_mul.restype = c_int
+
+        secp256k1.ctx = secp256k1.secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY)
+        r = secp256k1.secp256k1_context_randomize(secp256k1.ctx, os.urandom(32))
+        if r:
+            return secp256k1
+        else:
+            print_stderr('[secp256k1] warning: secp256k1_context_randomize failed')
+            return None
+    except (OSError, AttributeError):
+        print_stderr('[secp256k1] warning: libsecp256k1 library was found and loaded but there was an error when using it')
+        return None
+
+try:
+    secp256k1 = _load_library()
+except:
+    secp256k1 = None

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -29,7 +29,6 @@
 
 from .util import print_error, profiler
 
-from .schnorr import *
 from .bitcoin import *
 from .address import (PublicKey, Address, Script, ScriptOutput, hash160,
                       UnknownAddress, OpCodes as opcodes)
@@ -756,24 +755,8 @@ class Transaction:
                     secexp = pkey.secret
                     private_key = MySigningKey.from_secret_exponent(secexp, curve = SECP256k1)
                     public_key = private_key.get_verifying_key()
-   
-                    use_Schnorr_Sigs = False
-                    Schnorr_Fail = False
-
-                    # Turn on for DEBUG:
-                    # use_Schnorr_Sigs = True
-
-                    if use_Schnorr_Sigs:
-                        schnorr_pkey=bytes.fromhex(private_key.to_string().hex())
-                        schnorr_msg = bytes.fromhex(pre_hash.hex())
-                        sig = sign_schnorr(schnorr_msg,schnorr_pkey)
-                        if len(sig) < 64:
-                            Schnorr_Fail = True
-
-                    #this if normally would always execute for ECDSA:
-                    if not use_Schnorr_Sigs or Schnorr_Fail:
-                        sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
-                        assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
+                    sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
+                    assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
                     txin['signatures'][j] = bh2u(sig) + int_to_hex(self.nHashType() & 255, 1)
                     txin['pubkeys'][j] = pubkey # needed for fd keys
                     self._inputs[i] = txin

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -29,6 +29,7 @@
 
 from .util import print_error, profiler
 
+from .schnorr import *
 from .bitcoin import *
 from .address import (PublicKey, Address, Script, ScriptOutput, hash160,
                       UnknownAddress, OpCodes as opcodes)
@@ -755,8 +756,24 @@ class Transaction:
                     secexp = pkey.secret
                     private_key = MySigningKey.from_secret_exponent(secexp, curve = SECP256k1)
                     public_key = private_key.get_verifying_key()
-                    sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
-                    assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
+   
+                    use_Schnorr_Sigs = False
+                    Schnorr_Fail = False
+
+                    # Turn on for DEBUG:
+                    # use_Schnorr_Sigs = True
+
+                    if use_Schnorr_Sigs:
+                        schnorr_pkey=bytes.fromhex(private_key.to_string().hex())
+                        schnorr_msg = bytes.fromhex(pre_hash.hex())
+                        sig = sign_schnorr(schnorr_msg,schnorr_pkey)
+                        if len(sig) < 64:
+                            Schnorr_Fail = True
+
+                    #this if normally would always execute for ECDSA:
+                    if not use_Schnorr_Sigs or Schnorr_Fail:
+                        sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
+                        assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
                     txin['signatures'][j] = bh2u(sig) + int_to_hex(self.nHashType() & 255, 1)
                     txin['pubkeys'][j] = pubkey # needed for fd keys
                     self._inputs[i] = txin


### PR DESCRIPTION
Note -- this is a continuation of Jonadl's PR so that he gets commit credits too, because I know he really wants them.

Phase 1:

- Refactored libsecp-related setup into its own file: `secp256k1.py`. If libsecp256k1 is successfully loaded, an app-global context is created that various dependent modules can utilize.
- The loaded lib is accessed as: `secp256k1.secp256k1` (if loaded successfully), or is None otherwise
- `ecc_fast.py` depends on this, and uses the above facility now.  It itself does no library loading. 
- `schnorr.py` also uses the aforementioned facility now.
    
`schnorr.py` has been massiely refactored from Jonald's commit.  It has ~~a single useful function~~ ~~two~~ three useful functions right now: `schnorr.sign`, `schnorr.verify` and `schnorr.is_available`.
    
- Got rid of all the debug/extra code from `transaction.py` that was recently added by Jonald's commit.  We first need this in place, then we can think about where to hook it into the wallet code, etc.

Update: Added `verify` facility.
Update2: Added `is_available` function.