### PR TITLE
Configure payment_url to include payment request ID

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1733,7 +1733,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             'id': _id
         }
         if payment_url:
-            d['payment_url'] = payment_url
+            d['payment_url'] = payment_url + "/" + _id
         if op_return:
             d['op_return'] = op_return
         if op_return_raw:


### PR DESCRIPTION
Adding the ID as a suffix to the payment_url will allow users to create a payment_url that is identical to request_url and therefore maintain compatibility with bitcoin.com wallet which currently ignores payment_url from the Payment Request and uses request_url instead.