### PR TITLE
Removed cashshuffle.net

### DIFF
--- a/plugins/shuffle/servers.json
+++ b/plugins/shuffle/servers.json
@@ -18,13 +18,5 @@
 	"ecdkxftqvnievsmq.onion": {
 		"ssl": false,
 		"info": 8889
-	},
-	"cashshuffle.net": {
-		"ssl": true,
-		"info": 8080
-	},
-	"5sa45npeflx74qmk.onion": {
-		"ssl": false,
-		"info": 8081
 	}
 }


### PR DESCRIPTION
Shutting down cashshuffle.net server, activity on CashShuffle is 100% on shuffle.servo.cash

I can always create a new one