### PR TITLE
i18n: Only use system language as default if {de, en, es, ro}

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3862,7 +3862,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         lang_help = _('Select which language is used in the GUI (after restart).')
         lang_label = HelpLabel(_('Language') + ':', lang_help)
         lang_combo = QComboBox()
-        from electroncash.i18n import languages, get_system_language_match, match_language
+        from electroncash.i18n import languages, get_system_language_match, match_language, current_language
 
         language_names = []
         language_keys = []
@@ -3873,7 +3873,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if lang_code == '':
                 # System entry in languages list (==''), gets system setting
                 sys_lang = get_system_language_match()
-                if sys_lang:
+                if sys_lang and sys_lang == (current_language() or 'en_US'):
+                    # We only append [Language] if that's actually what we
+                    # ended up using. Sometimes we don't use the language
+                    # specified by the system as default because its
+                    # translations are of such poor quality, we would rather
+                    # default to English. See #1551.
                     lang_name.append(f' [{languages[sys_lang].name}]')
             language_names.append(''.join(lang_name))
         lang_combo.addItems(language_names)


### PR DESCRIPTION
Closes #1551.

User feedback raised a good point -- defaulting the app to the system
language may be very undesirable for UX as many of the translations we
have are incomplete to the point of being extremely off-putting. A
recent example was Thai which contained nonsense text.

In order to maximize perceived app quality, we just default to English
if the user's system language isn't in the "acceptable for new installs"
set which currently is: Spanish, German, English and Romanian.

Note this change only affects "new installs" that don't yet have a
language that is set.  Users can always set the language manually in the
preferences and their choice will be respected always.
