### PR TITLE
CashAccounts: Make all "copy" operations in app append the emoji char

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -319,9 +319,10 @@ class AddressList(MyTreeWidget):
                 ca_default = self._ca_get_default(ca_list)
                 for ca_info in ca_list:
                     ca_text = self.wallet.cashacct.fmt_info(ca_info, ca_info.minimal_chash)
+                    ca_text_em = self.wallet.cashacct.fmt_info(ca_info, ca_info.minimal_chash, emoji=True)
                     m = menu.addMenu(ca_info.emoji + " " + ca_text)
                     #a = menu.addAction(ca_info.emoji + " " + self.wallet.cashacct.fmt_info(ca_info, ca_info.minimal_chash), lambda: None)
-                    a = m.addAction(_("Copy Cash Account"), lambda x=None, text=ca_text: doCopy(text))
+                    a = m.addAction(_("Copy Cash Account"), lambda x=None, text=ca_text_em: doCopy(text))
                     a = m.addAction(_("Details") + "...", lambda: self.parent.show_address(addr))
                     a = m.addAction(_("View registration tx") + "...", lambda x=None, ca=ca_info: self.parent.do_process_from_txid(txid=ca.txid))
                     a = a_def = m.addAction(_("Make default for address"), lambda x=None, ca=ca_info: self._ca_set_default(ca, True))

--- a/gui/qt/cashacctqt.py
+++ b/gui/qt/cashacctqt.py
@@ -360,6 +360,7 @@ class InfoGroupBox(PrintError, QGroupBox):
             if not col:
                 row += 1
             info, min_chash, ca_string = item
+            ca_string_em = f"{ca_string} {info.emoji}"
             # Radio button (by itself in colum 0)
             rb = BUTTON_CLASS()
             rb.setObjectName("InfoGroupBoxButton")
@@ -417,9 +418,9 @@ class InfoGroupBox(PrintError, QGroupBox):
 
             if isinstance(parent, ElectrumWindow):
                 view_tx_lbl.linkActivated.connect(view_tx_link_activated)
-                copy_but.clicked.connect(lambda ignored=None, ca_string=ca_string, copy_but=copy_but:
-                                             parent.copy_to_clipboard(text=ca_string, tooltip=_('Cash Account copied to clipboard'), widget=copy_but) )
-                copy_but.setToolTip(_("Copy <b>{cash_account_name}</b>").format(cash_account_name=ca_string))
+                copy_but.clicked.connect(lambda ignored=None, ca_string_em=ca_string_em, copy_but=copy_but:
+                                             parent.copy_to_clipboard(text=ca_string_em, tooltip=_('Cash Account copied to clipboard'), widget=copy_but) )
+                copy_but.setToolTip(_("Copy <b>{cash_account_name}</b>").format(cash_account_name=ca_string_em))
             else:
                 view_tx_lbl.setHidden(True)
                 copy_but.setHidden(True)

--- a/gui/qt/contact_list.py
+++ b/gui/qt/contact_list.py
@@ -179,10 +179,12 @@ class ContactList(PrintError, MyTreeWidget):
             typ = i2c(item).type if item else 'unknown'
             ca_info = None
             if item and typ in ('cashacct', 'cashacct_W'):
+                ca_info = self.wallet.cashacct.get_verified(i2c(item).name)
                 if column == 1 and len(selected) == 1:
                     # hack .. for Cash Accounts just say "Copy Cash Account"
                     column_title = _('Cash Account')
-                ca_info = self.wallet.cashacct.get_verified(i2c(item).name)
+                    if ca_info:
+                        column_data = self.wallet.cashacct.fmt_info(ca_info, emoji=True)
             menu.addAction(_("Copy {}").format(column_title), lambda: self.parent.app.clipboard().setText(column_data))
             if item and column in self.editable_columns and self.on_permit_edit(item, column):
                 key = item.data(0, self.DataRoles.Contact)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1045,7 +1045,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 slf.info = info
             def on_copy(slf):
                 ''' overrides super class '''
