### PR TITLE
HW wallets: Generalize the validate_op_return_output_and_get_data

### DIFF
--- a/plugins/hw_wallet/plugin.py
+++ b/plugins/hw_wallet/plugin.py
@@ -90,9 +90,15 @@ def is_any_tx_output_on_change_branch(tx: Transaction) -> bool:
 
 def validate_op_return_output_and_get_data(output: tuple,        # tuple(typ, 'address', amount)
                                            max_size: int = 220,  # in bytes
-                                           max_pushes: int = 1   # number of pushes supported after the OP_RETURN, most HW wallets support only 1 push, some more than 1.
+                                           max_pushes: int = 1   # number of pushes supported after the OP_RETURN, most HW wallets support only 1 push, some more than 1.  Specify None to omit the number-of-pushes check.
                                            ) -> bytes:  # will return address.script[2:] (everyting after the first OP_RETURN & PUSH bytes)
     _type, address, _amount = output
+
+    if max_pushes is None:
+        # Caller says "no limit", so just to keep the below code simple, we
+        # do this and effectively sets the limit on pushes to "unlimited",
+        # since there can never be more pushes than bytes in the payload!
+        max_pushes = max_size
 
     assert max_pushes >= 1
 

--- a/plugins/hw_wallet/plugin.py
+++ b/plugins/hw_wallet/plugin.py
@@ -112,7 +112,7 @@ def validate_op_return_output_and_get_data(output: tuple,        # tuple(typ, 'a
     if len(ops) < 1 or ops[0][0] != OpCodes.OP_RETURN:
         raise RuntimeError(_("Only OP_RETURN scripts are supported."))
 
-    if num_pushes > max_pushes or any(ops[i+1][1] is None for i in range(num_pushes)):
+    if num_pushes < 1 or num_pushes > max_pushes or any(ops[i+1][1] is None for i in range(num_pushes)):
         raise RuntimeError(ngettext("OP_RETURN is limited to {max_pushes} data push.",
                                     "OP_RETURN is limited to {max_pushes} data pushes.",
                                     max_pushes).format(max_pushes=max_pushes))

--- a/plugins/hw_wallet/plugin.py
+++ b/plugins/hw_wallet/plugin.py
@@ -25,7 +25,7 @@
 # SOFTWARE.
 
 from electroncash.plugins import BasePlugin, hook
-from electroncash.i18n import _
+from electroncash.i18n import _, ngettext
 from electroncash import Transaction
 from electroncash.bitcoin import TYPE_SCRIPT
 from electroncash.util import bfh, finalization_print_error
@@ -88,27 +88,38 @@ def is_any_tx_output_on_change_branch(tx: Transaction) -> bool:
                 return True
     return False
 
-def validate_op_return_output_and_get_data(output, max_size=220) -> bytes:
+def validate_op_return_output_and_get_data(output: tuple,        # tuple(typ, 'address', amount)
+                                           max_size: int = 220,  # in bytes
+                                           max_pushes: int = 1   # number of pushes supported after the OP_RETURN, most HW wallets support only 1 push, some more than 1.
+                                           ) -> bytes:  # will return address.script[2:] (everyting after the first OP_RETURN & PUSH bytes)
     _type, address, _amount = output
+
+    assert max_pushes >= 1
 
     if _type != TYPE_SCRIPT:
         raise Exception("Unexpected output type: {}".format(_type))
 
     ops = Script.get_ops(address.script)
 
+    num_pushes = len(ops) - 1
+
     if len(ops) < 1 or ops[0][0] != OpCodes.OP_RETURN:
         raise RuntimeError(_("Only OP_RETURN scripts are supported."))
 
-    if len(ops) != 2 or ops[1][1] is None:
-        raise RuntimeError(_("OP_RETURN is limited to a single data push."))
+    if num_pushes > max_pushes or any(ops[i+1][1] is None for i in range(num_pushes)):
+        raise RuntimeError(ngettext("OP_RETURN is limited to {max_pushes} data push.",
+                                    "OP_RETURN is limited to {max_pushes} data pushes.",
+                                    max_pushes).format(max_pushes=max_pushes))
 
-    if len(ops[1][1]) > max_size:
+    data = address.script[2:]  # caller expects everything after the OP_RETURN and PUSHDATA op
+
+    if len(data) > max_size:
         raise RuntimeError(_("OP_RETURN data size exceeds the maximum of {} bytes.".format(max_size)))
 
     if _amount != 0:
         raise RuntimeError(_("Amount for OP_RETURN output must be zero."))
 
-    return ops[1][1]
+    return data
 
 def only_hook_if_libraries_available(func):
     # note: this decorator must wrap @hook, not the other way around,

--- a/plugins/keepkey/keepkey.py
+++ b/plugins/keepkey/keepkey.py
@@ -446,7 +446,7 @@ class KeepKeyPlugin(HW_PluginBase):
             txoutputtype.amount = amount
             if _type == TYPE_SCRIPT:
                 txoutputtype.script_type = self.types.PAYTOOPRETURN
-                txoutputtype.op_return_data = validate_op_return_output_and_get_data(o)
+                txoutputtype.op_return_data = validate_op_return_output_and_get_data(o, max_pushes=1)
             elif _type == TYPE_ADDRESS:
                 txoutputtype.script_type = self.types.PAYTOADDRESS
                 txoutputtype.address = address.to_full_string(Address.FMT_CASHADDR, net=networks.MainNet)

--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -414,8 +414,11 @@ class Ledger_KeyStore(Hardware_KeyStore):
                         try:
                             # Ledger has a maximum output size of 200 bytes:
                             # https://github.com/LedgerHQ/ledger-app-btc/commit/3a78dee9c0484821df58975803e40d58fbfc2c38#diff-c61ccd96a6d8b54d48f54a3bc4dfa7e2R26
-                            # which gives us a maximum OP_RETURN payload size of 187 bytes.
-                            validate_op_return_output_and_get_data(o, max_size=187)
+                            # which gives us a maximum OP_RETURN payload size of
+                            # 187 bytes. It also apparently has no limit on
+                            # max_pushes, so we specify max_pushes=None so as
+                            # to bypass that check.
+                            validate_op_return_output_and_get_data(o, max_size=187, max_pushes=None)
                         except RuntimeError as e:
                             self.give_error('{}: {}'.format(self.device, str(e)))
                 info = tx.output_info.get(address)


### PR DESCRIPTION
Hopefully we can use this function to support OP_RETURNs with more than
1 pushdata (such as Cash Accounts).

This function is now generalized to verify the script for the number of
pushdatas that the caller expects (defaults to 1).