### PR TITLE
AppImage: Make color emojis available on more platforms

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1604
+++ b/contrib/build-linux/appimage/Dockerfile_ub1604
@@ -11,7 +11,6 @@ RUN apt-get update -q && \
         autoconf=2.69-9 \
         libtool=2.4.6-0.1 \
         xz-utils=5.1.1alpha+20120614-2ubuntu2 \
-        libssl-dev=1.0.2g-1ubuntu4.15 \
         libffi-dev=3.2.1-4 \
         libncurses5-dev=6.0+20160213-1ubuntu1 \
         libsqlite3-dev=3.11.0-1ubuntu1.2 \
@@ -34,11 +33,15 @@ RUN sed -i -e 's/xenial/bionic/' /etc/apt/sources.list
 # The Ubuntu 16.04 freetype / fontconfig does not seem to properly support
 # color emojis. To support those we get a newer freetype / fontconfig combo
 # from the Ubuntu 18.04 repo.
+# We also install OpenSSL 1.1 to have that be available accross all the
+# platforms we support.
 RUN apt-get update -q && \
     apt-get install -qy \
         zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
         libfreetype6=2.8.1-2ubuntu2 \
         libfontconfig1=2.12.6-0ubuntu2 \
+        libssl-dev=1.1.0g-2ubuntu4.3 \
+        libssl1.1=1.1.0g-2ubuntu4.3 \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/contrib/build-linux/appimage/Dockerfile_ub1604
+++ b/contrib/build-linux/appimage/Dockerfile_ub1604
@@ -12,7 +12,6 @@ RUN apt-get update -q && \
         libtool=2.4.6-0.1 \
         xz-utils=5.1.1alpha+20120614-2ubuntu2 \
         libssl-dev=1.0.2g-1ubuntu4.15 \
-        zlib1g-dev=1:1.2.8.dfsg-2ubuntu4.1 \
         libffi-dev=3.2.1-4 \
         libncurses5-dev=6.0+20160213-1ubuntu1 \
         libsqlite3-dev=3.11.0-1ubuntu1.2 \
@@ -21,6 +20,25 @@ RUN apt-get update -q && \
         gettext=0.19.7-2ubuntu3.1 \
         pkg-config=0.29.1-0ubuntu1 \
         libdbus-1-3=1.10.6-1ubuntu3.4 \
+        && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && \
+    apt-get clean
+
+# Hack to switch from xenial to bionic. Normally you shouldn't mix these but
+# if you do, you need to make sure that what you install doesn't cause
+# conflicts. Best to install only packages with very few dependencies from
+# the newer version.
+RUN sed -i -e 's/xenial/bionic/' /etc/apt/sources.list
+
+# The Ubuntu 16.04 freetype / fontconfig does not seem to properly support
+# color emojis. To support those we get a newer freetype / fontconfig combo
+# from the Ubuntu 18.04 repo.
+RUN apt-get update -q && \
+    apt-get install -qy \
+        zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
+        libfreetype6=2.8.1-2ubuntu2 \
+        libfontconfig1=2.12.6-0ubuntu2 \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/contrib/build-linux/appimage/Dockerfile_ub1604
+++ b/contrib/build-linux/appimage/Dockerfile_ub1604
@@ -20,6 +20,7 @@ RUN apt-get update -q && \
         libudev-dev=229-4ubuntu21.21 \
         gettext=0.19.7-2ubuntu3.1 \
         pkg-config=0.29.1-0ubuntu1 \
+        libdbus-1-3=1.10.6-1ubuntu3.4 \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -147,12 +147,8 @@ info "Finalizing AppDir"
 
     cd "$APPDIR"
     # copy system dependencies
-    # note: temporarily move PyQt5 out of the way so
-    # we don't try to bundle its system dependencies.
-    mv "$APPDIR/usr/lib/python3.6/site-packages/PyQt5" "$BUILDDIR"
     copy_deps
     move_lib
-    mv "$BUILDDIR/PyQt5" "$APPDIR/usr/lib/python3.6/site-packages"
 
     # apply global appimage blacklist to exclude stuff
     # move usr/include out of the way to preserve usr/include/python3.6m.
