### PR TITLE
Ledger: Fix error message when BCH app is not active

### DIFF
--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -83,6 +83,13 @@ class Ledger_Client():
     def has_usable_connection_with_device(self):
         try:
             self.dongleObject.getFirmwareVersion()
+        except BTChipException as e:
+            if e.sw == 0x6700:
+                # When Ledger is in the app selection menu, getting the firmware version results
+                # in 0x6700 being returned. Getting an error code back means we can actually
+                # communicate with the device, so we return True here.
+                return True
+            return False
         except BaseException:
             return False
         return True


### PR DESCRIPTION
When trying to pair a Ledger which is not in any app but in the main screen for selecting applications it responds to the "GET FIRMWARE VERSION" ADPU with code 0x6700. We use that call to check if we have a connection to the device in has_usable_connection_with_device. This causes the check to fail and the device manager will mark the device as disconnected right after registering it. This will cause the message "'NoneType' object has no attribute 'handler'" being shown when attempting to pair.

Instead of just assuming our connection is dead when we get code 0x6700 back this patch makes it ignore that specific status. It might make sense here to ignore all status code returns of the Ledger as even
getting a status code back means we have a connection.

As a result of this patch we now properly trigger the "Ledger is not in Bitcoin Cash mode" error message.