### PR TITLE
Remove address output requirement for bitbox

### DIFF
--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -542,8 +542,6 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
 
             # Build pubkeyarray from outputs
             for _type, address, amount in tx.outputs():
-                if not _type == TYPE_ADDRESS:
-                    self.give_error(_("Only address outputs are supported by {}").format(self.name))
                 info = tx.output_info.get(address)
                 if info is not None:
                     index, xpubs, m, script_type = info


### PR DESCRIPTION
the check seems to prevent op_return transactions.