### PR TITLE
CashAccounts: Added parsing & integration of cashacct: URIs

### DIFF
--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -192,6 +192,7 @@ Section "Uninstall"
   RMDir  "$SMPROGRAMS\${PRODUCT_NAME}"
 
   DeleteRegKey HKCU "Software\Classes\bitcoincash"
+  DeleteRegKey HKCU "Software\Classes\cashacct"
   DeleteRegKey HKCU "Software\${PRODUCT_NAME}"
   DeleteRegKey HKCU "${PRODUCT_UNINST_KEY}"
 SectionEnd

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -142,6 +142,11 @@ Section
   WriteRegStr HKCU "Software\Classes\bitcoincash" "URL Protocol" ""
   WriteRegStr HKCU "Software\Classes\bitcoincash" "DefaultIcon" "$\"$INSTDIR\electron.ico, 0$\""
   WriteRegStr HKCU "Software\Classes\bitcoincash\shell\open\command" "" "$\"$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe$\" $\"%1$\""
+  ;Links cashacct: URI's to Electron Cash
+  WriteRegStr HKCU "Software\Classes\cashacct" "" "URL:cashacct Protocol"
+  WriteRegStr HKCU "Software\Classes\cashacct" "URL Protocol" ""
+  WriteRegStr HKCU "Software\Classes\cashacct" "DefaultIcon" "$\"$INSTDIR\electron.ico, 0$\""
+  WriteRegStr HKCU "Software\Classes\cashacct\shell\open\command" "" "$\"$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe$\" $\"%1$\""
 
   ;Adds an uninstaller possibilty to Windows Uninstall or change a program section
   WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "DisplayName" "$(^Name)"

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -175,9 +175,24 @@ else
     pyinstaller --clean --noconfirm --ascii --name $VERSION contrib/osx/osx.spec || fail "Could not build binary"
 fi
 
-info "Adding bitcoincash URI types to Info.plist"
+info "Adding bitcoincash & cashacct URI types to Info.plist"
+# NB: Make sure there are no trailing spaces after the '\' characters here
 plutil -insert 'CFBundleURLTypes' \
-	-xml '<array><dict> <key>CFBundleURLName</key> <string>bitcoincash</string> <key>CFBundleURLSchemes</key> <array><string>bitcoincash</string></array> </dict></array>' \
+	-xml \
+'<array> '\
+'<dict> '\
+'  <key>CFBundleURLName</key> '\
+'  <string>bitcoincash</string> '\
+'  <key>CFBundleURLSchemes</key> '\
+'    <array><string>bitcoincash</string></array> '\
+'</dict> '\
+'<dict> '\
+'  <key>CFBundleURLName</key> '\
+'  <string>CashAccount</string> '\
+'  <key>CFBundleURLSchemes</key> '\
+'    <array><string>cashacct</string></array> '\
+'</dict> '\
+'</array>' \
 	-- dist/$PACKAGE.app/Contents/Info.plist \
 	|| fail "Could not add keys to Info.plist. Make sure the program 'plutil' exists and is installed."
 

--- a/electron-cash
+++ b/electron-cash
@@ -377,7 +377,8 @@ if __name__ == '__main__':
     # check uri
     uri = config_options.get('url')
     if uri:
-        if not uri.lower().startswith(networks.net.CASHADDR_PREFIX + ':'):
+        lc_uri = uri.lower()
+        if not any(lc_uri.startswith(scheme + ':') for scheme in web.parseable_schemes()):
             print_stderr('unknown command:', uri)
             sys.exit(1)
         config_options['url'] = uri

--- a/electron-cash.desktop
+++ b/electron-cash.desktop
@@ -13,7 +13,7 @@ StartupNotify=true
 StartupWMClass=Electron Cash
 Terminal=false
 Type=Application
-MimeType=x-scheme-handler/bitcoincash;
+MimeType=x-scheme-handler/bitcoincash;x-scheme-handler/cashacct;
 Actions=Testnet;
 
 [Desktop Action Testnet]

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2292,6 +2292,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         except Exception as e:
             self.show_error(_('Invalid bitcoincash URI:') + '\n' + str(e))
             return
+        self.do_clear()
         self.show_send_tab()
         r = out.get('r')
         sig = out.get('sig')
@@ -2337,6 +2338,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.message_opreturn_e.setHidden(True)
             self.opreturn_rawhex_cb.setHidden(True)
             self.opreturn_label.setHidden(True)
