### PR TITLE
Build: Improvements for automatic builds and reproducibility

### DIFF
--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -112,3 +112,10 @@ fi
 GIT_DIR_NAME=`basename $GIT_REPO`
 PACKAGE=$GIT_DIR_NAME  # Modify this if you like -- Windows and MacOS build scripts read this
 PYI_SKIP_TAG="${PYI_SKIP_TAG:-0}" # Set this to non-zero to make PyInstaller skip tagging the bootloader
+
+# Build a command line argument for docker, enabling interactive mode if stdin
+# is a tty and enabling tty in docker if stdout is a tty.
+DOCKER_RUN_TTY=""
+if [ -t 0 ] ; then DOCKER_RUN_TTY="${DOCKER_RUN_TTY}i" ; fi
+if [ -t 1 ] ; then DOCKER_RUN_TTY="${DOCKER_RUN_TTY}t" ; fi
+if [ -n "$DOCKER_RUN_TTY" ] ; then DOCKER_RUN_TTY="-${DOCKER_RUN_TTY}" ; fi

--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -6,29 +6,40 @@ umask 0022
 # First, some functions that build scripts may use for pretty printing
 if [ -t 1 ] ; then
     RED='\033[0;31m'
-    BLUE='\033[0,34m'
+    BLUE='\033[0;34m'
     YELLOW='\033[0;33m'
     GREEN='\033[0;32m'
     NC='\033[0m' # No Color
+
+    MSG_INFO="\r💬 ${BLUE}INFO:${NC}"
+    MSG_ERROR="\r🗯  ${RED}ERROR:${NC}"
+    MSG_WARNING="\r⚠️  ${YELLOW}WARNING:${NC}"
+    MSG_OK="\r👍  ${GREEN}OK:${NC}"
 else
     RED=''
     BLUE=''
     YELLOW=''
     GREEN=''
     NC='' # No Color
+
+    MSG_INFO="INFO:"
+    MSG_ERROR="ERROR:"
+    MSG_WARNING="WARNING:"
+    MSG_OK="OK:"
 fi
