### PR TITLE
Payment Requests: Added BitPay 2.0 JSON API

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2283,10 +2283,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             cb()
 
     def payment_request_error(self):
-        request_error = self.payment_request and self.payment_request.error
+        request_error = (self.payment_request and self.payment_request.error) or ''
         self.payment_request = None
         self.print_error("PaymentRequest error:", request_error)
-        self.show_error(_("There was an error processing the payment request"), rich_text=False)
+        self.show_error(_("There was an error processing the payment request"), rich_text=False, detail_text=request_error)
         self.do_clear()
 
     def on_pr(self, request):
@@ -2666,11 +2666,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         vbox.addLayout(grid)
         weakD = Weak.ref(d)
         def do_export():
-            fn = self.getSaveFileName(_("Save invoice to file"), "*.bip70")
+            ext = pr.export_file_ext()
+            fn = self.getSaveFileName(_("Save invoice to file"), "*." + ext)
             if not fn:
                 return
             with open(fn, 'wb') as f:
-                data = f.write(pr.raw)
+                data = f.write(pr.export_file_data())
             self.show_message(_('Invoice saved as' + ' ' + fn))
         exportButton = EnterButton(_('Save'), do_export)
         def do_delete():

--- a/lib/web.py
+++ b/lib/web.py
@@ -220,8 +220,7 @@ def parse_URI(uri, on_pr=None, *, net=None):
                 request = pr.get_payment_request(r)
             if on_pr:
                 on_pr(request)
-        t = threading.Thread(target=get_payment_request_thread)
-        t.setDaemon(True)
+        t = threading.Thread(target=get_payment_request_thread, daemon=True)
         t.start()
 
     return out


### PR DESCRIPTION
This replaces BIP70 for "*.bitpay.com" on https *only*.

Apparently BitPay prefers we use this different API for payment
requests. It still presents us with some challenges in that it relies on
PGP ultimately to verify sigs.

For now we disable their bizarre key verification scheme and just
rely on SSL verification which is very secure against MITM.

I am waiting to hear back from BitPay if it's ok to hard-code bitcoin
keys in our app, since we'd rather not rely on PGP.

But for now, SSL verification is very good, so we rely on that for
BitPay 2.0.

I won't merge this just yet. I need to first make sure this doesn't break Android and iOS. The external API for these type payment requests is identical, more or less.  The only change is the pr.raw field which now is a more complex object for the `PaymentRequest_BitPay20` subclass.

@mhsmith Do you think this will cause problems on Android?  Are you currently supporting BIP70?
