### PR TITLE
Script parser cleanup

### DIFF
--- a/lib/address.py
+++ b/lib/address.py
@@ -379,7 +379,7 @@ class ScriptOutput(namedtuple("ScriptAddressTuple", "script")):
             ops = Script.get_ops(self.script)
         except ScriptError:
             # Truncated script -- so just default to hex string.
-            return self.script.hex()
+            return 'Invalid script: ' + self.script.hex()
         def lookup(x):
             try:
                 return OpCodes(x).name

--- a/lib/address.py
+++ b/lib/address.py
@@ -386,12 +386,8 @@ class ScriptOutput(namedtuple("ScriptAddressTuple", "script")):
             except ValueError:
                 return '('+str(x)+')'
         parts = []
-        for op in ops:
-            if isinstance(op, tuple):
-                op, data = op
-                if data is None:
-                    data = b''
-
+        for op, data in ops:
+            if data is not None:
                 # Attempt to make a friendly string, or fail to hex
                 try:
                     astext = data.decode('utf8')
@@ -719,24 +715,29 @@ class Script:
                 n += 1
 
                 if op <= OpCodes.OP_PUSHDATA4:
-                    # Raw bytes follow
                     if op < OpCodes.OP_PUSHDATA1:
+                        # Raw bytes follow
                         dlen = op
                     elif op == OpCodes.OP_PUSHDATA1:
+                        # One-byte length, then data
                         dlen = script[n]
                         n += 1
                     elif op == OpCodes.OP_PUSHDATA2:
+                        # Two-byte length, then data
                         dlen, = struct.unpack('<H', script[n: n + 2])
                         n += 2
-                    else:
+                    else: # op == OpCodes.OP_PUSHDATA4
+                        # Four-byte length, then data
                         dlen, = struct.unpack('<I', script[n: n + 4])
                         n += 4
                     if n + dlen > len(script):
                         raise IndexError
-                    op = (op, script[n:n + dlen])
+                    data = script[n:n + dlen]
                     n += dlen
+                else:
+                    data = None
 
-                ops.append(op)
+                ops.append((op, data))
         except Exception:
             # Truncated script; e.g. tx_hash
             # ebc9fa1196a59e192352d76c0f6e73167046b9d37b8302b6bb6968dfd279b767

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -166,47 +166,6 @@ def short_hex(bytes):
     return t[0:4]+"..."+t[-4:]
 
 
-def script_GetOp(_bytes):
-    i = 0
-    blen = len(_bytes)
-    while i < blen:
-        vch = None
-        opcode = _bytes[i]
-        i += 1
-
-        if opcode <= opcodes.OP_PUSHDATA4:
-            nSize = opcode
-            if opcode == opcodes.OP_PUSHDATA1:
-                nSize = _bytes[i] if i < blen else 0
-                i += 1
-            elif opcode == opcodes.OP_PUSHDATA2:
-                (nSize,) = struct.unpack_from('<H', _bytes, i) if i+2 <= blen else (0,) # tolerate truncated script
-                i += 2
-            elif opcode == opcodes.OP_PUSHDATA4:
-                (nSize,) = struct.unpack_from('<I', _bytes, i) if i+4 <= blen else (0,)
-                i += 4
-            vch = _bytes[i:i + nSize] # array slicing here never throws exception even if truncated script
-            i += nSize
-
-        yield opcode, vch, i
-
-
-def script_GetOpName(opcode):
-    return (opcodes.whatis(opcode)).replace("OP_", "")
-
-
-def decode_script(bytes):
-    result = ''
-    for (opcode, vch, i) in script_GetOp(bytes):
-        if len(result) > 0: result += " "
-        if opcode <= opcodes.OP_PUSHDATA4:
-            result += "%d:"%(opcode,)
-            result += short_hex(vch)
-        else:
-            result += script_GetOpName(opcode)
-    return result
-
-
 def match_decoded(decoded, to_match):
     if len(decoded) != len(to_match):
         return False;
@@ -229,7 +188,7 @@ def safe_parse_pubkey(x):
 
 def parse_scriptSig(d, _bytes):
     try:
-        decoded = list(script_GetOp(_bytes))
+        decoded = Script.get_ops(_bytes)
     except Exception as e:
         # coinbase transactions raise an exception
         print_error("cannot find address in input script", bh2u(_bytes))
@@ -285,7 +244,7 @@ def parse_scriptSig(d, _bytes):
 
 
 def parse_redeemScript(s):
-    dec2 = [ x for x in script_GetOp(s) ]
+    dec2 = Script.get_ops(s)
     # the following throw exception when redeemscript has one or zero opcodes
     m = dec2[0][0] - opcodes.OP_1 + 1
     n = dec2[-2][0] - opcodes.OP_1 + 1
@@ -304,7 +263,7 @@ def parse_redeemScript(s):
 
 def get_address_from_output_script(_bytes):
     try:
-        decoded = [x for x in script_GetOp(_bytes)]
+        decoded = Script.get_ops(_bytes)
 
         # The Genesis Block, self-payments, and pay-by-IP-address payments look like:
         # 65 BYTES:... CHECKSIG

--- a/plugins/hw_wallet/plugin.py
+++ b/plugins/hw_wallet/plugin.py
@@ -86,7 +86,7 @@ def validate_op_return_output_and_get_data(output, max_size=220) -> bytes:
 
     ops = Script.get_ops(address.script)
 
-    if not ops[0] == OpCodes.OP_RETURN:
+    if ops[0][0] != OpCodes.OP_RETURN:
         raise RuntimeError(_("Only OP_RETURN scripts are supported."))
 
     if len(ops) > 2 or ops[1][0] not in [OpCodes.OP_PUSHDATA1, OpCodes.OP_PUSHDATA2, OpCodes.OP_PUSHDATA4]:

--- a/plugins/hw_wallet/plugin.py
+++ b/plugins/hw_wallet/plugin.py
@@ -86,11 +86,11 @@ def validate_op_return_output_and_get_data(output, max_size=220) -> bytes:
 
     ops = Script.get_ops(address.script)
 
-    if ops[0][0] != OpCodes.OP_RETURN:
+    if len(ops) < 1 or ops[0][0] != OpCodes.OP_RETURN:
         raise RuntimeError(_("Only OP_RETURN scripts are supported."))
 
-    if len(ops) > 2 or ops[1][0] not in [OpCodes.OP_PUSHDATA1, OpCodes.OP_PUSHDATA2, OpCodes.OP_PUSHDATA4]:
-        raise RuntimeError(_("OP_RETURN is limited to a single constant push."))
+    if len(ops) != 2 or ops[1][1] is None:
+        raise RuntimeError(_("OP_RETURN is limited to a single data push."))
 
     if len(ops[1][1]) > max_size:
         raise RuntimeError(_("OP_RETURN data size exceeds the maximum of {} bytes.".format(max_size)))


### PR DESCRIPTION
To follow up from #829 and #1396, this cleans up the way that scripts are parsed.
- deduplicate effort in transaction.py/address.py, in favour of the more strict `Script.get_ops` in address.py
- make a nicer parse result in `Script.get_ops`

A couple of test txns to do load from blockchain:
9969603dca74d14d29d1d5f56b94c7872551607f8c2d6837ab9715c60721b50e (script output, to see decompilation)
ebc9fa1196a59e192352d76c0f6e73167046b9d37b8302b6bb6968dfd279b767 (invalid scripts on output)