### PR TITLE
TxDialog: Improve in/outputs text-selection behaviour

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -424,7 +424,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0,0,0,0)
 
-        self.i_text = i_text = QTextBrowser()
+        self.i_text = i_text = TextBrowserKeyboardFocusFilter()
         num_inputs = len(self.tx.inputs())
         inputs_lbl_text = ngettext("&Input", "&Inputs ({num_inputs})", num_inputs)
         if num_inputs > 1:
@@ -464,7 +464,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         i_text.customContextMenuRequested.connect(self.on_context_menu_for_inputs)
         i_text.setFont(QFont(MONOSPACE_FONT))
         i_text.setReadOnly(True)
-        i_text.setTextInteractionFlags(i_text.textInteractionFlags() | Qt.LinksAccessibleByMouse | Qt.LinksAccessibleByKeyboard | Qt.TextSelectableByKeyboard)
+        i_text.setTextInteractionFlags(i_text.textInteractionFlags() | Qt.LinksAccessibleByMouse | Qt.LinksAccessibleByKeyboard)
         vbox.addWidget(i_text)
 
 
@@ -472,7 +472,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         hbox.setContentsMargins(0,0,0,0)
         vbox.addLayout(hbox)
 
-        self.o_text = o_text = QTextBrowser()
+        self.o_text = o_text = TextBrowserKeyboardFocusFilter()
         num_outputs = len(self.tx.outputs())
         outputs_lbl_text = ngettext("&Output", "&Outputs ({num_outputs})", num_outputs)
         if num_outputs > 1:
@@ -503,7 +503,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         o_text.customContextMenuRequested.connect(self.on_context_menu_for_outputs)
         o_text.setFont(QFont(MONOSPACE_FONT))
         o_text.setReadOnly(True)
-        o_text.setTextInteractionFlags(o_text.textInteractionFlags() | Qt.LinksAccessibleByMouse | Qt.LinksAccessibleByKeyboard | Qt.TextSelectableByKeyboard)
+        o_text.setTextInteractionFlags(o_text.textInteractionFlags() | Qt.LinksAccessibleByMouse | Qt.LinksAccessibleByKeyboard)
         vbox.addWidget(o_text)
         self.cashaddr_signal_slots.append(self.update_io)
         self.main_window.gui_object.cashaddr_toggled_signal.connect(self.update_io)

--- a/gui/qt/util.py
+++ b/gui/qt/util.py
@@ -1225,6 +1225,28 @@ def webopen(url: str):
     else:
         webbrowser.open(url)
 
+class TextBrowserKeyboardFocusFilter(QTextBrowser):
+    """
+    This is a QTextBrowser that only enables keyboard text selection when the focus reason is
+    keyboard shortcuts or when a key is pressed while focused. Any other focus reason will
+    deactivate keyboard text selection.
+    """
+
+    def __init__(self, parent: QWidget = None):
+        super().__init__(parent)
+
+    def focusInEvent(self, e: QFocusEvent):
+        if e.reason() in (Qt.TabFocusReason, Qt.BacktabFocusReason, Qt.ShortcutFocusReason):
+            # Focused because of Tab, Shift+Tab or keyboard accelerator
+            self.setTextInteractionFlags(self.textInteractionFlags() | Qt.TextSelectableByKeyboard)
+        else:
+            self.setTextInteractionFlags(self.textInteractionFlags() & ~Qt.TextSelectableByKeyboard)
+        super().focusInEvent(e)
+
+    def keyPressEvent(self, e: QKeyEvent):
+        self.setTextInteractionFlags(self.textInteractionFlags() | Qt.TextSelectableByKeyboard)
+        super().keyPressEvent(e)
+
 if __name__ == "__main__":
     app = QApplication([])
     t = WaitingDialog(None, 'testing ...', lambda: [time.sleep(1)], lambda x: QMessageBox.information(None, 'done', "done"))


### PR DESCRIPTION
Previously entering the input/output list always caused a text cursor to be visible. This changes it so the cursor will only be visible when entering the control using the keyboard or pressing keys when it is focused.