### PR TITLE
Linux: Explicitly set umask when creating udev rules

### DIFF
--- a/gui/qt/udev_installer.py
+++ b/gui/qt/udev_installer.py
@@ -183,9 +183,11 @@ class InstallHardwareWalletSupportDialog(PrintError, WindowModalDialog):
         return script
 
     def installClicked(self):
-        script = 'cat << EOF > "{}"\n'.format(self.UDEV_RULES_FILE)
-        script = script + self.generateRulesFile()
-        script = script + 'EOF\n'
+        script = 'set +e\n'
+        script += 'umask 022\n'
+        script += 'cat << EOF > "{}"\n'.format(self.UDEV_RULES_FILE)
+        script += self.generateRulesFile()
+        script += 'EOF\n'
         script = self._addUdevAdmCommands(script)
         self.print_error(script)
         success = self._runScriptAsRoot(script)


### PR DESCRIPTION
There might be some freak configurations where root umask makes udev files writable by others by default. That would be bad as udev rules can execute commands. This patch explicitly sets the umask and also adds set +e to the script to let any errors propagate.