### PR TITLE
Gracefully fail when standard output script type parser throws exception

### DIFF
--- a/lib/address.py
+++ b/lib/address.py
@@ -442,7 +442,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
     def __new__(cls, hash160, kind):
         assert kind in (cls.ADDR_P2PKH, cls.ADDR_P2SH)
         hash160 = to_bytes(hash160)
-        assert len(hash160) == 20
+        assert len(hash160) == 20, "hash must be 20 bytes"
         ret = super().__new__(cls, hash160, kind)
         ret._addr2str_cache = [None] * cls._NUM_FMTS
         return ret


### PR DESCRIPTION
How this can occur:
- P2PK with pubkey of wrong length / prefixbyte
- P2PKH with wrong length hash
- P2SH with wrong length hash
- exceptions from script_GetOp if any (e.g., due to truncated scripts. Not right now but code may become more strict.).

In all cases it's safe to just fail to ScriptOutput.

testnet example I crafted (p2pkh with 19 bytes): f94324c9a21bef97feaead5bd2e96ba2ef3775aaa4b00d7c2c15dd564684921a

(also, fix a couple of nits: should never use BaseException, and give helpful exception message)