+
+        if address:
+            # this is important so that cashacct: URIs get insta-resolved
+            # (they only get resolved when payto_e loses focus)
+            self.message_e.setFocus()
+        elif not self.payto_e.isReadOnly() and self.payto_e.isVisible():
+            # otherwise, if the address field is empty, jump focus to the
+            # payto_e to indicate to the user that's what they need to
+            # fill in next.
+            self.payto_e.setFocus()
 
     def do_clear(self):
         ''' Clears the send tab, reseting its UI state to its initiatial state.'''

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -36,6 +36,7 @@ from electroncash.address import Address, ScriptOutput
 from electroncash import networks
 from electroncash.util import PrintError
 from electroncash.contacts import Contact
+from electroncash import web
 
 from . import util
 from . import cashacctqt
@@ -160,7 +161,8 @@ class PayToEdit(PrintError, ScanQRTextEdit):
         self.cointext = None
         if len(lines) == 1:
             data = lines[0]
-            if data.lower().startswith(networks.net.CASHADDR_PREFIX + ":"):
+            lc_data = data.lower()
+            if any(lc_data.startswith(scheme + ":") for scheme in web.parseable_schemes()):
                 self.scan_f(data)
                 return
             try:

--- a/lib/cashacct.py
+++ b/lib/cashacct.py
@@ -47,6 +47,10 @@ from . import verifier
 from . import blockchain
 from . import caches
 
+# 'cashacct:' URI scheme. Used by Crescent Cash and Electron Cash and
+# other wallets in the future.
+URI_SCHEME = 'cashacct'
+
 # Cash Accounts protocol code prefix is 0x01010101
 # See OP_RETURN prefix guideline: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/op_return-prefix-guideline.md
 protocol_code = bytes.fromhex("01010101")

--- a/lib/web.py
+++ b/lib/web.py
@@ -32,6 +32,7 @@ from .address import Address
 from . import bitcoin
 from . import networks
 from .util import format_satoshis_plain, bh2u, print_error
+from . import cashacct
 
 
 DEFAULT_EXPLORER = "Blockchair.com"
@@ -94,13 +95,21 @@ def BE_URL(config, kind, item):
 def BE_sorted_list():
     return sorted(BE_info())
 
+def _strip_cashacct_str(s: str) -> str:
+    '''Strips emojis and ';' characters from a cashacct string
+    of the form name#number[.123]'''
+    return cashacct.CashAcct.strip_emoji(s).replace(';', '').strip()
 
-def create_URI(addr, amount, message, *, op_return=None, op_return_raw=None):
-    if not isinstance(addr, Address):
+def create_URI(addr, amount, message, *, op_return=None, op_return_raw=None, net=None):
+    is_cashacct = bool(isinstance(addr, str) and cashacct.CashAcct.parse_string(addr))
+    if not isinstance(addr, Address) and not is_cashacct:
         return ""
     if op_return is not None and op_return_raw is not None:
         raise ValueError('Must specify exactly one of op_return or op_return_hex as kwargs to create_URI')
-    scheme, path = addr.to_URI_components()
+    if is_cashacct:
+        scheme, path = cashacct.URI_SCHEME, _strip_cashacct_str(addr)
+    else:
+        scheme, path = addr.to_URI_components(net=net)
     query = []
     if amount:
         query.append('amount=%s'%format_satoshis_plain(amount))
@@ -123,17 +132,27 @@ def urldecode(url):
     ''' Inverse of urlencode '''
     return urllib.parse.unquote(url)
 
-def parse_URI(uri, on_pr=None):
+def parseable_schemes(net = None) -> tuple:
+    if net is None:
+        net = networks.net
+    return (net.CASHADDR_PREFIX, cashacct.URI_SCHEME)
+
+def parse_URI(uri, on_pr=None, *, net=None):
+    if net is None:
+        net = networks.net
     if ':' not in uri:
         # Test it's valid
-        Address.from_string(uri)
+        Address.from_string(uri, net=net)
         return {'address': uri}
 
-    u = urllib.parse.urlparse(uri)
+    u = urllib.parse.urlparse(uri, allow_fragments=False)  # allow_fragments=False allows for cashacct:name#number URIs
     # The scheme always comes back in lower case
-    if u.scheme != networks.net.CASHADDR_PREFIX:
-        raise Exception("Not a {} URI".format(networks.net.CASHADDR_PREFIX))
+    accept_schemes = parseable_schemes(net=net)
+    if u.scheme not in accept_schemes:
+        raise Exception("Not a {} URI").format(str(accept_schemes))
     address = u.path
