### PR TITLE
PyInstaller: Rebuild bootloader from source using MinGW

### DIFF
--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -17,6 +17,8 @@ set -e
 
 git checkout "$to_build" || fail "Could not branch or tag $to_build"
 
+GIT_COMMIT_HASH=$(git rev-parse HEAD)
+
 info "Clearing $here/build and $here/dist..."
 rm "$here"/build/* -fr
 rm "$here"/dist/* -fr
@@ -203,6 +205,7 @@ prepare_wine() {
         (
             cd pyinstaller
             git checkout -b pinned $PYINSTALLER_COMMIT
+            echo "const char *ec_tag = \"tagged by Electron-Cash@$GIT_COMMIT_HASH\";" >> ./bootloader/src/pyi_main.c
             cd bootloader
             python3 ./waf all CC=i686-w64-mingw32-gcc CFLAGS="-Wno-stringop-overflow -static"
         )

--- a/contrib/requirements/requirements-wine-build.txt
+++ b/contrib/requirements/requirements-wine-build.txt
@@ -6,5 +6,3 @@ pip
 setuptools
 pywin32-ctypes==0.1.2
 win-inet-pton==1.0.1
-pyinstaller==3.4
-


### PR DESCRIPTION
For this we use a PyInstaller that has the `windres` bug fixed and we set `gcc` to ignore the `strncpy` errors in the bootloader.

This results in a smaller binary that gets much less detections by anti-virus programs. The binary dynamically links `msvcrt.dll`, but that binary is available by default on every system we support.

See https://github.com/EchterAgo/pyinstaller/commit/d1cdd726d6a9edc70150d5302453fb90fdd09bf2