### PR TITLE
p2sh: Fix coin tracking / balance, etc for esoteric scriptSigs/redeemScripts in inputs

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1143,7 +1143,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                     # Find address in self.txo for this prevout_hash:prevout_n
                     for addr2, item in dd.items():
                         for n, v, is_cb in item:
-                            if n == prevout_n:
+                            if n == prevout_n and self.is_mine(addr2):
                                 add_to_self_txi(tx_hash, addr2, ser, v)
                                 self._addr_bal_cache.pop(addr2, None)  # invalidate cache entry
                                 break

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1145,6 +1145,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                         for n, v, is_cb in item:
                             if n == prevout_n:
                                 add_to_self_txi(tx_hash, addr2, ser, v)
+                                self._addr_bal_cache.pop(addr2, None)  # invalidate cache entry
                                 break
                         else:
                             continue

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1112,7 +1112,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                     d[addr] = l = []
                 l.append((ser, v))
             def find_in_self_txo(prevout_hash: str, prevout_n: int) -> tuple:
-                ''' Returns a tuple of the Address-like-object for a given
+                ''' Returns a tuple of the (Address,value) for a given
                 prevout_hash:prevout_n, or (None, None) if not found. If valid
                 return, the Address object is found by scanning self.txo. The
                 lookup below is relatively fast in practice even on pathological

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -955,8 +955,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
     def _clean_pruned_txo_thread(self):
         ''' Runs in the thread self.pruned_txo_cleaner_thread which is only
         active if self.network. Cleans the self.pruned_txo dict and the
-        self.pruned_txo_values set of txo's that are not relevant to the
-        wallet. The processing below is needed becasue as of 9/16/2019, Electron
+        self.pruned_txo_values set of spends that are not relevant to the
+        wallet. The processing below is needed because as of 9/16/2019, Electron
         Cash temporarily puts all spends that pass through add_transaction and
         have an unparseable address (txi['address'] is None) into the dict
         self.pruned_txo. This is necessary for handling tx's with esoteric p2sh

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1034,7 +1034,9 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 for prevout_hash, s in txid_n.copy().items():
                     try:
                         with self.lock:
-                            tx = self.transactions.get(prevout_hash) or Transaction.tx_cache_get(prevout_hash)
+                            tx = self.transactions.get(prevout_hash)
+                        if tx is None:
+                            tx = Transaction.tx_cache_get(prevout_hash)
                         if isinstance(tx, Transaction):
                             tx = Transaction(tx.raw)  # take a copy
                         else:

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -960,8 +960,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         Cash temporarily puts all spends that pass through add_transaction and
         have an unparseable address (txi['address'] is None) into the dict
         self.pruned_txo. This is necessary for handling tx's with esoteric p2sh
-        redeemScripts and detecting balance changes properly for txins
-        containing such redeemScripts. See #895. '''
+        scriptSigs and detecting balance changes properly for txins
+        containing such scriptSigs. See #895. '''
         def deser(ser):
             prevout_hash, prevout_n = ser.split(':')
             prevout_n = int(prevout_n)
@@ -1158,8 +1158,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                     self._addr_bal_cache.pop(addr, None)  # invalidate cache entry
                     del dd, prevout_hash, prevout_n, ser
                 elif addr is None:
-                    # Unknown/unparsed address.. may be a strange p2sh redeem
-                    # script. Try and find it in txout's if it's one of ours.
+                    # Unknown/unparsed address.. may be a strange p2sh scriptSig
+                    # Try and find it in txout's if it's one of ours.
                     # See issue #895.
                     prevout_hash, prevout_n, ser = txin_get_info(txi)
                     # Find address in self.txo for this prevout_hash:prevout_n

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1078,6 +1078,12 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                         if rm_pruned_too and debug:
                             self.print_error(f"{me.name}: DEBUG removed", ser)
                 if ct:
+                    with self.lock:
+                        # Save changes to storage -- this is cheap and doesn't
+                        # actually write to file yet, just flags storage as
+                        # 'dirty' for when wallet.storage.write() is called
+                        # later.
+                        self.storage.put('pruned_txo', self.pruned_txo)
                     self.print_error(f"{me.name}: removed", ct,
                                      "(non-relevant) pruned_txo's in",
                                      f'{time.time()-t0:3.2f}', "seconds")

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1151,9 +1151,19 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                             continue
                         break
                     else:
-                        # This will grow pruned_txo with potentially irrelevant
-                        # txos, however irrelevant txos will be cleaned once in
-                        # a while by the self.pruned_txo_cleaner_thread
+                        # Not found in self.txo. Flag the spend, however, and
+                        # when the out-of-order prevout tx comes in later for
+                        # this input (if it's indeed one of ours), the real
+                        # address for this input will get picked up then in the
+                        # "add outputs" section below, and self.txi will be
+                        # properly updated to indicate the coin in question was
+                        # spent.
+                        #
+                        # If it's *not* one of ours, however, the below will
+                        # grow pruned_txo with an irrelevant txo. However, the
+                        # irrelevant txo will eventually be reaped and removed
+                        # by the self.pruned_txo_cleaner_thread which runs
+                        # periodically.
                         put_pruned_txo(ser, tx_hash)
             # don't keep empty entries in self.txi
             if not d:


### PR DESCRIPTION
This closes #895.

Below is a screenshot of the exact same wallet mentioned in #895; a watching-only wallet off the p2sh address: `bitcoincash:pqt79ay4h05q2dk889wn28l66942mgrtgqa7jjqt3h`.  Note how it now has the correct balance and it detected the spends of the coins correctly (whereas previously it did not).

