### PR TITLE
Windows & Linux - FreeType & fontconfig logic tweaks + prefs options

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -86,6 +86,11 @@ class ElectrumGui(QObject, PrintError):
         __class__.instance = self
         set_language(config.get('language'))
 
+        self.config = config
+        self.daemon = daemon
+        self.plugins = plugins
+        self.windows = []
+
         if self.windows_qt_use_freetype:
             # Use FreeType for font rendering on Windows. This fixes rendering
             # of the Schnorr sigil and allows us to load the Noto Color Emoji
@@ -126,10 +131,6 @@ class ElectrumGui(QObject, PrintError):
             QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
         if hasattr(QGuiApplication, 'setDesktopFileName'):
             QGuiApplication.setDesktopFileName('electron-cash.desktop')
-        self.config = config
-        self.daemon = daemon
-        self.plugins = plugins
-        self.windows = []
         self.app = QApplication(sys.argv)
         self._load_fonts()  # this needs to be done very early, before the font engine loads fonts.. out of paranoia
         self._exit_if_required_pyqt_is_missing()  # This may immediately exit the app if missing required PyQt5 modules, so it should also be done early.

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -310,6 +310,7 @@ class ElectrumGui(QObject, PrintError):
         did_set_custom_fontconfig = False
 
         if (sys.platform == 'linux'
+                and self.config.linux_qt_use_custom_fontconfig  # method-backed property, checks config settings
                 and not os.environ.get('FONTCONFIG_FILE')
                 and os.path.exists('/etc/fonts/fonts.conf')
                 and os.path.exists(linux_font_config_file)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -4092,6 +4092,19 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                     self.need_restart = True
                 freetype_chk.stateChanged.connect(on_freetype_chk)
                 gui_widgets.append((freetype_chk, None))
+            elif sys.platform in ('linux',):
+                # Enable/Disable the use of the fonts.xml FontConfig override
+                # (Linux only)
+                fontconfig_chk = QCheckBox(_('Use custom fontconfig for emojis'))
+                fontconfig_chk.setChecked(self.config.linux_qt_use_custom_fontconfig)
+                fontconfig_chk.setEnabled(self.config.is_modifiable('linux_qt_use_custom_fontconfig'))
+                fontconfig_chk.setToolTip(_("Enable/disable this option if you experience font rendering glitches (such as blurred text or monochrome emoji characters)"))
+                def on_fontconfig_chk():
+                    self.config.linux_qt_use_custom_fontconfig = fontconfig_chk.isChecked()  # property has a method backing it
+                    self.need_restart = True
+                fontconfig_chk.stateChanged.connect(on_fontconfig_chk)
+                gui_widgets.append((fontconfig_chk, None))
+
 
         # CashAddr control
         gui_widgets.append((None, None)) # spacer

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -4080,6 +4080,19 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             hidpi_chk.stateChanged.connect(on_hi_dpi_toggle)
             gui_widgets.append((hidpi_chk, None))
 
+            if sys.platform in ('win32', 'cygwin'):
+                # Enable/Disable the use of the FreeType library on Qt
+                # (Windows only)
+                freetype_chk = QCheckBox(_('Use FreeType for font rendering'))
+                freetype_chk.setChecked(self.config.windows_qt_use_freetype)
+                freetype_chk.setEnabled(self.config.is_modifiable('windows_qt_use_freetype'))
+                freetype_chk.setToolTip(_("Enable/disable this option if you experience font rendering glitches (such as blurred text or monochrome emoji characters)"))
+                def on_freetype_chk():
+                    self.config.windows_qt_use_freetype = freetype_chk.isChecked()  # property has a method backing it
+                    self.need_restart = True
+                freetype_chk.stateChanged.connect(on_freetype_chk)
+                gui_widgets.append((freetype_chk, None))
+
         # CashAddr control
         gui_widgets.append((None, None)) # spacer
         address_w = QGroupBox(_('Address Format'))

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -4084,11 +4084,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 # Enable/Disable the use of the FreeType library on Qt
                 # (Windows only)
                 freetype_chk = QCheckBox(_('Use FreeType for font rendering'))
-                freetype_chk.setChecked(self.config.windows_qt_use_freetype)
+                freetype_chk.setChecked(self.gui_object.windows_qt_use_freetype)
                 freetype_chk.setEnabled(self.config.is_modifiable('windows_qt_use_freetype'))
                 freetype_chk.setToolTip(_("Enable/disable this option if you experience font rendering glitches (such as blurred text or monochrome emoji characters)"))
                 def on_freetype_chk():
-                    self.config.windows_qt_use_freetype = freetype_chk.isChecked()  # property has a method backing it
+                    self.gui_object.windows_qt_use_freetype = freetype_chk.isChecked()  # property has a method backing it
                     self.need_restart = True
                 freetype_chk.stateChanged.connect(on_freetype_chk)
                 gui_widgets.append((freetype_chk, None))
@@ -4096,11 +4096,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 # Enable/Disable the use of the fonts.xml FontConfig override
                 # (Linux only)
                 fontconfig_chk = QCheckBox(_('Use custom fontconfig for emojis'))
-                fontconfig_chk.setChecked(self.config.linux_qt_use_custom_fontconfig)
+                fontconfig_chk.setChecked(self.gui_object.linux_qt_use_custom_fontconfig)
                 fontconfig_chk.setEnabled(self.config.is_modifiable('linux_qt_use_custom_fontconfig'))
                 fontconfig_chk.setToolTip(_("Enable/disable this option if you experience font rendering glitches (such as blurred text or monochrome emoji characters)"))
                 def on_fontconfig_chk():
-                    self.config.linux_qt_use_custom_fontconfig = fontconfig_chk.isChecked()  # property has a method backing it
+                    self.gui_object.linux_qt_use_custom_fontconfig = fontconfig_chk.isChecked()  # property has a method backing it
                     self.need_restart = True
                 fontconfig_chk.stateChanged.connect(on_fontconfig_chk)
                 gui_widgets.append((fontconfig_chk, None))

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -352,7 +352,8 @@ class SimpleConfig(PrintError):
         ''' Returns True iff we are windows and we are set to use freetype as
         the font engine.  This will always return false on platforms where the
         question doesn't apply. This config setting defaults to True for
-        Windows < Win10 and False otherwise. '''
+        Windows < Win10 and False otherwise. It is only relevant when
+        using the Qt GUI, however. '''
         return bool(sys.platform in ('win32', 'cygwin')
                     # We default windows_qt_use_freetype to True for Windows
                     # < Windows 10. This setting can be specified in the
@@ -365,6 +366,19 @@ class SimpleConfig(PrintError):
     def windows_qt_use_freetype(self, b):
         if self.is_modifiable('windows_qt_use_freetype') and sys.platform in ('win32', 'cygwin'):
             self.set_key('windows_qt_use_freetype', bool(b))
+
+    @property
+    def linux_qt_use_custom_fontconfig(self):
+        ''' Returns True iff we are Linux and we are set to use the fonts.xml
+        fontconfig override, False otherwise.  This config setting defaults to
+        True for all Linux, but only is relevant to Qt GUI. '''
+        return sys.platform in ('linux',) and self.get('linux_qt_use_custom_fontconfig', True)
+
+    @linux_qt_use_custom_fontconfig.setter
+    def linux_qt_use_custom_fontconfig(self, b):
+        if self.is_modifiable('linux_qt_use_custom_fontconfig') and sys.platform in ('linux',):
+            self.set_key('linux_qt_use_custom_fontconfig', bool(b))
+
 
 def read_user_config(path):
     """Parse and store the user config settings in electron-cash.conf into user_config[]."""

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -358,7 +358,7 @@ class SimpleConfig(PrintError):
         if sys.platform not in ('win32', 'cygwin'):
             return False
         try:
-            winver = int(platform.win32_ver()[0])
+            winver = float(platform.win32_ver()[0])  # '7', '8', '8.1', '10', etc
         except (AttributeError, ValueError, IndexError):
             # We can get here if cygwin, which has an empty win32_ver tuple
             # in some cases.

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -3,6 +3,7 @@ import threading
 import time
 import os
 import stat
+import sys
 
 from . import util
 from copy import deepcopy
@@ -346,6 +347,24 @@ class SimpleConfig(PrintError):
             device = ''
         return device
 
+    @property
+    def windows_qt_use_freetype(self):
+        ''' Returns True iff we are windows and we are set to use freetype as
+        the font engine.  This will always return false on platforms where the
+        question doesn't apply. This config setting defaults to True for
+        Windows < Win10 and False otherwise. '''
+        return bool(sys.platform in ('win32', 'cygwin')
+                    # We default windows_qt_use_freetype to True for Windows
+                    # < Windows 10. This setting can be specified in the
+                    # Preferences dialog.
+                    and self.get('windows_qt_use_freetype',
+                                 bool(hasattr(sys, 'getwindowsversion')
+                                      and sys.getwindowsversion() < (10, 0))))
+
+    @windows_qt_use_freetype.setter
+    def windows_qt_use_freetype(self, b):
+        if self.is_modifiable('windows_qt_use_freetype') and sys.platform in ('win32', 'cygwin'):
+            self.set_key('windows_qt_use_freetype', bool(b))
 
 def read_user_config(path):
     """Parse and store the user config settings in electron-cash.conf into user_config[]."""

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -372,7 +372,7 @@ class SimpleConfig(PrintError):
         ''' Returns True iff we are Linux and we are set to use the fonts.xml
         fontconfig override, False otherwise.  This config setting defaults to
         True for all Linux, but only is relevant to Qt GUI. '''
-        return sys.platform in ('linux',) and self.get('linux_qt_use_custom_fontconfig', True)
+        return bool(sys.platform in ('linux',) and self.get('linux_qt_use_custom_fontconfig', True))
 
     @linux_qt_use_custom_fontconfig.setter
     def linux_qt_use_custom_fontconfig(self, b):

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -3,8 +3,6 @@ import threading
 import time
 import os
 import stat
-import sys
-import platform
 
 from . import util
 from copy import deepcopy
@@ -347,43 +345,6 @@ class SimpleConfig(PrintError):
         if device == 'default':
             device = ''
         return device
-
-    @property
-    def windows_qt_use_freetype(self):
-        ''' Returns True iff we are windows and we are set to use freetype as
-        the font engine.  This will always return false on platforms where the
-        question doesn't apply. This config setting defaults to True for
-        Windows < Win10 and False otherwise. It is only relevant when
-        using the Qt GUI, however. '''
-        if sys.platform not in ('win32', 'cygwin'):
-            return False
-        try:
-            winver = float(platform.win32_ver()[0])  # '7', '8', '8.1', '10', etc
-        except (AttributeError, ValueError, IndexError):
-            # We can get here if cygwin, which has an empty win32_ver tuple
-            # in some cases.
-            # In that case "assume windows 10" and just proceed.  Cygwin users
-            # can always manually override this setting from GUI prefs.
-            winver = 10
-        # setting defaults to on for Windows < Win10
-        return bool(self.get('windows_qt_use_freetype', winver < 10))
-
-    @windows_qt_use_freetype.setter
-    def windows_qt_use_freetype(self, b):
-        if self.is_modifiable('windows_qt_use_freetype') and sys.platform in ('win32', 'cygwin'):
-            self.set_key('windows_qt_use_freetype', bool(b))
-
-    @property
-    def linux_qt_use_custom_fontconfig(self):
-        ''' Returns True iff we are Linux and we are set to use the fonts.xml
-        fontconfig override, False otherwise.  This config setting defaults to
-        True for all Linux, but only is relevant to Qt GUI. '''
-        return bool(sys.platform in ('linux',) and self.get('linux_qt_use_custom_fontconfig', True))
-
-    @linux_qt_use_custom_fontconfig.setter
-    def linux_qt_use_custom_fontconfig(self, b):
-        if self.is_modifiable('linux_qt_use_custom_fontconfig') and sys.platform in ('linux',):
-            self.set_key('linux_qt_use_custom_fontconfig', bool(b))
 
 
 def read_user_config(path):


### PR DESCRIPTION
Changes to status quo:

Windows:

- Enables FreeType on Windows by default only iff Windows version < Windows 10
- The above can be overridden by a new Preferences setting ("Enable FreeType for font rendering")

Linux:

- Added some paranoia checks when deciding to override fontconfig with FONTCONFIG_FILE
- Made the FONTCONFIG_FILE override entirely preference-overridable (see Prefs) (default enabled)
