### PR TITLE
Windows: Switch monospace font to Consolas

### DIFF
--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -15,7 +15,7 @@ from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 
 if platform.system() == 'Windows':
-    MONOSPACE_FONT = 'Lucida Console'
+    MONOSPACE_FONT = 'Consolas'
 elif platform.system() == 'Darwin':
     MONOSPACE_FONT = 'Monaco'
 else:


### PR DESCRIPTION
Consolas is the best monospace font on Windows and has been included by default starting with Windows 7