### PR TITLE
Liberalize transaction deserializer and restrict merkle node checker.

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -349,10 +349,8 @@ def deserialize(raw):
     start = vds.read_cursor
     d['version'] = vds.read_int32()
     n_vin = vds.read_compact_size()
-    assert n_vin != 0
     d['inputs'] = [parse_input(vds) for i in range(n_vin)]
     n_vout = vds.read_compact_size()
-    assert n_vout != 0
     d['outputs'] = [parse_output(vds, i) for i in range(n_vout)]
     d['lockTime'] = vds.read_uint32()
     if vds.can_read_more():

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -23,7 +23,7 @@
 from .util import ThreadJob, bh2u
 from .bitcoin import Hash, hash_decode, hash_encode
 from . import networks
-from .transaction import Transaction
+from .transaction import Transaction, SerializationError
 
 class InnerNodeOfSpvProofIsValidTx(Exception): pass
 
@@ -167,26 +167,35 @@ class SPV(ThreadJob):
         tx = Transaction(raw_tx)
         try:
             tx.deserialize()
-            # Besides deserializing, we perfom additional checks to reduce the
-            # chance that a legitimate merkle node trips us up.
-            # A legitimate txn of 64 bytes can only have 1 input and 1 output.
-            txin, = tx.inputs()
-            txout, = tx.outputs()
-            # Txes can be at most 1 MB and and each output requires >= 9 bytes;
-            # Thus prevout_n must be either
-            #   <= 111111 for a real spend, or
-            #   == 0xffffffff for a coinbase.
-            assert txin['prevout_n'] <= 111111 or txin['prevout_n'] == 0xffffffff
-            # Output amount can't possibly be more than 21 million bitcoin.
-            assert txout['value'] < 21e14
-            # The chance of reaching this point with a random 64-byte node is 3e-18.
-            # This could be reduced further only slightly by:
-            #  - restricting locktime.
-            #  - ensuring scriptSig is nontruncated.
-        except:
-            pass
-        else:
-            raise InnerNodeOfSpvProofIsValidTx()
+        except SerializationError:
+            return
+
+        # Besides deserializing, we perfom additional checks to reduce the
+        # chance that a legitimate merkle node give false positive.
+
+        # A legitimate txn of 64 bytes can only have 1 input and 1 output.
+        try:
+            (txin,) = tx.inputs()
+            (txout,) = tx.outputs()
+        except ValueError:
+            return
+
+        # Txes can be at most 1 MB and and each output requires >= 9 bytes;
+        # Thus prevout_n must <= 111111 for a real spend; it may also be
+        # max uint32 for a coinbase.
+        if 111111 < txin['prevout_n'] < 0xff_ff_ff_ff:
+            return
+
+        # Output amount can't possibly be more than 21 million bitcoin.
+        if txout['value'] > 21_000_000_0000_0000:
+            return
+
+        # The chance of reaching this point with a random 64-byte node is 3e-18.
+        # This could be reduced further, but only, slightly by:
+        #  - restricting locktime.
+        #  - ensuring scriptSig is nontruncated.
+        #  - restricting version (if a version consensus rule is ever introduced)
+        raise InnerNodeOfSpvProofIsValidTx()
 
     def undo_verifications(self):
         height = self.blockchain.get_base_height()

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -167,7 +167,7 @@ class SPV(ThreadJob):
         tx = Transaction(raw_tx)
         try:
             tx.deserialize()
-        except SerializationError:
+        except:
             return
 
         # Besides deserializing, we perfom additional checks to reduce the
@@ -186,8 +186,8 @@ class SPV(ThreadJob):
         if 111111 < txin['prevout_n'] < 0xff_ff_ff_ff:
             return
 
-        # Output amount can't possibly be more than 21 million bitcoin.
-        if txout['value'] > 21_000_000_0000_0000:
+        # Output amount can't possibly be more than 21 million bitcoin, ie 21e14.
+        if txout['value'] > 2_100_000_000_000_000:
             return
 
         # The chance of reaching this point with a random 64-byte node is 3e-18.


### PR DESCRIPTION
In #1457, the transaction deserializer was restricted for the sake of the
merkle node checker, however I realized that the merkle node checker can
do strict checks on its own, and the transaction deserializer can be
liberal which may be useful for smart contracts (e.g., crowd funds using
ANYONECANPAY that start out with 0 inputs).

Besides that advantage, this also further strictifies the merkle node checker
so its false positive rate is 1 million times lower.

Reviewers: please examine for runtime errors since this code runs
**extremely** infrequently: the txin, and txout, lines only get passed by
1 in a billion transactions. A runtime error will simply be ignored here,
but unfortunately this disables the point of this code.