### PR TITLE
clean up ngettext().format()

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -426,9 +426,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
 
         self.i_text = i_text = TextBrowserKeyboardFocusFilter()
         num_inputs = len(self.tx.inputs())
-        inputs_lbl_text = ngettext("&Input", "&Inputs ({num_inputs})", num_inputs)
-        if num_inputs > 1:
-            inputs_lbl_text = inputs_lbl_text.format(num_inputs=num_inputs)
+        inputs_lbl_text = ngettext("&Input", "&Inputs ({num_inputs})", num_inputs).format(num_inputs=num_inputs)
         l = QLabel(inputs_lbl_text)
         l.setBuddy(i_text)
         hbox.addWidget(l)
@@ -474,9 +472,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
 
         self.o_text = o_text = TextBrowserKeyboardFocusFilter()
         num_outputs = len(self.tx.outputs())
-        outputs_lbl_text = ngettext("&Output", "&Outputs ({num_outputs})", num_outputs)
-        if num_outputs > 1:
-            outputs_lbl_text = outputs_lbl_text.format(num_outputs=num_outputs)
+        outputs_lbl_text = ngettext("&Output", "&Outputs ({num_outputs})", num_outputs).format(num_outputs=num_outputs)
         l = QLabel(outputs_lbl_text)
         l.setBuddy(o_text)
         hbox.addWidget(l)

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -699,8 +699,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 height, conf, timestamp = self.get_tx_height(tx_hash)
                 if height > 0:
                     if conf:
-                        status = ngettext("{conf} confirmation", "{conf} confirmations", conf)
-                        status = status.format(conf=conf)
+                        status = ngettext("{conf} confirmation", "{conf} confirmations", conf).format(conf=conf)
                     else:
                         status = _('Not verified')
                 else:


### PR DESCRIPTION
follow-on from #1499

ngettext takes care of the number delegation which can vary greatly
depending on language (there can be multiple plural forms!), and .format
is fine with having unused keyword args.

also clean up one other instance with intermediate variable to match
rest of codebase.

To test this, try Tools | Load Transaction | From Text with: `00000000000000000000` (0 inputs and 0 outputs) in English locale; observe it no longer says "Inputs ({num_inputs})" and "Outputs ({num_outputs})" just above the list fields.