+
 function info {
-	printf "\r💬 ${BLUE}INFO:${NC}  ${1}\n"
+    printf "${MSG_INFO}  ${1}\n"
 }
 function fail {
-    printf "\r🗯  ${RED}ERROR:${NC}  ${1}\n" >&2
+    printf "${MSG_ERROR}  ${1}\n" >&2
     exit 1
 }
 function warn {
-	printf "\r⚠️  ${YELLOW}WARNING:${NC}  ${1}\n"
+    printf "${MSG_WARNING}  ${1}\n"
 }
 function printok {
-    printf "\r👍  ${GREEN}OK:${NC}  ${1}\n"
+    printf "${MSG_OK}  ${1}\n"
 }
 
 function verify_hash {

--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -111,3 +111,4 @@ if [ "$GIT_REPO" != "$DEFAULT_GIT_REPO" ]; then
 fi
 GIT_DIR_NAME=`basename $GIT_REPO`
 PACKAGE=$GIT_DIR_NAME  # Modify this if you like -- Windows and MacOS build scripts read this
+PYI_SKIP_TAG="${PYI_SKIP_TAG:-0}" # Set this to non-zero to make PyInstaller skip tagging the bootloader

--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -4,11 +4,19 @@
 umask 0022
 
 # First, some functions that build scripts may use for pretty printing
-RED='\033[0;31m'
-BLUE='\033[0,34m'
-YELLOW='\033[0;33m'
-GREEN='\033[0;32m'
-NC='\033[0m' # No Color
+if [ -t 1 ] ; then
+    RED='\033[0;31m'
+    BLUE='\033[0,34m'
+    YELLOW='\033[0;33m'
+    GREEN='\033[0;32m'
+    NC='\033[0m' # No Color
+else
+    RED=''
+    BLUE=''
+    YELLOW=''
+    GREEN=''
+    NC='' # No Color
+fi
 function info {
 	printf "\r💬 ${BLUE}INFO:${NC}  ${1}\n"
 }

--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -129,7 +129,7 @@ if [ "$GIT_REPO" != "$DEFAULT_GIT_REPO" ]; then
     info "Picked up override from env: GIT_REPO=${GIT_REPO}"
 fi
 GIT_DIR_NAME=`basename $GIT_REPO`
-PACKAGE=$GIT_DIR_NAME  # Modify this if you like -- Windows and MacOS build scripts read this
+PACKAGE="Electron-Cash"  # Modify this if you like -- Windows, MacOS & Linux srcdist build scripts read this, while AppImage has it hard-coded
 PYI_SKIP_TAG="${PYI_SKIP_TAG:-0}" # Set this to non-zero to make PyInstaller skip tagging the bootloader
 
 # Build a command line argument for docker, enabling interactive mode if stdin

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -81,7 +81,7 @@ FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME
 (
     # NOTE: We propagate forward the GIT_REPO override to the container's env,
     # just in case it needs to see it.
-    $SUDO docker run -it \
+    $SUDO docker run $DOCKER_RUN_TTY \
     -e GIT_REPO="$GIT_REPO" \
     --name electroncash-appimage-builder-cont-$DOCKER_SUFFIX \
     -v $FRESH_CLONE_DIR:/opt/electroncash \

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -87,7 +87,7 @@ mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home
     -e HOME="/opt/electroncash/contrib/build-linux/home" \
     -e GIT_REPO="$GIT_REPO" \
     --name electroncash-appimage-builder-cont-$DOCKER_SUFFIX \
-    -v $FRESH_CLONE_DIR:/opt/electroncash \
+    -v $FRESH_CLONE_DIR:/opt/electroncash:delegated \
     --rm \
     --workdir /opt/electroncash/contrib/build-linux/appimage \
     -u $(id -u $USER):$(id -g $USER) \

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -78,15 +78,19 @@ FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME
         git checkout $REV
 ) || fail "Could not create a fresh clone from git"
 
+mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home directory"
+
 (
     # NOTE: We propagate forward the GIT_REPO override to the container's env,
     # just in case it needs to see it.
     $SUDO docker run $DOCKER_RUN_TTY \
+    -e HOME="/opt/electroncash/contrib/build-linux/home" \
     -e GIT_REPO="$GIT_REPO" \
     --name electroncash-appimage-builder-cont-$DOCKER_SUFFIX \
     -v $FRESH_CLONE_DIR:/opt/electroncash \
     --rm \
     --workdir /opt/electroncash/contrib/build-linux/appimage \
+    -u $(id -u $USER):$(id -g $USER) \
     electroncash-appimage-builder-img-$DOCKER_SUFFIX \
     ./_build.sh $REV
 ) || fail "Build inside docker container failed"

--- a/contrib/build-linux/srcdist_docker/Dockerfile
+++ b/contrib/build-linux/srcdist_docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -q && \
         faketime \
         python3 \
         python3-pip \
+        python3-venv \
         pkg-config \
         libjpeg-dev \
         && \

--- a/contrib/build-linux/srcdist_docker/_build.sh
+++ b/contrib/build-linux/srcdist_docker/_build.sh
@@ -15,6 +15,8 @@ python3 --version || fail "No python"
 
 pushd $PROJECT_ROOT
 
+python3 -m venv env
+source env/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade setuptools
 python3 -m pip install --upgrade requests

--- a/contrib/build-linux/srcdist_docker/_build.sh
+++ b/contrib/build-linux/srcdist_docker/_build.sh
@@ -15,12 +15,14 @@ python3 --version || fail "No python"
 
 pushd $PROJECT_ROOT
 
+info "Setting up Python venv ..."
 python3 -m venv env
 source env/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade setuptools
 python3 -m pip install --upgrade requests
 
+# the below prints its own info message
 contrib/make_linux_sdist
 
 popd

--- a/contrib/build-linux/srcdist_docker/build.sh
+++ b/contrib/build-linux/srcdist_docker/build.sh
@@ -68,7 +68,7 @@ FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME
 (
     # NOTE: We propagate forward the GIT_REPO override to the container's env,
     # just in case it needs to see it.
-    $SUDO docker run -it \
+    $SUDO docker run $DOCKER_RUN_TTY \
     -e GIT_REPO="$GIT_REPO" \
     --name electroncash-srcdist-builder-cont \
     -v $FRESH_CLONE_DIR:/opt/electroncash \

--- a/contrib/build-linux/srcdist_docker/build.sh
+++ b/contrib/build-linux/srcdist_docker/build.sh
@@ -65,15 +65,19 @@ FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME
         git checkout $REV
 ) || fail "Could not create a fresh clone from git"
 
+mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home directory"
+
 (
     # NOTE: We propagate forward the GIT_REPO override to the container's env,
     # just in case it needs to see it.
     $SUDO docker run $DOCKER_RUN_TTY \
+    -e HOME="/opt/electroncash/contrib/build-linux/home" \
     -e GIT_REPO="$GIT_REPO" \
     --name electroncash-srcdist-builder-cont \
     -v $FRESH_CLONE_DIR:/opt/electroncash \
     --rm \
     --workdir /opt/electroncash/contrib/build-linux/srcdist_docker \
+    -u $(id -u $USER):$(id -g $USER) \
     electroncash-srcdist-builder-img \
     ./_build.sh $REV
 ) || fail "Build inside docker container failed"

--- a/contrib/build-linux/srcdist_docker/build.sh
+++ b/contrib/build-linux/srcdist_docker/build.sh
@@ -74,7 +74,7 @@ mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home
     -e HOME="/opt/electroncash/contrib/build-linux/home" \
     -e GIT_REPO="$GIT_REPO" \
     --name electroncash-srcdist-builder-cont \
-    -v $FRESH_CLONE_DIR:/opt/electroncash \
+    -v $FRESH_CLONE_DIR:/opt/electroncash:delegated \
     --rm \
     --workdir /opt/electroncash/contrib/build-linux/srcdist_docker \
     -u $(id -u $USER):$(id -g $USER) \

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -330,6 +330,9 @@ build_the_app() {
         cd dist
         mv $NAME_ROOT-setup.exe $NAME_ROOT-$VERSION-setup.exe  || fail "Failed to move $NAME_ROOT-$VERSION-setup.exe to the output dist/ directory"
 
+        ls -la *.exe
+        sha256sum *.exe
+
         popd
 
     ) || fail "Failed to build $PACKAGE"

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -200,7 +200,7 @@ prepare_wine() {
             git init
             git remote add origin $PYINSTALLER_REPO
             git fetch --depth 1 origin $PYINSTALLER_COMMIT
-            git checkout -b build FETCH_HEAD
+            git checkout FETCH_HEAD
             rm -fv PyInstaller/bootloader/Windows-*/run*.exe || true  # Make sure EXEs that came with repo are deleted -- we rebuild them and need to detect if build failed
             if [ ${PYI_SKIP_TAG:-0} -eq 0 ] ; then
                 echo "const char *ec_tag = \"tagged by Electron-Cash@$GIT_COMMIT_HASH\";" >> ./bootloader/src/pyi_main.c

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -66,7 +66,7 @@ FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME
 (
     # NOTE: We propagate forward the GIT_REPO override to the container's env,
     # just in case it needs to see it.
-    $SUDO docker run -it \
+    $SUDO docker run $DOCKER_RUN_TTY \
     -e GIT_REPO="$GIT_REPO" \
     -e PYI_SKIP_TAG="$PYI_SKIP_TAG" \
     --name electroncash-wine-builder-cont \

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -68,6 +68,7 @@ FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME
     # just in case it needs to see it.
     $SUDO docker run -it \
     -e GIT_REPO="$GIT_REPO" \
+    -e PYI_SKIP_TAG="$PYI_SKIP_TAG" \
     --name electroncash-wine-builder-cont \
     -v $FRESH_CLONE_DIR:/opt/wine64/drive_c/electroncash \
     --rm \

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -60,7 +60,7 @@ FRESH_CLONE="$WINE_PREFIX/drive_c/electroncash"
         cd $FRESH_CLONE  && \
         git clone $GIT_REPO $FRESH_CLONE && \
         cd $FRESH_CLONE && \
-        git checkout -b fresh $REV
+        git checkout $REV
 ) || fail "Could not create a fresh clone from git"
 
 mkdir "$WINE_PREFIX/home" || fail "Failed to create home directory"

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -83,7 +83,7 @@ FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME  # FIXME: spaces.. every instance of 
     -e GIT_REPO="$GIT_REPO" \
     -e PYI_SKIP_TAG="$PYI_SKIP_TAG" \
     --name ec-wine-builder-cont \
-    -v $FRESH_CLONE_DIR:/homedir/wine64/drive_c/electroncash \
+    -v $FRESH_CLONE_DIR:/homedir/wine64/drive_c/electroncash:delegated \
     --rm \
     --workdir /homedir/wine64/drive_c/electroncash/contrib/build-wine \
     $IMGNAME \

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -1,8 +1,6 @@
 FROM ubuntu:18.04@sha256:5f4bdc3467537cbbe563e80db2c3ec95d548a9145d64453b06939c4592d67b6d
 
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
-ARG USER_ID
-ARG GROUP_ID
 
 RUN dpkg --add-architecture i386 && \
     apt-get update -q && \
@@ -43,5 +41,8 @@ RUN wget -nc https://dl.winehq.org/wine-builds/Release.key && \
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean
+
+ARG USER_ID
+ARG GROUP_ID
 
 RUN mkdir -p /homedir/wine64/drive_c/electroncash ; chown -R ${USER_ID}:${GROUP_ID} /homedir && ls -al /homedir

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -125,28 +125,28 @@ Section
 
   ;Create desktop shortcut
   DetailPrint "Creating desktop shortcut..."
-  CreateShortCut "$DESKTOP\${PRODUCT_NAME}.lnk" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" ""
+  CreateShortCut "$DESKTOP\${PRODUCT_NAME}.lnk" "$INSTDIR\${INTERNAL_NAME}.exe" ""
 
   ;Create start-menu items
   DetailPrint "Creating start-menu items..."
   CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
   CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall.lnk" "$INSTDIR\Uninstall.exe" "" "$INSTDIR\Uninstall.exe" 0
-  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" "" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" 0
+  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk" "$INSTDIR\${INTERNAL_NAME}.exe" "" "$INSTDIR\${INTERNAL_NAME}.exe" 0
   ;See #1255 where some users have bad opengl drivers and need to use software-only rendering. Requires we package openglsw32.dll with the app.
-  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME} (Software OpenGL).lnk" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" "--qt_opengl software" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" 0
-  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME} Testnet.lnk" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" "--testnet" "$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe" 0
+  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME} (Software OpenGL).lnk" "$INSTDIR\${INTERNAL_NAME}.exe" "--qt_opengl software" "$INSTDIR\${INTERNAL_NAME}.exe" 0
+  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME} Testnet.lnk" "$INSTDIR\${INTERNAL_NAME}.exe" "--testnet" "$INSTDIR\${INTERNAL_NAME}.exe" 0
 
 
   ;Links bitcoincash: URI's to Electron Cash
   WriteRegStr HKCU "Software\Classes\bitcoincash" "" "URL:bitcoincash Protocol"
   WriteRegStr HKCU "Software\Classes\bitcoincash" "URL Protocol" ""
   WriteRegStr HKCU "Software\Classes\bitcoincash" "DefaultIcon" "$\"$INSTDIR\electron.ico, 0$\""
