### PR TITLE
Linux & Windows: Fix for Preferences crash caused by lazy-loading QtMultimedia

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3835,8 +3835,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
 
     def settings_dialog(self):
+        class SettingsModalDialog(WindowModalDialog):
+            shown_signal = pyqtSignal()
+            def showEvent(self, e):
+                super().showEvent(e)
+                self.shown_signal.emit()
         self.need_restart = False
-        d = WindowModalDialog(self.top_level_window(), _('Preferences'))
+        d = SettingsModalDialog(self.top_level_window(), _('Preferences'))
         d.setObjectName('WindowModalDialog - Preferences')
         destroyed_print_error(d)
         vbox = QVBoxLayout()
@@ -4022,26 +4027,51 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         gui_widgets.append((block_ex_label, block_ex_combo))
 
         qr_combo = QComboBox()
-        qr_combo.addItem(_("Default"),"default")
-        system_cameras = []
-        try:
-            from PyQt5.QtMultimedia import QCameraInfo
-            system_cameras = QCameraInfo.availableCameras()
-            qr_label = HelpLabel(_('Video Device') + ':', _("For scanning Qr codes."))
-        except ImportError as e:
+        qr_label = HelpLabel(_('Video Device'), '')
+        qr_did_scan = False
+        def set_no_camera(e=''):
             # Older Qt or missing libs -- disable GUI control and inform user why
             qr_combo.setEnabled(False)
+            qr_combo.clear()
+            qr_combo.addItem(_("Default"), "default")
             qr_combo.setToolTip(_("Unable to probe for cameras on this system. QtMultimedia is likely missing."))
-            qr_label = HelpLabel(_('Video Device') + ' ' + _('(disabled)') + ':', qr_combo.toolTip() + "\n\n" + str(e))
+            qr_label.setText(_('Video Device') + ' ' + _('(disabled)') + ':')
+            qr_label.help_text = qr_combo.toolTip() + "\n\n" + str(e)
             qr_label.setToolTip(qr_combo.toolTip())
-        for cam in system_cameras:
-            qr_combo.addItem(cam.description(), cam.deviceName())
-        video_device = self.config.get("video_device")
-        video_device_index = 0
-        if video_device:
-            video_device_index = qr_combo.findData(video_device)
-        qr_combo.setCurrentIndex(video_device_index)
-        on_video_device = lambda x: self.config.set_key("video_device", qr_combo.itemData(x), True)
+        def scan_cameras():
+            nonlocal qr_did_scan
+            if qr_did_scan:
+                # already scanned
+                return
+            qr_did_scan = True
+            system_cameras = []
+            try:
+                from PyQt5.QtMultimedia import QCameraInfo
+            except ImportError as e:
+                set_no_camera(e)
+                return
+            system_cameras = QCameraInfo.availableCameras()
+            qr_combo.clear()
+            qr_combo.addItem(_("Default"), "default")
+            qr_label.setText(_('Video Device') + ':')
+            qr_label.help_text = _("For scanning Qr codes.")
+            qr_combo.setToolTip(qr_label.help_text)
+            qr_label.setToolTip(qr_label.help_text)
+            for cam in system_cameras:
+                qr_combo.addItem(cam.description(), cam.deviceName())
+            video_device = self.config.get("video_device")
+            video_device_index = 0
+            if video_device:
+                video_device_index = qr_combo.findData(video_device)
+            qr_combo.setCurrentIndex(video_device_index)
+            qr_combo.setEnabled(True)
+        def on_video_device(x):
+            if qr_combo.isEnabled():
+                self.config.set_key("video_device", qr_combo.itemData(x), True)
+
+        set_no_camera() # pre-populate combo box with default so it has a sizeHint
+
+        d.shown_signal.connect(scan_cameras, Qt.QueuedConnection)  # do the camera scan once dialog is shown, using QueuedConnection so it's called from top level event loop and not from the showEvent handler
         qr_combo.currentIndexChanged.connect(on_video_device)
         gui_widgets.append((qr_label, qr_combo))
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -69,6 +69,18 @@ from .popup_widget import ShowPopupLabel, KillPopupLabel, PopupWidget
 from . import cashacctqt
 from .util import *
 
