### PR TITLE
refactor nHashType

### DIFF
--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -653,7 +653,7 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
                     sig_r = int(signed['sig'][:64], 16)
                     sig_s = int(signed['sig'][64:], 16)
                     sig = sigencode_der(sig_r, sig_s, generator_secp256k1.order())
-                    txin['signatures'][ii] = to_hexstr(sig) + int_to_hex(Transaction.nHashType() & 255, 1)
+                    txin['signatures'][ii] = to_hexstr(sig) + '41'
                     tx._inputs[i] = txin
         except UserCancelled:
             raise

--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -461,7 +461,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
                 else:
                     self.get_client().startUntrustedTransaction(False, 0,
                                                             singleInput, redeemScripts[inputIndex])
-                inputSignature = self.get_client().untrustedHashSign(inputsPaths[inputIndex], pin, lockTime=tx.locktime, sighashType=tx.nHashType())
+                inputSignature = self.get_client().untrustedHashSign(inputsPaths[inputIndex], pin, lockTime=tx.locktime, sighashType=0x41)
                 inputSignature[0] = 0x30 # force for 1.4.9+
                 signatures.append(inputSignature)
                 inputIndex = inputIndex + 1

--- a/plugins/shuffle/coin_utils.py
+++ b/plugins/shuffle/coin_utils.py
@@ -157,7 +157,7 @@ class CoinUtils(PrintError):
                                                             hashfunc=hashlib.sha256,
                                                             sigencode=ecdsa.util.sigencode_der)
                 assert public_key.verify_digest(sig, pre_hash, sigdecode=ecdsa.util.sigdecode_der)
-                signatures[txin['tx_hash'] + ":" + str(txin['tx_pos'])] = (bh2u(sig) + int_to_hex(transaction.nHashType() & 255, 1)).encode('utf-8')
+                signatures[txin['tx_hash'] + ":" + str(txin['tx_pos'])] = (bh2u(sig) + '41').encode('utf-8')
         return signatures
 
     @staticmethod


### PR DESCRIPTION
This doesn't make sense as a transaction property, and many places were calling this assuming that it would always return 0x41.

Also we don't support serializing sighash for other than 0x41 right now,
so I put in a sanity check.

(and tried a shuffle; this works =D)