-  WriteRegStr HKCU "Software\Classes\bitcoincash\shell\open\command" "" "$\"$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe$\" $\"%1$\""
+  WriteRegStr HKCU "Software\Classes\bitcoincash\shell\open\command" "" "$\"$INSTDIR\${INTERNAL_NAME}.exe$\" $\"%1$\""
   ;Links cashacct: URI's to Electron Cash
   WriteRegStr HKCU "Software\Classes\cashacct" "" "URL:cashacct Protocol"
   WriteRegStr HKCU "Software\Classes\cashacct" "URL Protocol" ""
   WriteRegStr HKCU "Software\Classes\cashacct" "DefaultIcon" "$\"$INSTDIR\electron.ico, 0$\""
-  WriteRegStr HKCU "Software\Classes\cashacct\shell\open\command" "" "$\"$INSTDIR\${INTERNAL_NAME}-${PRODUCT_VERSION}.exe$\" $\"%1$\""
+  WriteRegStr HKCU "Software\Classes\cashacct\shell\open\command" "" "$\"$INSTDIR\${INTERNAL_NAME}.exe$\" $\"%1$\""
 
   ;Adds an uninstaller possibilty to Windows Uninstall or change a program section
   WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "DisplayName" "$(^Name)"

--- a/contrib/make_linux_sdist
+++ b/contrib/make_linux_sdist
@@ -11,11 +11,21 @@ set -e
 
 pushd "$contrib"/..
 
