### PR TITLE
AppImage: Remove unused binaries and some redundant build commands

### DIFF
--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -196,22 +196,35 @@ remove_emptydirs
 
 
 info "Removing some unneeded files to decrease binary size"
-rm -rf "$APPDIR"/usr/lib/python3.6/test
-rm -rf "$APPDIR"/usr/lib/python3.6/config-3.6m-x86_64-linux-gnu
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/translations/qtwebengine_locales
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/resources/qtwebengine_*
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/qml
-for component in Web Designer Qml Quick Location Test Xml ; do
-    rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt/lib/libQt5${component}*
-    rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt${component}*
+rm -rf "$APPDIR"/usr/{share,include}
+PYDIR="$APPDIR"/usr/lib/python3.6
+rm -rf "$PYDIR"/{test,ensurepip,lib2to3,idlelib,turtledemo}
+rm -rf "$PYDIR"/{ctypes,sqlite3,tkinter,unittest}/test
+rm -rf "$PYDIR"/distutils/{command,tests}
+rm -rf "$PYDIR"/config-3.6m-x86_64-linux-gnu
+rm -rf "$PYDIR"/site-packages/{opt,pip,setuptools,wheel}
+rm -rf "$PYDIR"/site-packages/Cython/Tests
+rm -rf "$PYDIR"/site-packages/Cython/*/Tests
+rm -rf "$PYDIR"/site-packages/Cryptodome/SelfTest
+rm -rf "$PYDIR"/site-packages/{psutil,qrcode,websocket}/tests
+for component in connectivity declarative help location multimedia quickcontrols2 serialport webengine websockets xmlpatterns ; do
+  rm -rf "$PYDIR"/site-packages/PyQt5/Qt/translations/qt${component}_*
+  rm -rf "$PYDIR"/site-packages/PyQt5/Qt/resources/qt${component}_*
 done
-rm -rf "$APPDIR"/usr/lib/python3.6/site-packages/PyQt5/Qt.so
+rm -rf "$PYDIR"/site-packages/PyQt5/Qt/{qml,libexec}
+rm -rf "$PYDIR"/site-packages/PyQt5/{pyrcc.so,pylupdate.so,uic}
+rm -rf "$PYDIR"/site-packages/PyQt5/Qt/plugins/{bearer,gamepads,geometryloaders,geoservices,playlistformats,position,printsupport,renderplugins,sceneparsers,sensors,sqldrivers,texttospeech,webview}
+for component in Bluetooth Concurrent Designer Help Location NetworkAuth Nfc Positioning PositioningQuick PrintSupport Qml Quick Sensors SerialPort Sql Test Web Xml ; do
+
+    rm -rf "$PYDIR"/site-packages/PyQt5/Qt/lib/libQt5${component}*
+    rm -rf "$PYDIR"/site-packages/PyQt5/Qt${component}*
+done
+rm -rf "$PYDIR"/site-packages/PyQt5/Qt.so
 
 # these are deleted as they were not deterministic; and are not needed anyway
 find "$APPDIR" -path '*/__pycache__*' -delete
-rm "$APPDIR"/usr/lib/python3.6/site-packages/pyblake2-*.dist-info/RECORD
-rm "$APPDIR"/usr/lib/python3.6/site-packages/hidapi-*.dist-info/RECORD
-rm "$APPDIR"/usr/lib/python3.6/site-packages/psutil-*.dist-info/RECORD
+rm -rf "$PYDIR"/site-packages/*.dist-info/
+rm -rf "$PYDIR"/site-packages/*.egg-info/
 
 
 find -exec touch -h -d '2000-11-11T11:11:11+00:00' {} +

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -82,8 +82,6 @@ MKSQUASHFS="$BUILDDIR/squashfskit/squashfs-tools/mksquashfs"
 
     "$CONTRIB"/make_secp || fail "Could not build libsecp"
 
-    find lib -type f -name libsecp\* -exec touch -d '2000-11-11T11:11:11+00:00' {} +
-
     popd
 )
 
@@ -92,8 +90,6 @@ MKSQUASHFS="$BUILDDIR/squashfskit/squashfs-tools/mksquashfs"
     pushd "$PROJECT_ROOT"
 
     "$CONTRIB"/make_zbar || fail "Could not build libzbar"
-
-    find lib -type f -name libzbar\* -exec touch -d '2000-11-11T11:11:11+00:00' {} +
 
     popd
 )


### PR DESCRIPTION
There are a lot of dupliacted files, testing files and unused libraries present in the AppImage. Removing these reduces the AppImage size significantly.

0be65ec5b94f7a8b0a6024dd55ea2f573dc6aa77853d0c3038b837a8d0923d70  dist/Electron-Cash-4.0.7-dev4-4-gcff5fb1-x86_64.AppImage

File size is reduced to 46MB