@@ -161,9 +157,11 @@ info "Finalizing AppDir"
     mv usr/include.tmp usr/include
 ) || fail "Could not finalize AppDir"
 
-# We copy libusb here because it is on the AppImage excludelist and it can cause problems if we use system libusb
-info "Copying libusb"
-cp -f /usr/lib/x86_64-linux-gnu/libusb-1.0.so "$APPDIR/usr/lib/libusb-1.0.so" || fail "Could not copy libusb"
+# We copy some libraries here that are on the AppImage excludelist
+info "Copying additional libraries"
+
+# On some systems it can cause problems to use the system libusb
+cp -f /usr/lib/x86_64-linux-gnu/libusb-1.0.so "$APPDIR"/usr/lib/x86_64-linux-gnu || fail "Could not copy libusb"
 
 info "Stripping binaries of debug symbols"
 # "-R .note.gnu.build-id" also strips the build id

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -163,6 +163,15 @@ info "Copying additional libraries"
 # On some systems it can cause problems to use the system libusb
 cp -f /usr/lib/x86_64-linux-gnu/libusb-1.0.so "$APPDIR"/usr/lib/x86_64-linux-gnu || fail "Could not copy libusb"
 
+# Ubuntu 14.04 lacks a recent enough libfreetype / libfontconfig, so we include one here
+mkdir "$APPDIR"/usr/lib/fonts
+cp -f /usr/lib/x86_64-linux-gnu/libfreetype.so.6 "$APPDIR"/usr/lib/fonts || fail "Could not copy libfreetype"
+cp -f /usr/lib/x86_64-linux-gnu/libfontconfig.so.1 "$APPDIR"/usr/lib/fonts || fail "Could not copy libfontconfig"
+cp "$CONTRIB/build-linux/appimage/test-freetype.py" "$APPDIR"
+
+# libfreetype needs a recent enough zlib
+cp -f /lib/x86_64-linux-gnu/libz.so.1 "$APPDIR"/usr/lib/x86_64-linux-gnu || fail "Could not copy zlib"
+
 info "Stripping binaries of debug symbols"
 # "-R .note.gnu.build-id" also strips the build id
 strip_binaries()

--- a/contrib/build-linux/appimage/apprun.sh
+++ b/contrib/build-linux/appimage/apprun.sh
@@ -3,9 +3,14 @@
 set -e
 
 APPDIR="$(dirname "$(readlink -e "$0")")"
+PYTHON="${APPDIR}/usr/bin/python3.6"
 
 export LD_LIBRARY_PATH="${APPDIR}/usr/lib/:${APPDIR}/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
 export PATH="${APPDIR}/usr/bin:${PATH}"
 export LDFLAGS="-L${APPDIR}/usr/lib/x86_64-linux-gnu -L${APPDIR}/usr/lib"
 
-exec "${APPDIR}/usr/bin/python3.6" -s "${APPDIR}/usr/bin/electron-cash" "$@"
+if ! "$PYTHON" -s "${APPDIR}/test-freetype.py" ; then
+    export LD_LIBRARY_PATH="${APPDIR}/usr/lib/fonts${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
+fi
+
+exec "$PYTHON" -s "${APPDIR}/usr/bin/electron-cash" "$@"

--- a/contrib/build-linux/appimage/test-freetype.py
+++ b/contrib/build-linux/appimage/test-freetype.py
@@ -1,0 +1,40 @@
+# Electron Cash - lightweight Bitcoin client
+# Copyright (C) 2019 Axel Gembe <derago@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Tests if the system has libfreetype.so.6 and FT_Done_MM_Var is defined.
+The AppImage bundles libfreetype version 2.8 and FT_Done_MM_Var has been
+added in version 2.9. If this script returns success it means the system
+has a newer freetype library than we bundle and we should use that instead.
+"""
+
+import ctypes
+import sys
+
+try:
+    freetype = ctypes.CDLL('libfreetype.so.6')
+    freetype.FT_Done_MM_Var
+except Exception:
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
This makes it possible to support color emojis even on Ubuntu 14.04.

Please merge #1489, #1490 & #1491 first and then I'll rebase this.