+
+    is_cashacct = u.scheme == cashacct.URI_SCHEME
 
     # python for android fails to parse query
     if address.find('?') > 0:
@@ -148,7 +167,13 @@ def parse_URI(uri, on_pr=None):
 
     out = {k: v[0] for k, v in pq.items()}
     if address:
-        Address.from_string(address)
+        if is_cashacct:
+            if not cashacct.CashAcct.parse_string(address):
+                raise ValueError("{} is not a valid cashacct string".format(address))
+            address = _strip_cashacct_str(address)
+        else:
+            # validate
+            Address.from_string(address, net=net)
         out['address'] = address
 
     if 'amount' in out:
@@ -175,7 +200,12 @@ def parse_URI(uri, on_pr=None):
     r = out.get('r')
     sig = out.get('sig')
     name = out.get('name')
-    if on_pr and (r or (name and sig)):
+    is_pr = bool(r or (name and sig))
+
+    if is_pr and is_cashacct:
+        raise ValueError(cashacct.URI_SCHEME + ' payment requests are not currently supported')
+
+    if on_pr and is_pr:
         def get_payment_request_thread():
             from . import paymentrequest as pr
             if name and sig:

--- a/lib/web.py
+++ b/lib/web.py
@@ -168,6 +168,11 @@ def parse_URI(uri, on_pr=None, *, net=None):
     out = {k: v[0] for k, v in pq.items()}
     if address:
         if is_cashacct:
+            if '%' in address:
+                # on macOS and perhaps other platforms the '#' character may
+                # get passed-in as a '%23' if opened from a link or from
+                # some other source.  The below call is safe and won't raise.
+                address = urldecode(address)
             if not cashacct.CashAcct.parse_string(address):
                 raise ValueError("{} is not a valid cashacct string".format(address))
             address = _strip_cashacct_str(address)

--- a/org.electroncash.ElectronCash.appdata.xml
+++ b/org.electroncash.ElectronCash.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
-	<id>electron-cash.desktop</id>
+<component type="desktop-application">
+	<id>org.electroncash.ElectronCash</id>
 	<name>Electron Cash</name>
 	<developer_name>Jonald Fyookball</developer_name>
 	<summary>Lightweight Bitcoin Cash Client</summary>
@@ -8,13 +8,22 @@
 		<p>Electron Cash is an SPV wallet for Bitcoin Cash</p>
 		<p>Control your own private keys. Easily back up your wallet with a mnemonic seed phrase. Enjoy high security without downloading the blockchain or running a full node.</p>
 	</description>
+	<keywords>
+		<keyword>cryptocurrency</keyword>
+		<keyword>finance</keyword>
+		<keyword>bitcoin</keyword>
+		<keyword>bitcoincash</keyword>
+		<keyword>wallet</keyword>
+		<keyword>SPV</keyword>
+		<keyword>crypto</keyword>
+	</keywords>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>MIT</project_license>
 	<url type="homepage">https://www.electroncash.org/</url>
 	<url type="help">https://github.com/Electron-Cash/Electron-Cash/issues?q=is%3Aissue</url>
 	<screenshots>
 		<screenshot type="default">
-			<image type="source">https://www.electroncash.org/images/shot4.png</image>
+			<image type="source">https://www.electroncash.org/images/wallet-shot-3.png</image>
 			<caption>Main application window</caption>
 		</screenshot>
 	</screenshots>
@@ -25,5 +34,8 @@
 		<python3>electroncash_gui</python3>
 		<python3>electroncash_plugins</python3>
 	</provides>
-	<update_contact>alexander-fp@ninetailed.ninja</update_contact>
+	<mimetypes>
+		<mimetype>x-scheme-handler/bitcoincash</mimetype>
+		<mimetype>x-scheme-handler/cashacct</mimetype>
+	</mimetypes>
 </component>


### PR DESCRIPTION
This involved the minimal possible changes:
    
- electron-cash script accepts `cashacct:` URIs
- PayToEdit knows how to deal with them
- Main window pay_to_URI modified
- web.parse_URI can parse them
- web.create_URI can create them

 Added desktop integration for `cashacct:` URL type
    
- macOS Info.plist
- Windows setup.exe .nsi installer
- Linux .desktop file (AppImage, etc)

