### PR TITLE
AppImage: build fixes

### DIFF
--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -51,6 +51,12 @@ tar xf "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" -C "$BUILDDIR"
       -q
     TZ=UTC faketime -f '2019-01-01 01:01:01' make -j 4 -s || fail "Could not build Python"
     make -s install > /dev/null || fail "Failed to install Python"
+    # When building in docker on macOS, python builds with .exe extension because the
+    # case insensitive file system of macOS leaks into docker. This causes the build
+    # to result in a different output on macOS compared to Linux. We simply patch
+    # sysconfigdata to remove the extension.
+    # Some more info: https://bugs.python.org/issue27631
+    sed -i -e 's/\.exe//g' "$APPDIR"/usr/lib/python3.6/_sysconfigdata*
 )
 
 

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -190,6 +190,7 @@ rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt.so
 find "$APPDIR" -path '*/__pycache__*' -delete
 rm "$APPDIR"/usr/lib/python3.6/site-packages/pyblake2-*.dist-info/RECORD
 rm "$APPDIR"/usr/lib/python3.6/site-packages/hidapi-*.dist-info/RECORD
+rm "$APPDIR"/usr/lib/python3.6/site-packages/psutil-*.dist-info/RECORD
 
 
 find -exec touch -h -d '2000-11-11T11:11:11+00:00' {} +


### PR DESCRIPTION
See the individual commits for explanations. Note that our AppImages are still not reproducible, even though the contents are always the same after this commit. This is due to AppImageKit needing more fixes:

https://github.com/AppImage/AppImageKit/issues/929