### PR TITLE
[Lib] Fixed Transaction update_signatures to actually work w/ multisig

### DIFF
--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -92,7 +92,7 @@ class TestTransaction(unittest.TestCase):
 
         self.assertEqual(tx.serialize(), unsigned_blob)
 
-        tx.update_signatures(signed_blob)
+        tx.update_signatures(['3044022025bdc804c6fe30966f6822dc25086bc6bb0366016e68e880cf6efd2468921f3202200e665db0404f6d6d9f86f73838306ac55bb0d0f6040ac6047d4e820f24f46885'])
         self.assertEqual(tx.raw, signed_blob)
 
         tx.update(unsigned_blob)
@@ -127,7 +127,7 @@ class TestTransaction(unittest.TestCase):
 
         self.assertEqual(tx.serialize(), signed_blob)
 
-        tx.update_signatures(signed_blob)
+        tx.update_signatures([expected['inputs'][0]['signatures'][0][:-2]])
 
         self.assertEqual(tx.estimated_size(), 191)
 

--- a/plugins/trezor/trezor.py
+++ b/plugins/trezor/trezor.py
@@ -342,9 +342,9 @@ class TrezorPlugin(HW_PluginBase):
         inputs = self.tx_inputs(tx, xpub_path, True)
         outputs = self.tx_outputs(keystore.get_derivation(), tx, client)
         details = SignTx(lock_time=tx.locktime)
-        signed_tx = client.sign_tx(self.get_coin_name(), inputs, outputs, details=details,prev_txes=defaultdict(TransactionType))[1]
-        raw = bh2u(signed_tx)
-        tx.update_signatures(raw)
+        signatures, signed_tx = client.sign_tx(self.get_coin_name(), inputs, outputs, details=details,prev_txes=defaultdict(TransactionType))
+        signatures = [bh2u(x) for x in signatures]
+        tx.update_signatures(signatures)
 
     def show_address(self, wallet, address, keystore=None):
         if keystore is None:


### PR DESCRIPTION
The previous incarnation of this function was really really fragile/broken/dumb.

This one actually updates signatures without relying on the fragile (and not working for multisig) "scritpSig" hack we use to serialize metadata into the tx.

This is inspired by Electrum's approach (after reading their code) but independently developed  to be a little leaner and meaner.
