### PR TITLE
implement hmac pseudocode

### DIFF
--- a/lib/schnorr.py
+++ b/lib/schnorr.py
@@ -86,7 +86,7 @@ def nonce_function_rfc6979(order, privkeybytes, msg32, algo16=b'', ndata=b''):
         if k > 0 and k < order:
             break
         K = hmac.HMAC(K, V+b'\x00', 'sha256').digest()
-        V = HMAC_K(V)
+        V = hmac.HMAC(K, V, 'sha256').digest()
     return k
 
 


### PR DESCRIPTION
Python is genius because you can include pseudocode like this, and only
throws an exception when it needs to remind the programmer that they didn't
finish the implementation!

Pseudocode from https://tools.ietf.org/html/rfc6979#page-12

```
              K = HMAC_K(V || 0x00)

              V = HMAC_K(V)

           and loop (try to generate a new T, and so on).
```

(this code only has a 2^-128 chance of running, I only noticed because I re-read it)