### PR TITLE
Qt: High DPI support

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -81,6 +81,8 @@ class ElectrumGui(QObject, PrintError):
             disable_scaling = config.get('qt_disable_highdpi')
             if disable_scaling is False:
                 QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+        if hasattr(Qt, "AA_UseHighDpiPixmaps"):
+            QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
         if hasattr(QGuiApplication, 'setDesktopFileName'):
             QGuiApplication.setDesktopFileName('electron-cash.desktop')
         self.config = config

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -74,6 +74,13 @@ class ElectrumGui(QObject, PrintError):
         QCoreApplication.setAttribute(Qt.AA_X11InitThreads)
         if hasattr(Qt, "AA_ShareOpenGLContexts"):
             QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+        if hasattr(Qt, "AA_EnableHighDpiScaling"):
+            # On platforms that do not support high DPI scaling attribute, like macOS,
+            # qt_disable_highdpi will be set to None. We only enable scaling if it is set to
+            # False.
+            disable_scaling = config.get('qt_disable_highdpi')
+            if disable_scaling is False:
+                QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
         if hasattr(QGuiApplication, 'setDesktopFileName'):
             QGuiApplication.setDesktopFileName('electron-cash.desktop')
         self.config = config

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -893,6 +893,9 @@ def get_parser():
         # Hack to support forcing QT_OPENGL env var. See #1255. This allows us
         # to perhaps add a custom installer shortcut to force software rendering
         parser_gui.add_argument("-O", "--qt_opengl", dest="qt_opengl", default=None, help="(Windows only) If using Qt gui, override the QT_OPENGL env-var with this value (angle,software,desktop are possible overrides)")
+    if sys.platform in ('linux', 'win32', 'cygwin'):
+        # Qt High DPI scaling can not be disabled on macOS
+        parser_gui.add_argument("--qt_disable_highdpi", action="store_true", dest="qt_disable_highdpi", default=False, help="(Linux & Windows only) If using Qt gui, disable high DPI scaling")
     parser_gui.add_argument("-R", "--relax_warnings", action="store_true", dest="relaxwarn", default=False, help="Disables certain warnings that might be annoying during development and/or testing")
     add_network_options(parser_gui)
     add_global_options(parser_gui)


### PR DESCRIPTION
Enables automatic DPI scaling on Windows and Linux and enables high DPI pixmaps on all platforms.
There is a command line option that can be used to disable automatic DPI scaling called `--qt_disable_highdpi`. This can be used in cases where unwanted scaling happens, like small displays or displays with bad EDID information.