### PR TITLE
Implement CoinText

### DIFF
--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -37,6 +37,10 @@ from electroncash import networks
 from . import util
 
 RE_ALIAS = '^(.*?)\s*\<([0-9A-Za-z:]{26,})\>$'
+RE_COINTEXT = r'^cointext:([-+ 0-9]+)\s*$'
+
+RX_ALIAS = re.compile(RE_ALIAS)
+RX_COINTEXT = re.compile(RE_COINTEXT, re.I)
 
 frozen_style = "PayToEdit { border:none;}"
 normal_style = "PayToEdit { }"
@@ -71,6 +75,7 @@ class PayToEdit(ScanQRTextEdit):
         self.scan_f = win.pay_to_URI
         self.update_size()
         self.payto_address = None
+        self.cointext = None
 
         self.previous_payto = ''
 
@@ -98,9 +103,17 @@ class PayToEdit(ScanQRTextEdit):
         except:
             return bitcoin.TYPE_SCRIPT, ScriptOutput.from_string(x)
 
+    def parse_cointext(self, txt):
+        ''' Returns a non-empty string which is the phone number in a cointext:
+        style pseudo-url, if x matches the cointext re (eg: cointext:NUMBERS),
+        otherwise returns None. '''
+        m = RX_COINTEXT.match(txt)
+        if m: return ''.join(x for x in m[1].strip() if x.isdigit()) or None
+        return None
+
     def parse_address(self, line):
         r = line.strip()
-        m = re.match(RE_ALIAS, r)
+        m = RX_ALIAS.match(r)
         address = m.group(2) if m else r
         return Address.from_string(address)
 
@@ -119,6 +132,7 @@ class PayToEdit(ScanQRTextEdit):
         outputs = []
         total = 0
         self.payto_address = None
+        self.cointext = None
         if len(lines) == 1:
             data = lines[0]
             if data.lower().startswith(networks.net.CASHADDR_PREFIX + ":"):
@@ -127,8 +141,11 @@ class PayToEdit(ScanQRTextEdit):
             try:
                 self.payto_address = self.parse_output(data)
             except:
-                pass
-            if self.payto_address:
+                try:
+                    self.cointext = self.parse_cointext(data)
+                except:
+                    pass
+            if self.payto_address or self.cointext:
                 self.win.lock_amount(False)
                 return
 

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -37,7 +37,7 @@ from electroncash import networks
 from . import util
 
 RE_ALIAS = '^(.*?)\s*\<([0-9A-Za-z:]{26,})\>$'
-RE_COINTEXT = r'^cointext:([-+ 0-9]+)\s*$'
+RE_COINTEXT = r'^\s*cointext:([-+ 0-9]+)\s*$'
 
 RX_ALIAS = re.compile(RE_ALIAS)
 RX_COINTEXT = re.compile(RE_COINTEXT, re.I)


### PR DESCRIPTION
- Kicks-in only if pay to field reads like `cointext:phone_number`, otherwise normal call path is followed.
- Is slightly hacky -- but it's the best we can do: it intercepts the  Send/Preview button and then does an asynchronous request to the CoinText server, to retrieve the signed PR.
- The Send tab then goes into "Payment Request" mode where they get another chance to review the tx. The send tab is transformed with the final payment info -- including **amount** which *comes from the server*, hence why it **must** be reviewed again by the user.
- At this point it just works like a normal payment request.
