### PR TITLE
Build: Only set SUDO if it is not defined already

### DIFF
--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -35,10 +35,13 @@ set -e
 
 info "Using docker: $docker_version"
 
-SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
-if [ $(uname) = "Linux" ]; then
-    # .. on Linux we do
-    SUDO="sudo"
+# Only set SUDO if its not been set already
+if [ -z ${SUDO+x} ] ; then
+    SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
+    if [ $(uname) = "Linux" ]; then
+        # .. on Linux we do
+        SUDO="sudo"
+    fi
 fi
 
 # Ubuntu 18.04 based docker file. Seems to have trouble on older systems

--- a/contrib/build-linux/srcdist_docker/build.sh
+++ b/contrib/build-linux/srcdist_docker/build.sh
@@ -35,10 +35,13 @@ set -e
 
 info "Using docker: $docker_version"
 
-SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
-if [ $(uname) = "Linux" ]; then
-    # .. on Linux we do
-    SUDO="sudo"
+# Only set SUDO if its not been set already
+if [ -z ${SUDO+x} ] ; then
+    SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
+    if [ $(uname) = "Linux" ]; then
+        # .. on Linux we do
+        SUDO="sudo"
+    fi
 fi
 
 

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -35,10 +35,13 @@ set -e
 
 info "Using docker: $docker_version"
 
-SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
-if [ $(uname) = "Linux" ]; then
-    # .. on Linux we do
-    SUDO="sudo"
+# Only set SUDO if its not been set already
+if [ -z ${SUDO+x} ] ; then
+    SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
+    if [ $(uname) = "Linux" ]; then
+        # .. on Linux we do
+        SUDO="sudo"
+    fi
 fi
 
 info "Creating docker image ..."


### PR DESCRIPTION
This enables the usage of the build scripts for users that do not require sudo to execute the docker command.