### PR TITLE
Support older versions of Qt5

### DIFF
--- a/gui/qt/qrreaderutil.py
+++ b/gui/qt/qrreaderutil.py
@@ -1,0 +1,13 @@
+# TODO: Remove this when it is unlikely to encounter Qt5 installations that are
+# missing QtMultimedia
+def warn_unless_can_import_qrreader(parent):
+    try:
+        from .qrreader import QrReaderCameraDialog
+    except ModuleNotFoundError as e:
+        parent.show_error(
+            "QR reader failed to load. This often happens if you are using"
+            + " an old version of Qt5. \n\nDetailed error: " + str(e),
+            title = "QR reader disabled")
+        return False
+    return True
+

--- a/gui/qt/qrtextedit.py
+++ b/gui/qt/qrtextedit.py
@@ -99,6 +99,9 @@ class ScanQRTextEdit(ButtonsTextEdit, MessageBoxMixin):
             util.print_error("[ScanQRTextEdit] Warning: QR dialog is already presented, ignoring.")
             return
         from electroncash import get_config
+        from .qrreaderutil import warn_unless_can_import_qrreader
+        if not warn_unless_can_import_qrreader(self):
+            return
         from .qrreader import QrReaderCameraDialog
         try:
             self.qr_dialog = QrReaderCameraDialog(parent=self.top_level_window())


### PR DESCRIPTION
Disable QR reader for older verisons of Qt5. Show an error box when
attempting to use QR reader instead.

![Screenshot from 2019-05-27 10-33-51](https://user-images.githubusercontent.com/92707/58407094-46408400-806b-11e9-9bfe-d52954117c1d.png)