### PR TITLE
Zbar: Bump to upstream master and add Linux build

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1404
+++ b/contrib/build-linux/appimage/Dockerfile_ub1404
@@ -20,8 +20,14 @@ RUN apt-get update -q && \
         libusb-1.0-0-dev=2:1.0.17-1ubuntu2 \
         libudev-dev=204-5ubuntu20.31 \
         gettext=0.18.3.1-1ubuntu3.1 \
-        libzbar0=0.10+doc-9build1  \
         faketime=0.9.5-2 \
+        pkg-config=0.26-1ubuntu4 \
+        libx11-dev=2:1.6.2-1ubuntu2 \
+        libx11-6=2:1.6.2-1ubuntu2 \
+        libv4l-dev=1.0.1-1 \
+        libxv-dev=2:1.0.10-1 \
+        libxext-dev=2:1.3.2-1ubuntu0.0.14.04.1 \
+        libjpeg-dev=8c-2ubuntu8 \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -65,6 +65,17 @@ tar xf "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" -C "$BUILDDIR"
     popd
 )
 
+#info "Building libzbar"  # make_zbar below already prints this
+(
+    pushd "$PROJECT_ROOT"
+
+    "$CONTRIB"/make_zbar || fail "Could not build libzbar"
+
+    find lib -type f -name libzbar\* -exec touch -d '2000-11-11T11:11:11+00:00' {} +
+
+    popd
+)
+
 
 appdir_python() {
   env \
@@ -104,16 +115,6 @@ mkdir -p "$CACHEDIR/pip_cache"
 "$python" -m pip install --cache-dir "$CACHEDIR/pip_cache" -r "$CONTRIB/deterministic-build/requirements-hw.txt"
 "$python" -m pip install --cache-dir "$CACHEDIR/pip_cache" "$PROJECT_ROOT"
 
-
-info "Copying zbar"
-if [ -e /usr/lib/x86_64-linux-gnu/libzbar.so.0 ]; then
-    # Ubuntu 18.04 dockerfile image puts it in x86_64-linux-gnu
-    mkdir -p "$APPDIR/usr/lib/x86_64-linux-gnu"
-    cp /usr/lib/x86_64-linux-gnu/libzbar.so.0 "$APPDIR/usr/lib/x86_64-linux-gnu/libzbar.so.0" || fail "Could not copy zbar"
-else
-    # Earlier Ubuntu image puts it in plain old /usr/lib
-    cp /usr/lib/libzbar.so.0 "$APPDIR/usr/lib/libzbar.so.0" || fail "Could not copy zbar"
-fi
 
 info "Copying desktop integration"
 cp "$PROJECT_ROOT/electron-cash.desktop" "$APPDIR/electron-cash.desktop"

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -77,7 +77,7 @@ build_zbar() {
         set -e
         build_dll() {
             export SOURCE_DATE_EPOCH=1530212462
-            echo "zbar_libzbar_la_LDFLAGS += -Wc,-static" >> Makefile.am
+            echo "libzbar_la_LDFLAGS += -Wc,-static" >> zbar/Makefile.am
             echo "LDFLAGS += -Wc,-static" >> Makefile.am
             autoreconf -vfi || fail "Could not run autoreconf for zbar"
             # Note: It's really important that you set --build and --host when running configure
@@ -91,8 +91,9 @@ build_zbar() {
                 --enable-pthread=no \
                 --enable-doc=no \
                 --enable-video=yes \
+                --with-directshow=yes \
                 --with-jpeg=no \
-                --with-python2=no \
+                --with-python=no \
                 --with-gtk=no \
                 --with-qt=no \
                 --with-java=no \
@@ -107,7 +108,7 @@ build_zbar() {
         }
 
         pushd "$here"/../zbar || fail "Could not chdir to zbar"
-        LIBZBAR_VERSION="4b357528f6781374923edca7c070226caff67b49" # zbar 0.22.2
+        LIBZBAR_VERSION="11e819815be2de88b64b985605a3386a95079245" # mchehab master as of 2019-05-19
         git checkout $LIBZBAR_VERSION || fail "Could not check out zbar $LIBZBAR_VERSION"
         git clean -f -x -q
 

--- a/contrib/make_secp
+++ b/contrib/make_secp
@@ -19,7 +19,7 @@ LIBSECP_VERSION="9896f7062e67e05f9a1aa7163099fb2e052db9e8"  # According to Mark 
 
 pushd "$contrib"/secp256k1 || fail "Could not chdir to ${contrib}/secp256k1"
 git checkout $LIBSECP_VERSION || fail "Could not check out secp256k1 $LIBSECP_VERSION"
-git clean -f -x -q
+git clean -dfxq
 ./autogen.sh || fail "Could not run autogen for secp256k1. Please make sure you have automake and libtool installed, and try again."
 ./configure \
     --enable-module-recovery \
@@ -42,8 +42,7 @@ else
 fi
 cp -fpv .libs/$libsec_lib ../../lib || fail "Could not copy the secp256k1 binary to its destination"
 git checkout master  # Undo the previous explicit checkout to this hash
-git clean -f -x -q
-rm -fr .libs/
+git clean -dfxq
 popd
 
 info "$libsec_lib has been placed in the electroncash 'lib' folder."

--- a/contrib/make_zbar
+++ b/contrib/make_zbar
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+contrib=$(dirname "$0")
+test -n "$contrib" -a -d "$contrib" || (echo "Could not find the contrib/ directory" && exit 1)
+pushd "$contrib"
+contrib=`pwd`  # get abs path
+. "$contrib"/base.sh || (echo "Could not source contrib/base.sh" && exit 1)
+
+set -e
+
+which git || fail "Git is required to proceed"
+
+info "Refreshing submodules..."
+git submodule init
+git submodule update
+
+info "Building libzbar..."
+LIBZBAR_VERSION="11e819815be2de88b64b985605a3386a95079245" # mchehab master as of 2019-05-19
+
+pushd "$contrib"/zbar || fail "Could not chdir to ${contrib}/zbar"
+git checkout $LIBZBAR_VERSION || fail "Could not check out zbar $LIBZBAR_VERSION"
+git clean -dfxq
+autoreconf -vfi || fail "Could not run autoreconf for zbar. Please make sure you have automake and libtool installed, and try again."
+./configure \
+    --with-x=yes \
+    --enable-pthread=no \
+    --enable-doc=no \
+    --enable-video=yes \
+    --with-jpeg=yes \
+    --with-python=no \
+    --with-gtk=no \
+    --with-qt=no \
+    --with-java=no \
+    --with-imagemagick=no \
+    --with-dbus=no \
+    --enable-codes=qrcode \
+    --disable-static \
+    --enable-shared || fail "Could not configure zbar. Please make sure you have a C compiler installed and try again."
+make -j4 || fail "Could not build zbar"
+uname=`uname -s`
+if [ "$uname" = "Darwin" ]; then
+    libzbar_lib="libzbar.0.dylib"
+elif [ "$uname" = "Linux" ]; then
+    libzbar_lib="libzbar.so.0"
+else
+    fail "Unknown OS! Please manually copy the library produced in .libs/ and put it in the ../../lib folder (top level folder)"
+fi
+cp -fpv zbar/.libs/$libzbar_lib ../../lib || fail "Could not copy the zbar binary to its destination"
+git checkout master  # Undo the previous explicit checkout to this hash
+git clean -dfxq
+popd
+
+info "$libzbar_lib has been placed in the electroncash 'lib' folder."
+
+popd

--- a/lib/qrscanner.py
+++ b/lib/qrscanner.py
@@ -39,9 +39,12 @@ else:
 libzbar = None
 
 try:
-    libzbar = ctypes.cdll.LoadLibrary(name)
+    libzbar = ctypes.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), name))
 except OSError as e:
-    print_error(_('Failed to load zbar: {}').format(e))
+    try:
+        libzbar = ctypes.cdll.LoadLibrary(name)
+    except OSError as e:
+        print_error(_('Failed to load zbar: {}').format(e))
 
 def scan_barcode_ctypes(device='', timeout=-1, display=True, threaded=False):
     if libzbar is None:

--- a/setup.py
+++ b/setup.py
@@ -66,18 +66,25 @@ class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
 
     user_options = setuptools.command.sdist.sdist.user_options + [
         ("disable-secp", None, "Disable libsecp256k1 complilation (default)."),
-        ("enable-secp", None, "Enable libsecp256k1 complilation.")
+        ("enable-secp", None, "Enable libsecp256k1 complilation."),
+        ("disable-zbar", None, "Disable libzbar complilation (default)."),
+        ("enable-zbar", None, "Enable libzbar complilation.")
     ]
 
     def initialize_options(self):
         self.disable_secp = None
         self.enable_secp = None
+        self.disable_zbar = None
+        self.enable_zbar = None
         super().initialize_options()
 
     def finalize_options(self):
         if self.enable_secp is None:
             self.enable_secp = False
         self.enable_secp = not self.disable_secp and self.enable_secp
+        if self.enable_zbar is None:
+            self.enable_zbar = False
+        self.enable_zbar = not self.disable_zbar and self.enable_zbar
         super().finalize_options()
 
     def run(self):
@@ -89,6 +96,9 @@ class MakeAllBeforeSdist(setuptools.command.sdist.sdist):
         if self.enable_secp:
             self.announce("Running make_secp...")
             0==os.system("contrib/make_secp") or sys.exit("Could not build libsecp256k1")
+        if self.enable_zbar:
+            self.announce("Running make_zbar...")
+            0==os.system("contrib/make_zbar") or sys.exit("Could not build libzbar")
         super().run()
 
 setup(
@@ -131,6 +141,7 @@ setup(
             'www/index.html',
             'wordlist/*.txt',
             'libsecp256k1*',
+            'libzbar*',
             'locale/*/LC_MESSAGES/electron-cash.mo',
         ],
         'electroncash_plugins.shuffle' : [


### PR DESCRIPTION
Zbar master includes various fixes for Windows as well as DirectShow support. We should update this to 0.23 as soon as it is released.

The patch also adds a reproducible build of zbar for Linux.