### PR TITLE
AppImage: Improve reproducible Python build reliability on Linux

### DIFF
--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -46,14 +46,18 @@ tar xf "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" -C "$BUILDDIR"
 (
     cd "$BUILDDIR/Python-$PYTHON_VERSION"
     export SOURCE_DATE_EPOCH=1530212462
-    TZ=UTC faketime -f '2019-01-01 01:01:01' ./configure \
+    LC_ALL=C export BUILD_DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" "+%b %d %Y")
+    LC_ALL=C export BUILD_TIME=$(date -u -d "@$SOURCE_DATE_EPOCH" "+%H:%M:%S")
+    # Patch taken from Ubuntu python3.6_3.6.8-1~18.04.1.debian.tar.xz
+    patch -p1 < "$CONTRIB/build-linux/appimage/patches/python-3.6.8-reproducible-buildinfo.diff"
+    ./configure \
       --cache-file="$CACHEDIR/python.config.cache" \
       --prefix="$APPDIR/usr" \
       --enable-ipv6 \
       --enable-shared \
       --with-threads \
       -q
-    TZ=UTC faketime -f '2019-01-01 01:01:01' make -j 4 -s || fail "Could not build Python"
+    make -j 4 -s || fail "Could not build Python"
     make -s install > /dev/null || fail "Failed to install Python"
     # When building in docker on macOS, python builds with .exe extension because the
     # case insensitive file system of macOS leaks into docker. This causes the build

--- a/contrib/build-linux/appimage/patches/python-3.6.8-reproducible-buildinfo.diff
+++ b/contrib/build-linux/appimage/patches/python-3.6.8-reproducible-buildinfo.diff
@@ -1,0 +1,13 @@
+# DP: Build getbuildinfo.o with DATE/TIME values when defined
+
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -741,6 +741,8 @@ Modules/getbuildinfo.o: $(PARSER_OBJS) \
+ 	      -DGITVERSION="\"`LC_ALL=C $(GITVERSION)`\"" \
+ 	      -DGITTAG="\"`LC_ALL=C $(GITTAG)`\"" \
+ 	      -DGITBRANCH="\"`LC_ALL=C $(GITBRANCH)`\"" \
++	      $(if $(BUILD_DATE),-DDATE='"$(BUILD_DATE)"') \
++	      $(if $(BUILD_TIME),-DTIME='"$(BUILD_TIME)"') \
+ 	      -o $@ $(srcdir)/Modules/getbuildinfo.c
+ 
+ Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile


### PR DESCRIPTION
follow up to #1444 

There was a problem where Python would not properly include the faketime timestamp sometimes. This patch replaces faketime with a patch that is used by Ubuntu for reproducible builds by exporting BUILD_DATE and BUILD_TIME with the desired values.