### PR TITLE
Allow in-memory-only wallets

### DIFF
--- a/lib/storage.py
+++ b/lib/storage.py
@@ -177,6 +177,9 @@ class WalletStorage(PrintError):
             self._write()
 
     def _write(self):
+        if not self.path:
+            # allow memory-only wallets
+            return
         if threading.currentThread().isDaemon():
             self.print_error('warning: daemon thread cannot write wallet')
             return


### PR DESCRIPTION
You can pass None to the WalletStorage constructor, in which case the wallet will never be written to disk.

I found this trick handy in openswap: https://github.com/markblundeberg/openswap/commit/1bc04bc372b5eb68852f25df84d62109cdf1dcf3#diff-30a60ee8395b4acd14d9276844936041 . Essentially, it's useful in any case where you want to download history and watch for transactions on a given ad-hoc address. Smart contracts etc.