### PR TITLE
Qt GUI Fix: On Python 3.7.3, PyQt5 5.12.3+, signals not cleaned up

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -69,7 +69,8 @@ class AddressList(MyTreeWidget):
         self._ca_cb_registered = False
         self._ca_minimal_chash_updated_signal.connect(self._ca_update_chash)
 
-        parent.ca_address_default_changed_signal.connect(self._ca_on_address_default_change)
+        self.parent.gui_object.cashaddr_toggled_signal.connect(self.update)
+        self.parent.ca_address_default_changed_signal.connect(self._ca_on_address_default_change)
 
         if not __class__._cashacct_icon:
             # lazy init the icon
@@ -80,6 +81,11 @@ class AddressList(MyTreeWidget):
         if self.wallet.network:
             self.wallet.network.unregister_callback(self._ca_updated_minimal_chash_callback)
             self._ca_cb_registered = False
+        # paranoia -- we have seen Qt not clean up the signal before the object is destroyed on Python 3.7.3 PyQt 5.12.3, see #1531
+        try: self.parent.gui_object.cashaddr_toggled_signal.disconnect(self.update)
+        except TypeError: pass
+        try: self.parent.ca_address_default_changed_signal.disconnect(self._ca_on_address_default_change)
+        except TypeError: pass
 
     def filter(self, p):
         ''' Reimplementation from superclass filter.  Chops off the

--- a/gui/qt/contact_list.py
+++ b/gui/qt/contact_list.py
@@ -75,12 +75,16 @@ class ContactList(PrintError, MyTreeWidget):
         if self.wallet.network:
             self.wallet.network.register_callback(self._ca_callback, ['ca_verified_tx', 'ca_updated_minimal_chash'] )
         self._ca_minimal_chash_updated_signal.connect(self._ca_update_chash)
+        self.parent.gui_object.cashaddr_toggled_signal.connect(self.update)
+
 
     def clean_up(self):
         self.cleaned_up = True
         try: self._ca_minimal_chash_updated_signal.disconnect(self._ca_update_chash)
         except TypeError: pass
         try: self.do_update_signal.disconnect(self.update)
+        except TypeError: pass
+        try: self.parent.gui_object.cashaddr_toggled_signal.disconnect(self.update)
         except TypeError: pass
         if self.wallet.network:
             self.wallet.network.unregister_callback(self._ca_callback)

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -61,6 +61,7 @@ class UTXOList(MyTreeWidget):
         self.setSortingEnabled(True)
         self.wallet = self.parent.wallet
         self.parent.ca_address_default_changed_signal.connect(self._ca_on_address_default_change)
+        self.parent.gui_object.cashaddr_toggled_signal.connect(self.update)
         self.utxos = list()
         # cache some values to avoid constructing Qt objects for every pass through self.on_update (this is important for large wallets)
         self.monospaceFont = QFont(MONOSPACE_FONT)
@@ -72,6 +73,10 @@ class UTXOList(MyTreeWidget):
 
     def clean_up(self):
         self.cleaned_up = True
+        try: self.parent.ca_address_default_changed_signal.disconnect(self._ca_on_address_default_change)
+        except TypeError: pass
+        try: self.parent.gui_object.cashaddr_toggled_signal.disconnect(self.update)
+        except TypeError: pass
 
     def if_not_dead(func):
         '''Boilerplate: Check if cleaned up, and if so, don't execute method'''


### PR DESCRIPTION
Closes #1531 

In particular the cashaddr_toggled_signal was connected to objects that
were since deleted. According to Qt (and PyQt) documentation the
connections should get auto-reaped.  But Axel Gember was getting
"Wrapped C++ object deleted" exceptions (#1531) related to this signal still
firing on deleted slots -- very rarely.

As a safety measure, we are now explicitly disconnecting this signal during window close
for objects that connect to the global gui_object.cashaddr_toggled_signal, as well as other associated signals.

This level of paranoia shouldn't be necessary but we did get a crash report -- and according to the API docs the impossible happened.  Hence this patch.
