### PR TITLE
Localization: Default to system language and improve dialog

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3558,7 +3558,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         lang_help = _('Select which language is used in the GUI (after restart).')
         lang_label = HelpLabel(_('Language') + ':', lang_help)
         lang_combo = QComboBox()
-        from electroncash.i18n import languages, get_system_language_match
+        from electroncash.i18n import languages, get_system_language_match, match_language
 
         language_names = []
         language_keys = []
@@ -3566,17 +3566,22 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             language_keys.append(lang_code)
             lang_name = []
             lang_name.append(lang_def.name)
-            if not lang_code:
-                # System entry in languages list, get system setting
+            if lang_code == '':
+                # System entry in languages list (==''), gets system setting
                 sys_lang = get_system_language_match()
                 if sys_lang:
-                    lang_name.append(f' ({languages[sys_lang].name})')
+                    lang_name.append(f' [{languages[sys_lang].name}]')
             language_names.append(''.join(lang_name))
         lang_combo.addItems(language_names)
-        try:
-            index = language_keys.index(self.config.get("language",''))
-        except ValueError:
-            index = 0
+        conf_lang = self.config.get("language", '')
+        if conf_lang:
+            # The below code allows us to rename languages in saved config and
+            # have them still line up with languages in our languages dict.
+            # For example we used to save English as en_UK but now it's en_US
+            # and it will still match
+            conf_lang = match_language(conf_lang)
+        try: index = language_keys.index(conf_lang)
+        except ValueError: index = 0
         lang_combo.setCurrentIndex(index)
 
         if not self.config.is_modifiable('language'):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3559,19 +3559,17 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         lang_label = HelpLabel(_('Language') + ':', lang_help)
         lang_combo = QComboBox()
         from electroncash.i18n import languages, get_system_language_match
-        from electroncash.utils.unicode_tools import str_to_monospace
 
         language_names = []
         language_keys = []
         for (lang_code, lang_def) in languages.items():
             language_keys.append(lang_code)
             lang_name = []
-            if lang_code != '':
-                lang_name.append(f'({str_to_monospace(lang_code)}) ')
             lang_name.append(lang_def.name)
-            if lang_code == '':
+            if not lang_code:
+                # System entry in languages list, get system setting
                 sys_lang = get_system_language_match()
-                if sys_lang != '':
+                if sys_lang:
                     lang_name.append(f' ({languages[sys_lang].name})')
             language_names.append(''.join(lang_name))
         lang_combo.addItems(language_names)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3558,13 +3558,22 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         lang_help = _('Select which language is used in the GUI (after restart).')
         lang_label = HelpLabel(_('Language') + ':', lang_help)
         lang_combo = QComboBox()
-        from electroncash.i18n import languages
+        from electroncash.i18n import languages, get_system_language_match
+        from electroncash.utils.unicode_tools import str_to_monospace
 
         language_names = []
         language_keys = []
-        for item in languages.items():
-            language_keys.append(item[0])
-            language_names.append(item[1])
+        for (lang_code, lang_def) in languages.items():
+            language_keys.append(lang_code)
+            lang_name = []
+            if lang_code != '':
+                lang_name.append(f'({str_to_monospace(lang_code)}) ')
+            lang_name.append(lang_def.name)
+            if lang_code == '':
+                sys_lang = get_system_language_match()
+                if sys_lang != '':
+                    lang_name.append(f' ({languages[sys_lang].name})')
+            language_names.append(''.join(lang_name))
         lang_combo.addItems(language_names)
         try:
             index = language_keys.index(self.config.get("language",''))
@@ -3995,12 +4004,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         fiat_widgets.append((QLabel(_('Source')), ex_combo))
 
         tabs_info = [
+            (gui_widgets, _('General')),
             (fee_widgets, _('Fees')),
             (OrderedDict([
                 ( _("App-Global Options") , global_tx_widgets ),
                 ( _("Per-Wallet Options") , per_wallet_tx_widgets),
              ]), _('Transactions')),
-            (gui_widgets, _('General')),
             (fiat_widgets, _('Fiat')),
             (id_widgets, _('Identity')),
         ]

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -43,13 +43,19 @@ def set_language(x):
     if not x:
         # User hasn't selected a language so we default to the system language
         x = get_system_language_match()
