### PR TITLE
merkle node checker fixup

### DIFF
--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -275,9 +275,10 @@ class SPV(ThreadJob):
             return
 
         # Txes can be at most 1 MB and and each output requires >= 9 bytes;
-        # Thus prevout_n must <= 111111 for a real spend; it may also be
-        # max uint32 for a coinbase.
-        if 111111 < txin['prevout_n'] < 0xff_ff_ff_ff:
+        # Thus prevout_n must <= 111111 for a normal transaction.
+        # If prevout_n is larger it still could in principle be a coinbase
+        # transaction, but then the input txid must be zeroed out.
+        if txin['prevout_n'] > 111111 and txin['prevout_hash'] != '00'*32:
             return
 
         # Output amount can't possibly be more than 21 million bitcoin, ie 21e14.


### PR DESCRIPTION
I just realized, I had a brainfart in #1506 : for coinbases there is actually no restriction on the prevout_n, rather it is just a *convention* to set it to 0xffffffff. Fortunately, we can still make use of the prevout_n range idea, since coinbases have another very distinguishing feature.

Reference:
https://github.com/Bitcoin-ABC/bitcoin-abc/blob/2f1adeefb67e985757cfae62b40c2edc5011b742/src/consensus/tx_verify.cpp#L233-L250
https://github.com/Bitcoin-ABC/bitcoin-abc/blob/2f1adeefb67e985757cfae62b40c2edc5011b742/src/primitives/transaction.h#L281-L283