### PR TITLE
AppImage: Fix webbrowser.open not opening links

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -23,11 +23,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import webbrowser
-
 from functools import partial
 
-from .util import MyTreeWidget, MONOSPACE_FONT, SortableTreeWidgetItem, rate_limited
+from .util import MyTreeWidget, MONOSPACE_FONT, SortableTreeWidgetItem, rate_limited, webopen
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont, QColor, QKeySequence
 from PyQt5.QtWidgets import QTreeWidgetItem, QAbstractItemView, QMenu
@@ -217,7 +215,7 @@ class AddressList(MyTreeWidget):
                 menu.addAction(_("Remove from wallet"), lambda: self.parent.remove_address(addr))
             addr_URL = web.BE_URL(self.config, 'addr', addr)
             if addr_URL:
-                menu.addAction(_("View on block explorer"), lambda: webbrowser.open(addr_URL))
+                menu.addAction(_("View on block explorer"), lambda: webopen(addr_URL))
 
         freeze = self.parent.set_frozen_state
         if any(self.wallet.is_frozen(addr) for addr in addrs):

--- a/gui/qt/contact_list.py
+++ b/gui/qt/contact_list.py
@@ -22,7 +22,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import webbrowser
 
 from electroncash.i18n import _
 import electroncash.web as web
@@ -33,7 +32,7 @@ from PyQt5.QtGui import *
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import (
     QAbstractItemView, QFileDialog, QMenu, QTreeWidgetItem)
-from .util import MyTreeWidget
+from .util import MyTreeWidget, webopen
 
 
 class ContactList(MyTreeWidget):
@@ -98,7 +97,7 @@ class ContactList(MyTreeWidget):
             URLs = [web.BE_URL(self.config, 'addr', Address.from_string(key))
                     for key in keys if Address.is_valid(key)]
             if any(URLs):
-                menu.addAction(_("View on block explorer"), lambda: [URL and webbrowser.open(URL) for URL in URLs])
+                menu.addAction(_("View on block explorer"), lambda: [URL and webopen(URL) for URL in URLs])
 
         run_hook('create_contact_menu', menu, selected)
         menu.exec_(self.viewport().mapToGlobal(position))

--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -23,8 +23,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import webbrowser
-
 from .util import *
 import electroncash.web as web
 from electroncash.i18n import _
@@ -44,7 +42,6 @@ TX_ICONS = [
     "clock5.svg",
     "confirmed.svg",
 ]
-
 
 class HistoryList(MyTreeWidget):
     filter_columns = [2, 3, 4]  # Date, Description, Amount
@@ -231,7 +228,7 @@ class HistoryList(MyTreeWidget):
         if pr_key:
             menu.addAction(self.invoiceIcon, _("View invoice"), lambda: self.parent.show_invoice(pr_key))
         if tx_URL:
-            menu.addAction(_("View on block explorer"), lambda: webbrowser.open(tx_URL))
+            menu.addAction(_("View on block explorer"), lambda: webopen(tx_URL))
 
         run_hook("history_list_context_menu_setup", self, menu, item, tx_hash)  # Plugins can modify menu
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -26,7 +26,6 @@
 import sys, time, threading
 import os, json, traceback
 import shutil
-import webbrowser
 import csv
 from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
 import base64
@@ -647,9 +646,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         help_menu = menubar.addMenu(_("&Help"))
         help_menu.addAction(_("&About"), self.show_about)
         help_menu.addAction(_("&Check for updates..."), lambda: self.gui_object.show_update_checker(self))
-        help_menu.addAction(_("&Official website"), lambda: webbrowser.open("https://electroncash.org"))
+        help_menu.addAction(_("&Official website"), lambda: webopen("https://electroncash.org"))
         help_menu.addSeparator()
-        help_menu.addAction(_("Documentation"), lambda: webbrowser.open("http://electroncash.readthedocs.io/")).setShortcut(QKeySequence.HelpContents)
+        help_menu.addAction(_("Documentation"), lambda: webopen("http://electroncash.readthedocs.io/")).setShortcut(QKeySequence.HelpContents)
         help_menu.addAction(_("&Report Bug"), self.show_report_bug)
         help_menu.addSeparator()
         help_menu.addAction(_("&Donate to server"), self.donate_to_server)

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -4,6 +4,8 @@ import sys
 import platform
 import queue
 import threading
+import os
+import webbrowser
 from collections import namedtuple
 from functools import partial, wraps
 
@@ -1040,6 +1042,17 @@ def destroyed_print_error(qobject, msg=None):
         msg = "[{}] destroyed".format(name)
     qobject.destroyed.connect(lambda x=None,msg=msg: print_error(msg))
 
+def webopen(url: str):
+    if sys.platform == 'linux' and os.environ.get('APPIMAGE'):
+        # When on Linux webbrowser.open can fail in AppImage because it can't find the correct libdbus.
+        # We just fork the process and unset LD_LIBRARY_PATH before opening the URL.
+        # See https://github.com/spesmilo/electrum/issues/5425
+        if os.fork() == 0:
+            del os.environ['LD_LIBRARY_PATH']
+            webbrowser.open(url)
+            sys.exit(0)
+    else:
+        webbrowser.open(url)
 
 if __name__ == "__main__":
     app = QApplication([])


### PR DESCRIPTION
There was an issue where `webbrowser.open` would invoke a program like `kde-open5` that loaded the systems `libQt5DBus`, which was not satisfied with the AppImage's `libdbus`. To fix this we fork the
process, unset `LD_LIBRARY_PATH` and then open the URL.

See https://github.com/spesmilo/electrum/issues/5425