<img width="851" alt="Screen Shot 2019-09-16 at 11 03 27 AM" src="https://user-images.githubusercontent.com/266627/64942533-fb44b980-d871-11e9-8367-56afce4fd1d2.png">


---

**Note:** An additional wallet one can try is watching-only over one of the May hard-fork attacker's addresses: `bitcoincash:pz3y5uvukandk0h3yvut2zsua9gp2tknf5nwnue2tj`

---

#### Overview

This PR fixes the coin tracking when the scriptSig / redeemScript is not what the wallet was expecting. Previously, `add_transaction` would *solely* rely on the heuristic parsing of the scriptSig to track coin spends (eg `txin['address']`). This works 99% of the time but if one wants to do something fancy (such as, say, use exotic scriptSigs that don't follow the M-of-N multisig template), the wallet would have a bad time.

#### The approach used

@markblundeberg Suggested we do away with the `txin['address']` and the heuristic parsing altogether, and instead track coin spends a different way, perhaps using Electrum's `spent_outpoint` approach.  I investigated that method but it had a few drawbacks as implemented and I decided against it. Here is my rationale for the approach used:

  - Maintaining the `spent_outpoint` data structure (as it is implemented in Electrum) comes with a cost that is hard to justify.  **Every** outpoint the wallet sees (even unrelated outpoints not involving the wallet) for every tx it processes  ends up being saved to a nested dict-of-dicts and saved to wallet storage. On some of my wallets this was a +50% size increase on disk and +100% memory footprint for each wallet. It also slowed down wallet open and save (particularly relevant on **mobile**) and just made for a bad  time performance-wise.  We here on BCH have a larger need to scale due to the nature of how we use our cryptocurrency.  

    - For example: The wallet I used to take back the attacker's funds takes 40MB on disk and takes 100+ MB in memory.  If we were to use Electrum's `spent_outpoint` technique, this wallet would eat 66MB on disk and eat 200+ MB of memory to maintain such a data structure.  I didn't characterize the cost to load/save it on mobile -- but I suspect it would be a 2x-3x slowdown (already mobile risks suffering from too much delay in loading/saving wallets). So, `spent_outpoint` seemed suboptimal and unnecessary.

 - Doing away with `txin['address']` actually throws away information!  We should view the `txin['address']` heuristic as a performance optimization.  99% of the time, you **can** parse the scriptSig and *know* the address of the input, and stop right there and be done.  This is a good thing! You can end processing early and avoid needless enqueuing of data for processing later when the out-of-order `txo` tx for a particular coin arrives in the wallet (or, if you have the `txo` already, you avoid doing a linear search immediately).  This is not a bad thing! 

 - Doing away with `txin['address']` would also break existing plugins (if any) that rely on this data structure existing.

 - Maintaining `spent_outpoint` correctly required actually tracking conflicting tx's and it required writing additional code for managing that data structure during re-orgs.  Not having that data structure actually saves us from that additional code and we can just leverage our existing reorg code which just looks at the triplet of data structures: `self.txo`, `self.txi`, `self.pruned_txo` already.

 - By not adding `spent_outpoint` we don't have to worry about upgrading the wallet format. Old wallets continue to work as before without upgrade.  Users can continue to move back and forth between Electron Cash versions freely.  This would not be possible if we went with Electrum's `spent_outpoint` technique.

**So**, instead this is what we do:

1. When a tx arrives, we inspect `txin['address']` as before.  Thanks to the *great work* @markblundeberg  has recently done, this is a more reliable data field than it previously was. Either it has real data, or it is `None`.

2. If it has real data, we know/assume it is good, examine the address, and debit the coin out of the wallet (by registering it in `self.txin`), as before.

3. If it does *not* have real data -- previously the wallet would give up at this point (hence the bug seen in #895).  Instead, now, what we do is we first scan `self.txo` for the coin. If it's there, great! It means tx's came in "in order".  We debit it in `self.txi` based on the address found by scanning `self.txo`.

4. If the `txo` is **not** found (owing to CTOR and out-of-order arrival, perhaps), we now additionally *"queue"* the coin up for later processing by marking it in `self.pruned_txo`. This forutnate data structure already existed in the wallet and was there for just such a purpose. Previously it was only used for coins we knew were ours -- but now we re-purpose it to **also** stuff coins we know nothing about (unknown address) **temporarily**.

5. When the out-of-order receiving tx comes in for the said coin (if it's indeed one of ours), the code that examines tx outputs detects the thing we did in *(4)* above and debits the `txin` correctly.

6. If the flagged coin was not one of ours, code has been written to eventually expire dead entries from `pruned_txo` by an asynchronous network thread that checks these `prevout_hash:prevout_n` coins against the EX servers to see if they need to be wiped.

#### Conclusion

I have tested this on various wallets -- both ones containing `mine` p2sh's with esoteric scriptSigs as well as ones that have tx's with esoteric p2sh's that are not `mine` (such as the May hard-fork attacker fund heist: `bitcoincash:pz3y5uvukandk0h3yvut2zsua9gp2tknf5nwnue2tj`).  Everything works well.  I realize this approach is a hybrid approach but in my mind it is the best of both worlds: leverage the information you do have (if `txin['address']` was successfully parsed), and if you don't have the information, use a backup plan.

I tried other approaches and this was the cleanest and also fastest.
