### PR TITLE
add blind signature mechanism to schnorr.py

### DIFF
--- a/lib/secp256k1.py
+++ b/lib/secp256k1.py
@@ -101,6 +101,9 @@ def _load_library():
         secp256k1.secp256k1_ec_pubkey_tweak_mul.argtypes = [c_void_p, c_char_p, c_char_p]
         secp256k1.secp256k1_ec_pubkey_tweak_mul.restype = c_int
 
+        secp256k1.secp256k1_ec_pubkey_combine.argtypes = [c_void_p, c_void_p, POINTER(c_void_p), c_size_t]
+        secp256k1.secp256k1_ec_pubkey_combine.restype = c_int
+
         secp256k1.ctx = secp256k1.secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY)
         r = secp256k1.secp256k1_context_randomize(secp256k1.ctx, os.urandom(32))
         if r:

--- a/lib/tests/test_schnorr.py
+++ b/lib/tests/test_schnorr.py
@@ -8,6 +8,8 @@ import unittest
 from .. import schnorr
 
 import hashlib
+import secrets
+from ..bitcoin import regenerate_key
 
 class TestSchnorr(unittest.TestCase):
 
@@ -49,3 +51,47 @@ class TestSchnorr(unittest.TestCase):
             schnorr._secp256k1_schnorr_sign, schnorr._secp256k1_schnorr_verify = saved
             self.do_it()
 
+class TestBlind(unittest.TestCase):
+
+    def do_it(self):
+        # signer
+        privkey = secrets.token_bytes(32)
+        pubkey = regenerate_key(privkey).GetPubKey(True)
+        signer = schnorr.BlindSigner()
+        R = signer.get_R()
+
+        # requester
+        message_hash = secrets.token_bytes(32)
+        requester = schnorr.BlindSignatureRequest(pubkey, R, message_hash)
+
+        # create and send request
+        e_request = requester.get_request()
+        s_response = signer.sign(privkey, e_request)
+
+        # finalize and unblind the signature
+        signature = requester.finalize(s_response)
+
+        self.assertTrue(schnorr.verify(pubkey, signature, message_hash))
+
+    def test_fast(self):
+        if not schnorr.seclib:
+            self.skipTest("accelerated ECC library not available")
+        self.do_it()
+
+    def test_slow(self):
+        saved = schnorr.seclib
+        schnorr.seclib = None
+        try:
+            self.do_it()
+        finally:
+            schnorr.seclib = saved
+
+    def test_jacobi(self):
+        """ test the faster jacobi implementation against ecdsa package"""
+        alist = [-2,-1,0,1,2,3,4] + [secrets.randbits(256) for _ in range(100)]
+        nlist = [(secrets.randbits(256)*2 + 3) for _ in alist]
+        jac_1 = schnorr.jacobi
+        from ecdsa.numbertheory import jacobi as jac_2
+
+        for a,n in zip(alist, nlist):
+            self.assertEqual(jac_1(a,n), jac_2(a,n), msg=(a,n))


### PR DESCRIPTION
The BlindSignatureRequest class lets you request blinded Schnorr
signatures, and then upon completion, unblind them.

There is also a functional and secure BlindSigner class, though see the
caveats in the docstring.

The resultant signatures are fully valid with respect to the BCH Schnorr
signature convention. So, you could in principle use them for transaction
signatures or CHECKDATASIG signatures. Or, just use them in off-chain
protocols like Cash Fusion.