### PR TITLE
Add Schnorr signature capability to the UI

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3669,7 +3669,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def is_schnorr_possible(self, reason: list = None) -> bool:
         ''' Returns True if this system can sign with Schnorr and/or this
         wallet type is compatible.
-        `reason` is an optional list where you would like an translated string
+        `reason` is an optional list where you would like a translated string
         of why Schnorr isn't possible placed (on False return). '''
         wallet_ok = bool(not self.wallet.is_multisig() and not self.wallet.is_hardware())
         available = schnorr.is_available()
@@ -3678,7 +3678,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if not wallet_ok:
                 reason.insert(0, _('Schnorr signatures are disabled for this wallet type.'))
             elif not available:
-                reason.insert(0, _('Schnorr signatures are disabled because no secp256k1 library with Schnorr capabilities could be found.'))
+                reason.insert(0, _('Schnorr signatures are disabled because no secp256k1 library with Schnorr capabilities was found.'))
         return ret
 
     def is_schnorr_enabled(self) -> bool:

--- a/lib/coinchooser.py
+++ b/lib/coinchooser.py
@@ -166,7 +166,7 @@ class CoinChooserBase(PrintError):
         return change, dust
 
     def make_tx(self, coins, outputs, change_addrs, fee_estimator,
-                dust_threshold):
+                dust_threshold, sign_schnorr=False):
         '''Select unspent coins to spend to pay outputs.  If the change is
         greater than dust_threshold (after adding the change output to
         the transaction) it is kept, otherwise none is sent and it is
@@ -177,7 +177,7 @@ class CoinChooserBase(PrintError):
         self.p = PRNG(''.join(sorted(utxos)))
 
         # Copy the ouputs so when adding change we don't modify "outputs"
-        tx = Transaction.from_io([], outputs)
+        tx = Transaction.from_io([], outputs, sign_schnorr=sign_schnorr)
         # Size of the transaction with no inputs and no change
         base_size = tx.estimated_size()
         spent_amount = tx.output_value()

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -497,6 +497,18 @@ class Transaction:
         # redo raw
         self.raw = self.serialize()
 
+    def is_schnorr_signed(self, input_idx):
+        ''' Return True IFF any of the signatures for a particular input
+        are Schnorr signatures (Schnorr signatures are always 64 bytes + 1) '''
+        if (isinstance(self._inputs, (list, tuple))
+                and input_idx < len(self._inputs)
+                and self._inputs[input_idx]):
+            # Schnorr sigs are always 64 bytes. However the sig has a hash byte
+            # at the end, so that's 65. Plus we are hex encoded, so 65*2=130
+            return any(isinstance(sig, (str, bytes)) and len(sig) == 130
+                       for sig in self._inputs[input_idx].get('signatures', []))
+        return False
+
     def deserialize(self):
         if self.raw is None:
             return

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -32,6 +32,7 @@ from .util import print_error, profiler
 from .bitcoin import *
 from .address import (PublicKey, Address, Script, ScriptOutput, hash160,
                       UnknownAddress, OpCodes as opcodes)
+from . import schnorr
 import struct
 
 #
@@ -424,6 +425,7 @@ class Transaction:
         self._outputs = None
         self.locktime = 0
         self.version = 1
+        self._sign_schnorr = False
 
         # attribute used by HW wallets to tell the hw keystore about any outputs
         # in the tx that are to self (change), etc. See wallet.py add_hw_info
@@ -436,6 +438,9 @@ class Transaction:
         # is change that's too small to go to change outputs (below dust threshold) and needed
         # to go to the fee. Values in this dict are advisory only and may or may not always be there!
         self.ephemeral = dict()
+
+    def set_sign_schnorr(self, b):
+        self._sign_schnorr = b
 
     def update(self, raw):
         self.raw = raw
@@ -507,13 +512,14 @@ class Transaction:
         return d
 
     @classmethod
-    def from_io(klass, inputs, outputs, locktime=0):
+    def from_io(klass, inputs, outputs, locktime=0, sign_schnorr=False):
         assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
                    for output in outputs)
         self = klass(None)
         self._inputs = inputs
         self._outputs = outputs.copy()
         self.locktime = locktime
+        self.set_sign_schnorr(sign_schnorr)
         return self
 
     @classmethod
@@ -547,15 +553,19 @@ class Transaction:
             return 0x21  # just guess it is compressed
 
     @classmethod
-    def get_siglist(self, txin, estimate_size=False):
+    def get_siglist(self, txin, estimate_size=False, sign_schnorr=False):
         # if we have enough signatures, we use the actual pubkeys
         # otherwise, use extended pubkeys (with bip32 derivation)
         num_sig = txin.get('num_sig', 1)
         if estimate_size:
             pubkey_size = self.estimate_pubkey_size_for_txin(txin)
             pk_list = ["00" * pubkey_size] * len(txin.get('x_pubkeys', [None]))
-            # we assume that signature will be 0x48 bytes long
-            sig_list = [ "00" * 0x48 ] * num_sig
+            # we assume that signature will be 0x48 bytes long if ECDSA, 0x41 if Schnorr
+            if sign_schnorr:
+                siglen = 0x41
+            else:
+                siglen = 0x48
+            sig_list = [ "00" * siglen ] * num_sig
         else:
             pubkeys, x_pubkeys = self.get_sorted_pubkeys(txin)
             x_signatures = txin['signatures']
@@ -570,11 +580,11 @@ class Transaction:
         return pk_list, sig_list
 
     @classmethod
-    def input_script(self, txin, estimate_size=False):
+    def input_script(self, txin, estimate_size=False, sign_schnorr=False):
         _type = txin['type']
         if _type == 'coinbase':
             return txin['scriptSig']
-        pubkeys, sig_list = self.get_siglist(txin, estimate_size)
+        pubkeys, sig_list = self.get_siglist(txin, estimate_size, sign_schnorr)
         script = ''.join(push_script(x) for x in sig_list)
         if _type == 'p2pk':
             pass
@@ -676,7 +686,7 @@ class Transaction:
         nLocktime = int_to_hex(self.locktime, 4)
         inputs = self.inputs()
         outputs = self.outputs()
-        txins = var_int(len(inputs)) + ''.join(self.serialize_input(txin, self.input_script(txin, estimate_size), estimate_size) for txin in inputs)
+        txins = var_int(len(inputs)) + ''.join(self.serialize_input(txin, self.input_script(txin, estimate_size, self._sign_schnorr), estimate_size) for txin in inputs)
         txouts = var_int(len(outputs)) + ''.join(self.serialize_output(o) for o in outputs)
         return nVersion + txins + txouts + nLocktime
 
@@ -736,6 +746,24 @@ class Transaction:
         s, r = self.signature_count()
         return r == s
 
+    @staticmethod
+    def _ecdsa_sign(sec, pre_hash):
+        pkey = regenerate_key(sec)
+        secexp = pkey.secret
+        private_key = MySigningKey.from_secret_exponent(secexp, curve = SECP256k1)
+        public_key = private_key.get_verifying_key()
+        sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
+        assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
+        return sig
+
+    @staticmethod
+    def _schnorr_sign(pubkey, sec, pre_hash):
+        pubkey = bytes.fromhex(pubkey)
+        sig = schnorr.sign(sec, pre_hash)
+        assert schnorr.verify(pubkey, sig, pre_hash)  # verify what we just signed
+        return sig
+
+
     def sign(self, keypairs):
         for i, txin in enumerate(self.inputs()):
             num = txin['num_sig']
@@ -746,17 +774,15 @@ class Transaction:
                     # txin is complete
                     break
                 if x_pubkey in keypairs.keys():
-                    print_error("adding signature for", x_pubkey)
+                    print_error("adding signature for", x_pubkey, "use schnorr?", self._sign_schnorr)
                     sec, compressed = keypairs.get(x_pubkey)
                     pubkey = public_key_from_private_key(sec, compressed)
                     # add signature
                     pre_hash = Hash(bfh(self.serialize_preimage(i)))
-                    pkey = regenerate_key(sec)
-                    secexp = pkey.secret
-                    private_key = MySigningKey.from_secret_exponent(secexp, curve = SECP256k1)
-                    public_key = private_key.get_verifying_key()
-                    sig = private_key.sign_digest_deterministic(pre_hash, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der)
-                    assert public_key.verify_digest(sig, pre_hash, sigdecode = ecdsa.util.sigdecode_der)
+                    if self._sign_schnorr:
+                        sig = self._schnorr_sign(pubkey, sec, pre_hash)
+                    else:
+                        sig = self._ecdsa_sign(sec, pre_hash)
                     txin['signatures'][j] = bh2u(sig) + int_to_hex(self.nHashType() & 255, 1)
                     txin['pubkeys'][j] = pubkey # needed for fd keys
                     self._inputs[i] = txin


### PR DESCRIPTION
Off by default. Can be enabled in prefs.  Only transactions signed from the UI will use Schnorr if enabled.

It is enabled on a per-wallet basis.

CashShuffle is unaffected (all CashShuffle tx's will continue to use ECDSA, as per CashShuffle spec).

In prefs screen:

<img width="442" alt="Screen Shot 2019-05-10 at 8 50 17 PM" src="https://user-images.githubusercontent.com/266627/57547489-44867900-7367-11e9-8b99-1b7151007876.png">

Disabled for multisig or hardware wallets:

<img width="437" alt="Screen Shot 2019-05-10 at 9 07 10 PM" src="https://user-images.githubusercontent.com/266627/57547659-9cbd7b00-7367-11e9-9a9e-8d918d78d078.png">

Disabled for systems lacking libsecp or libsecp + Schnorr:

<img width="604" alt="Screen Shot 2019-05-10 at 9 10 39 PM" src="https://user-images.githubusercontent.com/266627/57547845-1bb2b380-7368-11e9-92e7-b2ed9d3ed329.png">


This is what it looks like when you sign a tx:

![schnorr_sign - Edited](https://user-images.githubusercontent.com/266627/57547466-389ab700-7367-11e9-9eaa-66bf27e4240f.gif)