+try:
+    # pre-load QtMultimedia at app start, if possible
+    # this is because lazy-loading it from within Python
+    # callbacks led to crashes on Linux (likely due to)
+    # bugs in PyQt5 (crashes wouldn't happen when testing
+    # with PySide2)
+    from PyQt5.QtMultimedia import QCameraInfo
+    del QCameraInfo  # defensive programming: not always available so don't keep name around
+except ImportError as e:
+    pass  # we tried to pre-load it, failure is ok; camera just won't be available
+
+
 class StatusBarButton(QPushButton):
     def __init__(self, icon, tooltip, func):
         QPushButton.__init__(self, icon, '')

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -72,9 +72,9 @@ from .util import *
 try:
     # pre-load QtMultimedia at app start, if possible
     # this is because lazy-loading it from within Python
-    # callbacks led to crashes on Linux (likely due to)
+    # callbacks led to crashes on Linux, likely due to
     # bugs in PyQt5 (crashes wouldn't happen when testing
-    # with PySide2)
+    # with PySide2!).
     from PyQt5.QtMultimedia import QCameraInfo
     del QCameraInfo  # defensive programming: not always available so don't keep name around
 except ImportError as e:
@@ -4074,7 +4074,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             video_device = self.config.get("video_device")
             video_device_index = 0
             if video_device:
-                video_device_index = qr_combo.findData(video_device)
+                video_device_index = max(0, qr_combo.findData(video_device))  # if not found, default to 0 (the default item)
             qr_combo.setCurrentIndex(video_device_index)
             qr_combo.setEnabled(True)
         def on_video_device(x):


### PR DESCRIPTION
Here is how to reproduce the crash (Linux & Windows):

---

![crashola](https://user-images.githubusercontent.com/266627/61901436-718b0680-af28-11e9-8369-78c871f72bf9.gif)

- Start up a wallet
- Double-click a tx
- Close tx dialog
- Open up preferences within a few seconds (can use `Ctrl+,` hotkey or the StatusButton -- does not matter)

There is a 90% chance it will crash.  The stack trace is it crashing in a `free()` call in the C lib from a `QDialog` destructor, which is misleading.

Update: This is on Linux Ubuntu 18.04 & Windows 10 using Python 3.6.8, running form source, with PyQt5 5.12.3 -- Windows 10 is using 32-bit Python and Linux is 64-bit; the crashes also happen when building an AppImage or Windows .exe, however.

Update 2: Also crashes on Ubuntu 18.04 with Python 3.7.3 using the requirements from contrib/ installed.

---

This is the stack trace on Windows:

```
1  PyInit_sip                      sip              0x644984d7 
2  sip                                              0x6449118c 
3  sip                                              0x644911a8 
4  PyInit_sip                      sip              0x64498026 
5  SendNotificationsForLibraryItem Windows_Storage  0x74f0aebe 
6  QObject::~QObject               Qt5Core          0x6463c619 
7  free_base                       ucrtbase         0x744ae13b 
8  free                            ucrtbase         0x744ae108 
9  QLayout::removeItem             Qt5Widgets       0x63af67f5 
10 PyInit_QtWidgets                QtWidgets        0x641369fc 
11 QBoxLayout::~QBoxLayout         Qt5Widgets       0x63aee7b3 
12 PyInit_QtWidgets                QtWidgets        0x6413707c 
13 QWidget::~QWidget               Qt5Widgets       0x63afd741 
14 QWidget::hide                   Qt5Widgets       0x63b03ff7 
15 QDialog::~QDialog               Qt5Widgets       0x63c57985
```

The actual cause, however, was isolated down to lazy-loading `QtMultimedia` from within the preferences settings_dialog factory function in main_window.py here:  https://github.com/Electron-Cash/Electron-Cash/blob/5ebd59c504dd1e96142844a2d778251342fa8810/gui/qt/main_window.py#L4017

Commenting-out the above code leads to 0% crashes.

The fix in this PR is to:

1. Do not lazy-load QtMultimedia.  It seems that if it is loaded at app startup before much activity has happened in Qt and before a QApplication exists, then it never crashes.  So we load it at the top of `main_windows.py` and then immediately delete the imported symbol (this still has the side-effect that QtMultimedia is now linked and loaded, however).

2. As a paranoia measure, we also don't use QCameraInfo from the `settings_dialog` action callback directly, but rather enqueue it to run later in the top-level of the event loop via a pyqtSignal connected via `Qt.QueuedConnection`.

This latter step (2) is not strictly necessary -- but is there in case QCameraInfo raises exceptions or otherwise hangs -- so the user at least sees an empty window while it's "doing stuff" and can realize the delays are due to the Preferences window.  It also is a bit of paranoia as I still don't quite trust `QtMultimedia` in PyQt5 -- and doing it from the top-level event loop rather than nested in a handler feels like it will be less likely to produce crashes.

**It should be noted that when tested with `PySide2`, no crashes occur.** So this is likely a bug in PyQt5.