+# EC_PACKAGE_VERSION and EC_PACKAGE_NAME are used by setup.py to specify
+# generated filename with a version from git tag. Otherwise defaults are used.
+EC_PACKAGE_VERSION=`git describe --tags` || fail "Could not get determine git tag version"
+EC_PACKAGE_NAME="${PACKAGE}"
+export EC_PACKAGE_VERSION EC_PACKAGE_NAME
+
+info "Making SrcDist for version: ${EC_PACKAGE_NAME}-${EC_PACKAGE_VERSION} ..."
+
 "$contrib"/make_locale && \
     "$contrib"/make_packages && \
     python3 setup.py sdist --enable-secp --enable-zbar --format=zip,gztar || fail "Failed."
 
-info "Linux source distribution (including compiled libseck256k1) has been placed in dist/"
+unset EC_PACKAGE_VERSION EC_PACKAGE_NAME
+
+info "Linux source distribution (including compiled libseck256k1 & libzbar) has been placed in dist/"
 
 popd
 popd

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ with open('contrib/requirements/requirements-hw.txt') as f:
 
 version = imp.load_source('version', 'lib/version.py')
 
-if sys.version_info[:3] < (3, 5, 2):
-    sys.exit("Error: Electron Cash requires Python version >= 3.5.2...")
+if sys.version_info[:3] < (3, 6):
+    sys.exit("Error: Electron Cash requires Python version >= 3.6...")
 
 data_files = []
 
@@ -123,8 +123,8 @@ setup(
     cmdclass={
         'sdist': MakeAllBeforeSdist,
     },
-    name="Electron Cash",
-    version=version.PACKAGE_VERSION,
+    name=os.environ.get('EC_PACKAGE_NAME') or "Electron Cash",
+    version=os.environ.get('EC_PACKAGE_VERSION') or version.PACKAGE_VERSION,
     install_requires=requirements + ['pyqt5'],
     extras_require={
         'hardware': requirements_hw,


### PR DESCRIPTION
* Adds PYI_SKIP_TAG, which can be set to 1 to skip PyInstaller boot loader tagging. This can be useful to compare binary output across different revisions.
* Remove version included in PyInstaller name. This caused builds to not be comparable across different revisions.
* Correctly handle stdin/out not being a TTY. Output will be logfile friendly.
* Run as current user inside docker. This will prevent root-owned files being created in the source directory.
* Show SHA256 sums and file sizes at end of Wine build.
