### PR TITLE
AppImage libusb / PyQt5 fix

### DIFF
--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -181,6 +181,7 @@ rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Quick*
 rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Location*
 rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Test*
 rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Xml*
+rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt.so
 
 # these are deleted as they were not deterministic; and are not needed anyway
 find "$APPDIR" -path '*/__pycache__*' -delete

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -174,13 +174,10 @@ rm -rf "$APPDIR"/usr/lib/python3.6/config-3.6m-x86_64-linux-gnu
 rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/translations/qtwebengine_locales
 rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/resources/qtwebengine_*
 rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/qml
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Web*
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Designer*
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Qml*
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Quick*
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Location*
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Test*
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5Xml*
+for component in Web Designer Qml Quick Location Test Xml ; do
+    rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5${component}*
+    rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt${component}*
+done
 rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt.so
 
 # these are deleted as they were not deterministic; and are not needed anyway

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -145,6 +145,9 @@ info "Finalizing AppDir"
     mv usr/include.tmp usr/include
 ) || fail "Could not finalize AppDir"
 
+# We copy libusb here because it is on the AppImage excludelist and it can cause problems if we use system libusb
+info "Copying libusb"
+cp -f /usr/lib/x86_64-linux-gnu/libusb-1.0.so "$APPDIR/usr/lib/libusb-1.0.so" || fail "Could not copy libusb"
 
 info "Stripping binaries of debug symbols"
 # "-R .note.gnu.build-id" also strips the build id

--- a/plugins/ledger/qt.py
+++ b/plugins/ledger/qt.py
@@ -1,6 +1,6 @@
 import threading
 
-from PyQt5.Qt import QInputDialog, QLineEdit, QVBoxLayout, QLabel
+from PyQt5.QtWidgets import QInputDialog, QLineEdit, QVBoxLayout, QLabel
 
 from electroncash.i18n import _
 from electroncash.plugins import hook


### PR DESCRIPTION
There was an issue on some systems when loading the systems libusb caused by a bad interaction between PyQt5 and libusb. Check the individual commit messages to see what this PR addresses in detail.