+    elif x not in languages:
+        # Attempt to match passed-in language with a known one if not exact
+        # match.
+        x = match_language(x) or x
 
     if x:
         language = gettext.translation('electron-cash', LOCALE_DIR, fallback=True, languages=[x])
+        return x  # indicate to caller what code was actually used, if anything.
 
 def get_system_language_match() -> str:
     """
-    Returns the language code best matching the systems default language or None if none match.
+    Returns the language code best matching the systems default language or None
+    if no match.
     """
     try:
         if sys.platform == 'darwin':
@@ -69,8 +75,8 @@ def get_system_language_match() -> str:
 
 def match_language(language_code: str) -> str:
     """
-    Returns the language code from the languages dictionary that most closely matches the given
-    language code or None if none match.
+    Returns the language code from the languages dictionary that most closely
+    matches the given language code or None if no match.
     """
 
     if not language_code:
@@ -88,7 +94,7 @@ LanguageDef = namedtuple(
 languages: Dict[str, LanguageDef] = {
     '':      LanguageDef(
         name=_('System'),
-        matches=lambda c: False, excludes=lambda c: False
+        matches=lambda c: False, excludes=lambda c: True  # this never fuzzy matches anything
         ),
     'ar_SA': LanguageDef(
         name='العَرَبِيَّة‎',

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -22,10 +22,15 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import gettext, os
+import gettext
+import os
+import re
+import locale
+from typing import Dict
+from collections import namedtuple
 
 LOCALE_DIR = os.path.join(os.path.dirname(__file__), 'locale')
-language = gettext.translation('electron-cash', LOCALE_DIR, fallback = True)
+language = gettext.translation('electron-cash', LOCALE_DIR, fallback=True)
 
 def _(x):
     global language
@@ -33,39 +38,197 @@ def _(x):
 
 def set_language(x):
     global language
-    if x: language = gettext.translation('electron-cash', LOCALE_DIR, fallback = True, languages=[x])
 
+    if not x:
+        # User hasn't selected a language so we default to the system language
+        x = get_system_language_match()
 
-languages = {
-    '':_('Default'),
-    'ar_SA':_('Arabic'),
-    'cs_CZ':_('Czech'),
-    'da_DK':_('Danish'),
-    'de_DE':_('German'),
-    'eo_UY':_('Esperanto'),
-    'el_GR':_('Greek'),
-    'en_UK':_('English'),
-    'es_AR':_('Spanish (S. America)'),
-    'es_ES':_('Spanish'),
-    'fr_FR':_('French'),
-    'hu_HU':_('Hungarian'),
-    'hy_AM':_('Armenian'),
-    'id_ID':_('Indonesian'),
-    'it_IT':_('Italian'),
-    'ja_JP':_('Japanese'),
-    'ky_KG':_('Kyrgyz'),
-    'lv_LV':_('Latvian'),
-    'nl_NL':_('Dutch'),
-    'no_NO':_('Norwegian'),
-    'pl_PL':_('Polish'),
-    'pt_BR':_('Brasilian'),
-    'pt_PT':_('Portuguese'),
-    'ro_RO':_('Romanian'),
-    'ru_RU':_('Russian'),
-    'sk_SK':_('Slovak'),
-    'sl_SI':_('Slovenian'),
-    'ta_IN':_('Tamil'),
-    'th_TH':_('Thai'),
-    'vi_VN':_('Vietnamese'),
-    'zh_CN':_('Chinese')
-    }
+    if x:
+        language = gettext.translation('electron-cash', LOCALE_DIR, fallback=True, languages=[x])
+
+def get_system_language_match() -> str:
+    """
+    Returns the language code best matching the systems default language or None if none match.
+    """
+    try:
+        default_locale = locale.getdefaultlocale()[0]
+    except Exception:
+        return None
+    return match_language(default_locale)
+
+def match_language(language_code: str) -> str:
+    """
+    Returns the language code from the languages dictionary that most closely matches the given
+    language code or None if none match.
+    """
+
+    if not language_code:
+        return None
+
+    for (code, ldef) in languages.items():
+        if ldef.matches(language_code) and not ldef.excludes(language_code):
+            return code
+
+    return None
+
+LanguageDef = namedtuple(
+    'LanguageDef', ['name', 'matches', 'excludes'])
+
+languages: Dict[str, LanguageDef] = {
+    '':      LanguageDef(
+        name=_('System'),
+        matches=lambda c: False, excludes=lambda c: False
+        ),
+    'ar_SA': LanguageDef(
+        name='العَرَبِيَّة‎',
+        matches=lambda c: re.match('^ar.*', c), excludes=lambda c: False
+        ),
+    'bg_BG': LanguageDef(
+        name='Български',
+        matches=lambda c: re.match('^bg.*', c), excludes=lambda c: False
+        ),
+    'cs_CZ': LanguageDef(
+        name='Čeština',
+        matches=lambda c: re.match('^bg.*', c), excludes=lambda c: False
+        ),
+    'da_DK': LanguageDef(
+        name='Dansk',
+        matches=lambda c: re.match('^da.*', c), excludes=lambda c: False
+        ),
+    'de_DE': LanguageDef(
+        name='Deutsch',
+        matches=lambda c: re.match('^de.*', c), excludes=lambda c: False
+        ),
+    'el_GR': LanguageDef(
+        name='Ελληνικά',
+        matches=lambda c: re.match('^el.*', c), excludes=lambda c: False
+        ),
+    'eo_UY': LanguageDef(
+        name='Esperanto',
+        matches=lambda c: re.match('^eo.*', c), excludes=lambda c: False
+        ),
+    'en_US': LanguageDef(
+        name='English',
+        matches=lambda c: re.match('^en.*', c), excludes=lambda c: False
+        ),
+    'es_AR': LanguageDef(
+        name='Español (S. América)',
+        matches=lambda c: re.match('^es.*', c), excludes=lambda c: re.match('^es_(ES|MX)', c)
+        ),
+    'es_ES': LanguageDef(
+        name='Español',
+        matches=lambda c: re.match('^es_ES', c), excludes=lambda c: False
+        ),
+    'es_MX': LanguageDef(
+        name='Español (México)',
+        matches=lambda c: re.match('^es_MX', c), excludes=lambda c: False
+        ),
+    'fa_IR': LanguageDef(
+        name='فارسی',
+        matches=lambda c: re.match('^fa.*', c), excludes=lambda c: False
+        ),
+    'fr_FR': LanguageDef(
+        name='Français',
+        matches=lambda c: re.match('^fr.*', c), excludes=lambda c: False
+        ),
+    'hu_HU': LanguageDef(
+        name='Magyar',
+        matches=lambda c: re.match('^hu.*', c), excludes=lambda c: False
+        ),
+    'hy_AM': LanguageDef(
+        name='Հայաստան',
+        matches=lambda c: re.match('^hy.*', c), excludes=lambda c: False
+        ),
+    'id_ID': LanguageDef(
+        name='Bahasa Indonesia',
+        matches=lambda c: re.match('^id.*', c), excludes=lambda c: False
+        ),
+    'it_IT': LanguageDef(
+        name='Italiano',
+        matches=lambda c: re.match('^it.*', c), excludes=lambda c: False
+        ),
+    'ja_JP': LanguageDef(
+        name='日本語',
+        matches=lambda c: re.match('^ja.*', c), excludes=lambda c: False
+        ),
+    'ko_KR': LanguageDef(
+        name='한국어',
+        matches=lambda c: re.match('^ko.*', c), excludes=lambda c: False
+        ),
+    'ky_KG': LanguageDef(
+        name='кыргызча',
+        matches=lambda c: re.match('^ky.*', c), excludes=lambda c: False
+        ),
+    'lv_LV': LanguageDef(
+        name='Latviešu',
+        matches=lambda c: re.match('^lv.*', c), excludes=lambda c: False
+        ),
+    'nb_NO': LanguageDef(
+        name='Norsk',
+        matches=lambda c: re.match('^n[bno].*', c), excludes=lambda c: False
+        ),
+    'nl_NL': LanguageDef(
+        name='Nederlands',
+        matches=lambda c: re.match('^nl.*', c), excludes=lambda c: False
+        ),
+    'pl_PL': LanguageDef(
+        name='Polski',
+        matches=lambda c: re.match('^pl.*', c), excludes=lambda c: False
+        ),
+    'pt_BR': LanguageDef(
+        name='Português brasileiro',
+        matches=lambda c: re.match('^pt_BR', c), excludes=lambda c: False
+        ),
+    'pt_PT': LanguageDef(
+        name='Português',
+        matches=lambda c: re.match('^pt.*', c), excludes=lambda c: re.match('^pt_BR', c)
+        ),
+    'ro_RO': LanguageDef(
+        name='Românește',
+        matches=lambda c: re.match('^ro.*', c), excludes=lambda c: False
+        ),
+    'ru_RU': LanguageDef(
+        name='Русский',
+        matches=lambda c: re.match('^ru.*', c), excludes=lambda c: False
+        ),
+    'sk_SK': LanguageDef(
+        name='Slovenčina',
+        matches=lambda c: re.match('^sk.*', c), excludes=lambda c: False
+        ),
+    'sl_SI': LanguageDef(
+        name='Slovenščina',
+        matches=lambda c: re.match('^sl.*', c), excludes=lambda c: False
+        ),
+    'sv_SE': LanguageDef(
+        name='Svenska',
+        matches=lambda c: re.match('^sv.*', c), excludes=lambda c: False
+        ),
+    'ta_IN': LanguageDef(
+        name='தமிழ்',
+        matches=lambda c: re.match('^ta.*', c), excludes=lambda c: False
+        ),
+    'th_TH': LanguageDef(
+        name='ภาษาไทย',
+        matches=lambda c: re.match('^th.*', c), excludes=lambda c: False
+        ),
+    'tr_TR': LanguageDef(
+        name='Türkçe',
+        matches=lambda c: re.match('^tr.*', c), excludes=lambda c: False
+        ),
+    'uk_UA': LanguageDef(
+        name='Українська',
+        matches=lambda c: re.match('^uk.*', c), excludes=lambda c: False
+        ),
+    'vi_VN': LanguageDef(
+        name='Tiếng việt',
+        matches=lambda c: re.match('^vi.*', c), excludes=lambda c: False
+        ),
+    'zh_CN': LanguageDef(
+        name='普通話',
+        matches=lambda c: re.match('^zh.*', c), excludes=lambda c: re.match('^zh_TW', c)
+        ),
+    'zh_TW': LanguageDef(
+        name='台灣話',
+        matches=lambda c: re.match('^zh_TW', c), excludes=lambda c: False
+        ),
+}

--- a/lib/utils/macos.py
+++ b/lib/utils/macos.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+#
+# macos.py -  utility functions, mainly functions that call into CoreFoundation
+# and Foundation
+#
+# Copyright © 2018 Alexander Schlarb
+# Copyright © 2019 Calin Culianu <calin.culianu@gmail.com>
+#
+# License: MIT
+
+import sys
+
+if sys.platform != 'darwin':
+    raise ImportError("This file can only be used on macOS")
+
+from ctypes import (cdll, c_bool, c_char, c_ubyte, c_uint, c_void_p, c_char_p,
+                    c_ssize_t, POINTER, util, cast, create_string_buffer, sizeof,
+                    Structure, byref)
+
+# macOS framework libraries used
+cf_path = util.find_library('CoreFoundation')
+foundation_path = util.find_library('Foundation')
+if not cf_path or not foundation_path:
+    raise ImportError("This module requires the macOS Foundation libraries")
+
+cf = cdll.LoadLibrary(cf_path)
+foundation = cdll.LoadLibrary(foundation_path)
+
+# macOS Framework constants used
+NSApplicationSupportDirectory = 14
+NSCachesDirectory = 13
+NSUserDomainMask = 1
+kCFStringEncodingUTF8 = 0x08000100
+
+# Used for type annotation
+class _Void: pass
+
+# macOS CoreFoundation types used
+CFIndex = c_ssize_t
+CFIndex_p = POINTER(CFIndex)
+
+class CFArray(Structure):
+    _fields_ = []
+CFArray_p = POINTER(CFArray)
+
+class CFBundle(Structure):
+    _fields_ = []
+CFBundle_p = POINTER(CFBundle)
+
+class CFString(Structure):
+    _fields_ = []
+CFString_p = POINTER(CFString)
+
+class CFRange(Structure):
+    _fields_ = [('location', CFIndex), ('length', CFIndex)]
+
+
+# Boolean CFStringGetCString(CFStringRef theString, char *buffer, CFIndex bufferSize, CFStringEncoding encoding);
+cf.CFStringGetCString.restype = c_bool
+cf.CFStringGetCString.argtypes = [c_void_p, c_char_p, c_ssize_t, c_uint]
+
+# CFIndex CFStringGetLength(CFStringRef theString);
+cf.CFStringGetLength.restype = CFIndex
+cf.CFStringGetLength.argtypes = [CFString_p]
+
+# CFIndex CFStringGetBytes(CFStringRef theString, CFRange range, CFStringEncoding encoding, UInt8 lossByte, Boolean isExternalRepresentation, UInt8 *buffer, CFIndex maxBufLen, CFIndex *usedBufLen)
+cf.CFStringGetBytes.restype = CFIndex
+cf.CFStringGetBytes.argtypes = [CFString_p, CFRange, c_uint, c_ubyte, c_bool, c_char_p, CFIndex, CFIndex_p]
+
+# CFIndex CFArrayGetCount(CFArrayRef theArray);
+cf.CFArrayGetCount.restype = CFIndex
+cf.CFArrayGetCount.argtypes = [CFArray_p]
+
+# const void* CFArrayGetValueAtIndex(CFArrayRef theArray, CFIndex idx);
+cf.CFArrayGetValueAtIndex.restype = c_void_p
+cf.CFArrayGetValueAtIndex.argtypes = [CFArray_p, CFIndex]
+
+# void CFRelease(void *), basically
+cf.CFRelease.argtypes = [c_void_p]
+cf.CFRelease.restype = None
+
+def CFString2Str(cfstr: CFString_p) -> str:
+    l = cf.CFStringGetLength(cfstr)
+    r = CFRange(0, l)
+    blen = CFIndex(0)
+    lossbyte = c_ubyte(ord(b'?'))
+    slen = cf.CFStringGetBytes(cfstr, r, kCFStringEncodingUTF8, lossbyte, False, c_char_p(0), 0, byref(blen))
+    buf = create_string_buffer((blen.value+1) * sizeof(c_char))
+    slen = cf.CFStringGetBytes(cfstr, r, kCFStringEncodingUTF8, lossbyte, False, buf, CFIndex(blen.value+1), byref(blen))
+    if slen != l:
+        raise ValueError('Cannot retrieve c-string from cfstring')
+    buf = bytes(buf)
+    return buf[:blen.value].decode('utf-8')
+
+def CFArrayGetIndex(array: CFArray_p, idx: int, default=_Void) -> c_void_p:
+    length = cf.CFArrayGetCount(array)
+    if length > idx:
+        return cf.CFArrayGetValueAtIndex(array, idx)
+    elif default is not _Void:
+        return default
+    else:
+        raise IndexError("CoreFramework array index is out range: {} <= {}".format(length, idx))
+
+
+import pathlib
+# NSArray<NSString*>* NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory directory, NSSearchPathDomainMask domainMask, BOOL expandTilde);
+foundation.NSSearchPathForDirectoriesInDomains.restype = CFArray_p
+foundation.NSSearchPathForDirectoriesInDomains.argtypes = [c_uint, c_uint, c_bool]
+
+def get_user_directory(type: str) -> pathlib.Path:
+    """
+    Retrieve the macOS directory path for the given type
+    The `type` parameter must be one of: "application-support", "cache".
+    Example results:
+     - '/Users/calin/Library/Application Support' (for "application-support")
+     - '/Users/calin/Library/Caches' (for "cache")
+    Returns the discovered path on success, `None` otherwise.
+    """
+    if type == 'application-support':
+        ns_type = NSApplicationSupportDirectory
+    elif type == 'cache':
+        ns_type = NSCachesDirectory
+    else:
+        raise AssertionError('Unexpected directory type name')
+    array = foundation.NSSearchPathForDirectoriesInDomains(ns_type, NSUserDomainMask, c_bool(True))
+    result = CFArrayGetIndex(array, 0, None)
+    if result is not None:
+        return pathlib.Path(CFString2Str(cast(result, CFString_p)))
+
+
+# CFBundleRef CFBundleGetMainBundle(void);
+cf.CFBundleGetMainBundle.restype = CFBundle_p
+cf.CFBundleGetMainBundle.argtypes = []
+
+# CFStringRef CFBundleGetIdentifier(CFBundleRef bundle);
+cf.CFBundleGetIdentifier.restype = CFString_p
+cf.CFBundleGetIdentifier.argtypes = [CFBundle_p]
+
+def get_bundle_identifier() -> str:
+    """
+    Retrieve this app's bundle identifier
+    Example result: 'org.python.python'
+    Returns the bundle identifier on success, `None` otherwise.
+    """
+    bundle = cf.CFBundleGetMainBundle()
+    if bundle:
+        return CFString2Str(cf.CFBundleGetIdentifier(bundle))
+
+
+# CFArray CFLocaleCopyPreferredLanguages(void) // returns a copy of the current preferred languages for this user
+cf.CFLocaleCopyPreferredLanguages.restype = CFArray_p
+cf.CFLocaleCopyPreferredLanguages.argtypes = []
+
+def get_preferred_languages():
+    ''' Returns a list of preferred languages queried from the system using
+    reliable macos calls.  This is because locale.getdefaultlocale() is
+    unreliable.  The returned list is of the form:
+
+    [
+        'en_US', 'ro_US', 'el_US', 'ru_US'
+    ]
+
+    And always contains at least 1 item.
+    '''
+    array = cf.CFLocaleCopyPreferredLanguages()
+    ret = []
+    if array:
+        try:
+            for idx in range( cf.CFArrayGetCount(array) ):
+                ret.append(CFString2Str(cast(cf.CFArrayGetValueAtIndex(array, idx), CFString_p)).replace('-', '_'))
+        finally:
+            # unconditional release (free) resources
+            cf.CFRelease(array)
+    return ret

--- a/lib/utils/unicode_tools.py
+++ b/lib/utils/unicode_tools.py
@@ -1,0 +1,48 @@
+# Electron Cash - lightweight Bitcoin client
+# Copyright (C) 2019 Axel Gembe <derago@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+def char_to_monospace(char: str) -> str:
+    if char >= 'A' and char <= 'Z':
+        return chr(ord(char) - ord('A') + 0x1d670)
+    elif char >= 'a' and char <= 'z':
+        return chr(ord(char) - ord('a') + 0x1d68a)
+    elif char >= '0' and char <= '9':
+        return chr(ord(char) - ord('0') + 0x1d7f6)
+    return char
+
+
+def str_to_monospace(text: str) -> str:
+    return ''.join(char_to_monospace(c) for c in text)
+
+
+def char_to_fullwidth(char: str) -> str:
+    if char >= '!' and char <= '~':
+        return chr(ord(char) - ord('!') + 0xff01)
+    elif char == ' ':
+        return chr(0x2003)  # em space
+    return char
+
+
+def str_to_fullwidth(text: str) -> str:
+    return ''.join(char_to_monospace(c) for c in text)

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
     packages=[
         'electroncash',
         'electroncash.qrreaders',
+        'electroncash.utils',
         'electroncash_gui',
         'electroncash_gui.qt',
         'electroncash_gui.qt.qrreader',


### PR DESCRIPTION
When the user has not chosen a language we now use the system language or its best match by default. This takes care of selecting for example es_AR as the preferred match for Spanish.

In the dialog we now show the language name translated to that language and we include the language code in monospace as a prefix to help sorting.

We move the General tab to the first position of the settings dialog which makes it slightly easier to find the language setting in case the UI is in the wrong language.

Finally we forgot to include 8 languages that are on Crowdin but not in the GUI (Bulgarian, Mexican, Farsi, Korean, Swedish, Turkish, Ukranian and Traditional Chinese)