### PR TITLE
Windows: Switch libusb to version 1.0.23-rc2

### DIFF
--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -143,8 +143,8 @@ prepare_wine() {
         NSIS_URL='https://github.com/cculianu/Electron-Cash-Build-Tools/releases/download/v1.0/nsis-3.02.1-setup.exe'
         NSIS_SHA256=736c9062a02e297e335f82252e648a883171c98e0d5120439f538c81d429552e
 
-        LIBUSB_REPO='https://github.com/EchterAgo/libusb.git'
-        LIBUSB_COMMIT=f2b1128714663ab9450d222ba7f438dbe4ec9d87
+        LIBUSB_REPO='https://github.com/libusb/libusb.git'
+        LIBUSB_COMMIT=a5990ab10f68e5ec7498f627d1664b1f842fec4e
 
         PYINSTALLER_REPO='https://github.com/EchterAgo/pyinstaller.git'
         PYINSTALLER_COMMIT=1a8b2d47c277c451f4e358d926a47c096a5615ec


### PR DESCRIPTION
This version merged our code changes for partial composite device opening and should work for KeepKey and Trezor.