-                QApplication.instance().clipboard().setText(slf.text()[3:]) # cut off the leading emoji
+                QApplication.instance().clipboard().setText(slf.text()[3:] + ' ' + slf.text()[:1]) # cut off the leading emoji, and add it to the end
                 QToolTip.showText(QCursor.pos(), _("Cash Account copied to clipboard"), slf)
             def on_network_qt(slf, event, args=None):
                 ''' pick up cash account changes and update receive tab. Called

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -772,7 +772,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
             if ca_script:
                 copy_list += [ ( _("Copy Address (Embedded)"), lambda: self._copy_to_clipboard(ca_script.address.to_ui_string(), o_text) ) ]
                 if ca_script.is_complete():
-                    text_getter = lambda: self.wallet.cashacct.fmt_info(cashacct.Info.from_script(ca_script, self.tx_hash))
+                    text_getter = lambda: self.wallet.cashacct.fmt_info(cashacct.Info.from_script(ca_script, self.tx_hash), emoji=True)
                     text_getter()  # go out to network to cache the shortest encoding for cash account name ahead of time...
                     copy_list += [ ( _("Copy Cash Account"), lambda: self._copy_to_clipboard(text_getter(), o_text) ) ]
         except (TypeError, ValueError, IndexError, KeyError) as e:

--- a/lib/cashacct.py
+++ b/lib/cashacct.py
@@ -840,9 +840,9 @@ class CashAcct(util.PrintError, verifier.SPVDelegate):
         name2#100;
         name3#101.1234567890;
 
-        If emoji=True, then we will prepend the emoji character like so:
+        If emoji=True, then we will append the emoji character like so:
 
-        "🌶 NilacTheGrim#123.45"
+        "NilacTheGrim#123.45; 🌶"
 
         (Note that the returned string will always end in a semicolon.)
 
@@ -853,12 +853,16 @@ class CashAcct(util.PrintError, verifier.SPVDelegate):
         if minimal_chash is None:
             minimal_chash = self.get_minimal_chash(name, number, chash)
         if minimal_chash: minimal_chash = '.' + minimal_chash
-        emojipart = f'{info.emoji} ' if emoji and info.emoji else ''
-        return f"{emojipart}{name}#{number}{minimal_chash};"
+        emojipart = f' {info.emoji}' if emoji and info.emoji else ''
+        return f"{name}#{number}{minimal_chash};{emojipart}"
 
 
     _number_re = re.compile(r'^[0-9]{3,}$')
     _collision_re = re.compile(r'^[0-9]{0,10}$')
+
+    @staticmethod
+    def strip_emoji(s : str) -> str:
+        return ''.join(filter(lambda x: x not in emoji_set, s))
 
     @classmethod
     def parse_string(cls, s : str) -> tuple:
@@ -876,6 +880,8 @@ class CashAcct(util.PrintError, verifier.SPVDelegate):
 
         Does not raise, merely returns None on all errors.'''
         s = s.strip()
+        while s and s[-1] in emoji_set:
+            s = s[:-1].strip() # strip trailing "<space><emoji>"
         while s.endswith(';'):
             s = s[:-1]  # strip trailing ;
         parts = s.split('#')


### PR DESCRIPTION
And all fields that accept cash accounts "accept" the emoji char if at
the end (it is stripped out internally and not used).

This makes it easier to eg copy/paste your cash account into a message,
Slack, Telegram, etc when giving it out.

Eg: "VoidPointer#26710; 🍌"

I'd like to know what people think of this -- not sure if we want to do this but it does make it easier to give out your cash account + emoji .. and does no harm.

I talked to Pokkst (the other wallet dev that has a wallet that supports Cash Accounts) and he says pasting such a string into his wallet will work (will do no harm).

So -- request for comments!