### PR TITLE
Refactor sign_schnorr tx generation mechanics to be per-input

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2650,7 +2650,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         from electroncash.transaction import tx_from_str
         try:
             txt_tx = tx_from_str(txt)
-            tx = Transaction(txt_tx, sign_schnorr=self.is_schnorr_enabled())
+            tx = Transaction(txt_tx)
             tx.deserialize()
             if self.wallet:
                 my_coins = self.wallet.get_spendable_coins(None, self.config)
@@ -2765,7 +2765,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if not ok:
                 self.show_message(_("Error retrieving transaction") + ":\n" + r)
                 return
-            tx = transaction.Transaction(r, sign_schnorr=self.is_schnorr_enabled())  # note that presumably the tx is already signed if it comes from blockchain so this sign_schnorr parameter is superfluous, but here to satisfy my OCD -Calin
+            tx = transaction.Transaction(r)
             self.show_transaction(tx)
 
     @protected
@@ -3045,7 +3045,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 else:
                     self.show_message(_("User cancelled"))
                     return
-            coins, keypairs = sweep_preparations(keys, self.network)
+            coins, keypairs = sweep_preparations(keys, self.network, sign_schnorr = self.is_schnorr_enabled())
             self.tx_external_keypairs = keypairs
             self.payto_e.setText(get_address_text())
             self.spend_coins(coins)

--- a/lib/coinchooser.py
+++ b/lib/coinchooser.py
@@ -84,14 +84,14 @@ class CoinChooserBase(PrintError):
     def keys(self, coins):
         raise NotImplementedError
 
-    def bucketize_coins(self, coins, sign_schnorr=False):
+    def bucketize_coins(self, coins):
         keys = self.keys(coins)
         buckets = defaultdict(list)
         for key, coin in zip(keys, coins):
             buckets[key].append(coin)
 
         def make_Bucket(desc, coins):
-            size = sum(Transaction.estimated_input_size(coin, sign_schnorr=sign_schnorr)
+            size = sum(Transaction.estimated_input_size(coin)
                        for coin in coins)
             value = sum(coin['value'] for coin in coins)
             return Bucket(desc, size, value, coins)
@@ -166,7 +166,7 @@ class CoinChooserBase(PrintError):
         return change, dust
 
     def make_tx(self, coins, outputs, change_addrs, fee_estimator,
-                dust_threshold, sign_schnorr=False):
+                dust_threshold):
         '''Select unspent coins to spend to pay outputs.  If the change is
         greater than dust_threshold (after adding the change output to
         the transaction) it is kept, otherwise none is sent and it is
@@ -177,7 +177,7 @@ class CoinChooserBase(PrintError):
         self.p = PRNG(''.join(sorted(utxos)))
 
         # Copy the ouputs so when adding change we don't modify "outputs"
-        tx = Transaction.from_io([], outputs, sign_schnorr=sign_schnorr)
+        tx = Transaction.from_io([], outputs)
         # Size of the transaction with no inputs and no change
         base_size = tx.estimated_size()
         spent_amount = tx.output_value()
@@ -190,7 +190,7 @@ class CoinChooserBase(PrintError):
             return total_input >= spent_amount + fee_estimator(total_size)
 
         # Collect the coins into buckets, choose a subset of the buckets
-        buckets = self.bucketize_coins(coins, sign_schnorr=sign_schnorr)
+        buckets = self.bucketize_coins(coins)
         buckets = self.choose_buckets(buckets, sufficient_funds,
                                       self.penalty_func(tx))
 

--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -558,7 +558,7 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
             if p2pkhTransaction:
                 class CustomTXSerialization(Transaction):
                     @classmethod
-                    def input_script(self, txin, estimate_size=False, sign_schnorr=False):
+                    def input_script(self, txin, estimate_size=False):
                         if txin['type'] == 'p2pkh':
                             return Transaction.get_preimage_script(txin)
                         if txin['type'] == 'p2sh':


### PR DESCRIPTION
By adding this to the unsigned coins (unsigned input dicts) we get a
finer grained control over which inputs are signed which way.

Overall less passing around of the `sign_schnorr` parameter, too.