### PR TITLE
Translations: Add support for plural forms

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -34,7 +34,7 @@ from PyQt5.QtWidgets import *
 
 from electroncash.address import Address, PublicKey, ScriptOutput
 from electroncash.bitcoin import base_encode
-from electroncash.i18n import _
+from electroncash.i18n import _, ngettext
 from electroncash.plugins import run_hook
 from electroncash import web
 
@@ -372,11 +372,12 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
             amount_str = _("Amount received:") + ' %s'% format_amount(amount) + ' ' + base_unit
         else:
             amount_str = _("Amount sent:") + ' %s'% format_amount(-amount) + ' ' + base_unit
-        size_str = _("Size:") + ' %d bytes'% size
+        size_str = _("Size: {size} bytes").format(size=size)
         fee_str = _("Fee") + ": "
         if fee is not None:
-            fee_str += format_amount(fee) + ' ' + base_unit
-            fee_str += '  ( %s ) '%  self.main_window.format_fee_rate(fee/size*1000)
+            fee_str = _("Fee: {fee_amount} {fee_unit} ( {fee_rate} )")
+            fee_str = fee_str.format(fee_amount=format_amount(fee), fee_unit=base_unit,
+                                     fee_rate=self.main_window.format_fee_rate(fee/size*1000))
             dusty_fee = self.tx.ephemeral.get('dust_to_fee', 0)
             if dusty_fee:
                 fee_str += ' <font color=#999999>' + (_("( %s in dust was added to fee )") % format_amount(dusty_fee)) + '</font>'
@@ -409,7 +410,11 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0,0,0,0)
 
-        hbox.addWidget(QLabel(_("Inputs") + ' (%d)'%len(self.tx.inputs())))
+        num_inputs = len(self.tx.inputs())
+        inputs_lbl_text = ngettext("Input", "Inputs ({num_inputs})", num_inputs)
+        if num_inputs > 1:
+            inputs_lbl_text = inputs_lbl_text.format(num_inputs=num_inputs)
+        hbox.addWidget(QLabel(inputs_lbl_text))
 
 
         hbox.addSpacerItem(QSpacerItem(20, 0))  # 20 px padding
@@ -450,7 +455,12 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0,0,0,0)
         vbox.addLayout(hbox)
-        hbox.addWidget(QLabel(_("Outputs") + ' (%d)'%len(self.tx.outputs())))
+
+        num_outputs = len(self.tx.outputs())
+        outputs_lbl_text = ngettext("Output", "Outputs ({num_outputs})", num_outputs)
+        if num_outputs > 1:
+            outputs_lbl_text = outputs_lbl_text.format(num_outputs=num_outputs)
+        hbox.addWidget(QLabel(outputs_lbl_text))
 
         box_char = "█"
         self.recv_legend = QLabel("<font color=" + ColorScheme.GREEN.as_color(background=True).name() + ">" + box_char + "</font> = " + _("Receiving Address"))

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -37,6 +37,10 @@ def _(x):
     global language
     return language.gettext(x)
 
+def ngettext(singular: str, plural: str, n: int) -> str:
+    global language
+    return language.ngettext(singular, plural, n)
+
 def set_language(x):
     global language
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -39,7 +39,7 @@ from collections import defaultdict
 from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
 from functools import partial
 
-from .i18n import _
+from .i18n import _, ngettext
 from .util import NotEnoughFunds, ExcessiveFee, PrintError, UserCancelled, profiler, format_satoshis, format_time, finalization_print_error
 
 from .address import Address, Script, ScriptOutput, PublicKey
@@ -646,7 +646,8 @@ class Abstract_Wallet(PrintError):
                 height, conf, timestamp = self.get_tx_height(tx_hash)
                 if height > 0:
                     if conf:
-                        status = _("{} confirmations").format(conf)
+                        status = ngettext("{conf} confirmation", "{conf} confirmations", conf)
+                        status = status.format(conf=conf)
                     else:
                         status = _('Not verified')
                 else:


### PR DESCRIPTION
We add an ngettext function to the i18n module and change some translation strings to use it. This also improves some translation strings.