### PR TITLE
Zbar: Disable video support for Windows build

### DIFF
--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -90,8 +90,8 @@ build_zbar() {
                 --with-x=no \
                 --enable-pthread=no \
                 --enable-doc=no \
-                --enable-video=yes \
-                --with-directshow=yes \
+                --enable-video=no \
+                --with-directshow=no \
                 --with-jpeg=no \
                 --with-python=no \
                 --with-gtk=no \


### PR DESCRIPTION
This is not needed anymore as we now use Qt to get video data from the camera.