### PR TITLE
Add TOR service for electroncash.de & cashshuffle server

### DIFF
--- a/lib/servers.json
+++ b/lib/servers.json
@@ -130,6 +130,12 @@
         "s": "50002",
         "t": "50001",
         "version": "1.4"
+    },
+    "jktsologn7uprtwn7gsgmwuddj6rxsqmwc2vaug7jwcwzm2bxqnfpwad.onion": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
     }
 }
 

--- a/lib/servers_testnet.json
+++ b/lib/servers_testnet.json
@@ -19,7 +19,11 @@
         "s": "50004",
         "t": "50003"
     },
-    "testnet.electroncash.de": {
+    "jktsologn7uprtwn7gsgmwuddj6rxsqmwc2vaug7jwcwzm2bxqnfpwad.onion": {
+        "s": "50004",
+        "t": "50003"
+    },
+    "electroncash.de": {
         "s": "50004",
         "t": "50003"
     }

--- a/plugins/shuffle/servers.json
+++ b/plugins/shuffle/servers.json
@@ -18,5 +18,13 @@
 	"ecdkxftqvnievsmq.onion": {
 		"ssl": false,
 		"info": 8889
+	},
+	"cashshuffle.net": {
+		"ssl": true,
+		"info": 8080
+	},
+	"5sa45npeflx74qmk.onion": {
+		"ssl": false,
+		"info": 8081
 	}
 }


### PR DESCRIPTION
I have added a TOR service for electroncash.de

cashshuffle.net and the .onion service is currently configured as a 7 player shuffle server