### PR TITLE
Update servers list

### DIFF
--- a/lib/servers.json
+++ b/lib/servers.json
@@ -1,85 +1,102 @@
 {
-    "bch.curalle.ovh": {
-        "pruning": "-",
-        "s": "50002",
-        "version": "1.4"
-    },
     "bch.imaginary.cash": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.1"
     },
     "bch0.kister.net": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.1"
+    },
+    "bch.loping.net": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4.1"
+    },
+    "bch.soul-dev.com": {
+        "pruning": "-",
+        "s": "50002",
+        "version": "1.4.1"
+    },
+    "bchx.disdev.org": {
+        "pruning": "-",
+        "s": "50002",
+        "version": "1.4.2"
     },
     "bitcoincash.quangld.com": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.2"
     },
     "blackie.c3-soft.com": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.1"
     },
     "cash.theblains.org": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.1"
     },
     "crypto.mldlabs.com": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.1"
     },
     "electron-cash.dragon.zone": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.2"
     },
     "electron.jochen-hoenicke.de": {
         "pruning": "-",
         "s": "51002",
         "t": "51001",
-        "version": "1.4"
+        "version": "1.4.1"
     },
     "electroncash.dk": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.2"
     },
     "electrum.imaginary.cash": {
         "pruning": "-",
         "s": "50002",
+        "t": "50001",
         "version": "1.4.1"
-    },
-    "electrum.leblancnet.us": {
-        "pruning": "-",
-        "s": "50012",
-        "t": "50011",
-        "version": "1.4"
     },
     "electrumx.hillsideinternet.com": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.1"
+    },
+    "electrum-abc.criptolayer.net": {
+        "pruning": "-",
+        "s": "50012",
+        "version": "1.4.1"
+    },
+    "electrumx-cash.1209k.com": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4.2"
     },
     "wallet.satoshiscoffeehouse.com": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.1"
     },
     "7nshufncf3nmp7pa42oqhnj6whsjgo2eok4jveex62tczuhvqur5ciad.onion": {
         "pruning": "-",
@@ -89,7 +106,7 @@
     "kisternetg2pq7wx.onion": {
         "pruning": "-",
         "t": "50001",
-        "version": "1.4"
+        "version": "1.4.1"
     },
     "electron.coinucopia.io": {
         "pruning": "-",


### PR DESCRIPTION
Added: 
bch.soul-dev.com 
electrumx-cash.1209k.com 
bch.loping.net 
bchx.disdev.org 
electrum-abc.criptolayer.net 

Removed for unresponsive: 
leblancnet
curalle.ovh

Updated versions and ports