### PR TITLE
Translation: Defer translation lookup of some strings

### DIFF
--- a/gui/qt/fee_slider.py
+++ b/gui/qt/fee_slider.py
@@ -29,7 +29,7 @@ class FeeSlider(QSlider):
         if self.config.has_custom_fee_rate():
             tooltip = _('Custom rate: ') + rate_str
         elif self.dyn:
-            tooltip = fee_levels[pos] + '\n' + rate_str
+            tooltip = _(fee_levels[pos]) + '\n' + rate_str
         else:
             tooltip = _('Fixed rate: ') + rate_str
             if self.config.has_fee_estimates():

--- a/gui/qt/invoice_list.py
+++ b/gui/qt/invoice_list.py
@@ -49,7 +49,7 @@ class InvoiceList(MyTreeWidget):
             requestor = pr.get_requestor()
             exp = pr.get_expiration_date()
             date_str = format_time(exp) if exp else _('Never')
-            item = QTreeWidgetItem([date_str, requestor, pr.memo, self.parent.format_amount(pr.get_amount(), whitespaces=True), pr_tooltips.get(status,'')])
+            item = QTreeWidgetItem([date_str, requestor, pr.memo, self.parent.format_amount(pr.get_amount(), whitespaces=True), _(pr_tooltips.get(status,''))])
             item.setIcon(4, QIcon(pr_icons.get(status)))
             item.setData(0, Qt.UserRole, key)
             item.setFont(1, QFont(MONOSPACE_FONT))

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1123,7 +1123,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.connect_fields(self, self.receive_amount_e, self.fiat_receive_e, None)
 
         self.expires_combo = QComboBox()
-        self.expires_combo.addItems([i[0] for i in expiration_values])
+        self.expires_combo.addItems([_(i[0]) for i in expiration_values])
         self.expires_combo.setCurrentIndex(3)
         self.expires_combo.setFixedWidth(self.receive_amount_e.width())
         msg = ' '.join([

--- a/gui/qt/request_list.py
+++ b/gui/qt/request_list.py
@@ -129,7 +129,7 @@ class RequestList(MyTreeWidget):
             requestor = req.get('name', '')
             amount_str = self.parent.format_amount(amount) if amount else ""
             item = QTreeWidgetItem([date, address.to_ui_string(), '', message,
-                                    amount_str, pr_tooltips.get(status,'')])
+                                    amount_str, _(pr_tooltips.get(status,''))])
             item.setData(0, Qt.UserRole, address)
             if signature is not None:
                 item.setIcon(2, QIcon(":icons/seal.svg"))

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -9,7 +9,6 @@ import webbrowser
 from collections import namedtuple
 from functools import partial, wraps
 
-from electroncash.i18n import _
 from electroncash.address import Address
 from electroncash.util import print_error, PrintError, Weak, finalization_print_error
 from electroncash.wallet import Abstract_Wallet
@@ -35,6 +34,8 @@ pr_icons = {
     PR_EXPIRED:":icons/expired.svg"
 }
 
+def _(message): return message
+
 pr_tooltips = {
     PR_UNPAID:_('Pending'),
     PR_PAID:_('Paid'),
@@ -47,6 +48,10 @@ expiration_values = [
     (_('1 week'), 7*24*60*60),
     (_('Never'), None)
 ]
+
+del _
+from electroncash.i18n import _
+
 
 
 class EnterButton(QPushButton):

--- a/lib/util.py
+++ b/lib/util.py
@@ -36,8 +36,6 @@ import subprocess
 from locale import localeconv
 from abc import ABC, abstractmethod
 
-from .i18n import _
-
 import queue
 
 def inv_dict(d):
@@ -48,7 +46,12 @@ base_units = {'BCH':8, 'mBCH':5, 'bits':2}
 inv_base_units = inv_dict(base_units)
 base_unit_labels = tuple(inv_base_units[dp] for dp in sorted(inv_base_units.keys(), reverse=True))  # ('BCH', 'mBCH', 'bits')
 
+def _(message): return message
+
 fee_levels = [_('Within 25 blocks'), _('Within 10 blocks'), _('Within 5 blocks'), _('Within 2 blocks'), _('In the next block')]
+
+del _
+from .i18n import _
 
 class NotEnoughFunds(Exception): pass
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -39,7 +39,7 @@ from collections import defaultdict
 from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
 from functools import partial
 
-from .i18n import _, ngettext
+from .i18n import ngettext
 from .util import NotEnoughFunds, ExcessiveFee, PrintError, UserCancelled, profiler, format_satoshis, format_time, finalization_print_error
 
 from .address import Address, Script, ScriptOutput, PublicKey, OpCodes
@@ -67,6 +67,8 @@ from .paymentrequest import InvoiceStore
 from .contacts import Contacts
 from . import cashacct
 
+def _(message): return message
+
 TX_STATUS = [
     _('Unconfirmed parent'),
     _('Low fee'),
@@ -74,7 +76,8 @@ TX_STATUS = [
     _('Not Verified'),
 ]
 
-
+del _
+from .i18n import _
 
 def relayfee(network):
     RELAY_FEE = 5000
@@ -1186,7 +1189,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         else:
             status = 3 + min(conf, 6)
         time_str = format_time(timestamp) if timestamp else _("unknown")
-        status_str = TX_STATUS[status] if status < 4 else time_str
+        status_str = _(TX_STATUS[status]) if status < 4 else time_str
         return status, status_str
 
     def relayfee(self):


### PR DESCRIPTION
Some strings get translated before the actual translation files are loaded. This patch changes it to use deferred translation as described in:

https://docs.python.org/3/library/gettext.html#deferred-translations

This finally makes the transaction status, request expiry and payment request tooltips translatable.