### PR TITLE
OpenAlias: Change prefix and fix code rot

### DIFF
--- a/lib/contacts.py
+++ b/lib/contacts.py
@@ -112,9 +112,9 @@ class Contacts(dict):
         except DNSException as e:
             print_error('Error resolving openalias: ', str(e))
             return None
-        prefix = 'btc'
+        prefix = 'bch'
         for record in records:
-            string = record.strings[0]
+            string = record.strings[0].decode('utf-8')
             if string.startswith('oa1:' + prefix):
                 address = self.find_regex(string, r'recipient_address=([A-Za-z0-9]+)')
                 name = self.find_regex(string, r'recipient_name=([^;]+)')


### PR DESCRIPTION
This changes the OpenAlias prefix to 'bch' instead of 'btc'. The OpenAlias website says there is no need to register prefixes at the moment.

This also fixes some code rot that prevented OpenAlias from working, specifically the TXT record not being decoded into a string, the PayToEdit not handling returned Address objects.

closes #1441