### PR TITLE
i18n: Add support for pgettext and npgettext with msgctxt

### DIFF
--- a/contrib/make_locale
+++ b/contrib/make_locale
@@ -33,7 +33,7 @@ print("Found {} files to translate".format(len(files.splitlines())))
 # Generate fresh translation template
 if not os.path.exists('lib/locale'):
     os.mkdir('lib/locale')
-cmd = 'xgettext -s --from-code UTF-8 --language Python --no-wrap -f app.fil --output=lib/locale/messages.pot'
+cmd = 'xgettext -s --from-code UTF-8 --language Python --no-wrap -f app.fil --keyword=pgettext:1c,2 --keyword=npgettext:1c,2,3 -c --output=lib/locale/messages.pot'
 print('Generate template')
 os.system(cmd)
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -42,7 +42,7 @@ from electroncash.address import Address, ScriptOutput
 from electroncash.bitcoin import COIN, TYPE_ADDRESS, TYPE_SCRIPT
 from electroncash import networks
 from electroncash.plugins import run_hook
-from electroncash.i18n import _, ngettext
+from electroncash.i18n import _, ngettext, pgettext
 from electroncash.util import (format_time, format_satoshis, PrintError,
                                format_satoshis_plain, NotEnoughFunds,
                                ExcessiveFee, UserCancelled, InvalidPassword,
@@ -1068,7 +1068,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                     f = slf.font(); f.setItalic(False); f.setPointSize(slf.font_default_size); slf.setFont(f)
                     slf.setText(info.emoji + "  " + self.wallet.cashacct.fmt_info(info, minimal_chash=minimal_chash))
                 else:
-                    slf.setText(_("None"))
+                    slf.setText(pgettext("Referencing CashAccount", "None"))
                     f = slf.font(); f.setItalic(True); f.setPointSize(slf.font_default_size-1); slf.setFont(f)
                     slf.ca_copy_b.setDisabled(True)
                 slf.info = info
@@ -4439,7 +4439,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if not self.fx: return
             currencies = sorted(self.fx.get_currencies(self.fx.get_history_config()))
             ccy_combo.clear()
-            ccy_combo.addItems([_('None')] + currencies)
+            ccy_combo.addItems([pgettext('Referencing Fiat currency', 'None')] + currencies)
             if self.fx.is_enabled():
                 ccy_combo.setCurrentIndex(ccy_combo.findText(self.fx.get_currency()))
 

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -30,7 +30,7 @@ from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 import PyQt5.QtCore as QtCore
 
-from electroncash.i18n import _
+from electroncash.i18n import _, pgettext
 from electroncash import networks
 from electroncash.util import print_error, Weak, PrintError
 from electroncash.network import serialize_server, deserialize_server, get_eligible_servers
@@ -521,7 +521,7 @@ class NetworkChoiceLayout(QObject, PrintError):
         self.autoconnect_cb.setChecked(auto_connect)
         self.preferred_only_cb.setChecked(preferred_only)
 
-        host = self.network.interface.host if self.network.interface else _('None')
+        host = self.network.interface.host if self.network.interface else pgettext('Referencing server', 'None')
         self.server_label.setText(host)
 
         self.set_protocol(protocol)

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -306,7 +306,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         text = bfh(str(self.tx))
         text = base_encode(text, base=43)
         try:
-            self.main_window.show_qrcode(text, 'Transaction', parent=self)
+            self.main_window.show_qrcode(text, _('Transaction'), parent=self)
         except Exception as e:
             self.show_message(str(e))
 

--- a/ios/ElectronCash/electroncash_gui/ios_native/network_dialog.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/network_dialog.py
@@ -31,7 +31,7 @@ from . import utils
 from . import gui
 from .custom_objc import *
 
-from electroncash.i18n import _
+from electroncash.i18n import _, pgettext
 
 import socket
 from collections import namedtuple
@@ -230,7 +230,7 @@ class NetworkDialogVC(UIViewController):
         self.lastPort = at(int(port))
         self.autoServerSW.on = bool(auto_connect)
 
-        host = network.interface.host if network.interface else _('None')
+        host = network.interface.host if network.interface else pgettext('Referencing server', 'None')
         self.serverLbl.text = str(host)
 
         #self.set_protocol(protocol)

--- a/ios/ElectronCash/electroncash_gui/ios_native/prefs.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/prefs.py
@@ -9,7 +9,7 @@ from . import gui
 from . import addrconv
 from . import amountedit
 from electroncash.util import timestamp_to_datetime, base_units, base_unit_labels
-from electroncash.i18n import _, language
+from electroncash.i18n import _, language, pgettext
 import time
 import html
 from .uikit_bindings import *
@@ -107,7 +107,7 @@ class PrefsVC(UITableViewController):
     @objc_method
     def updateCurrencies(self):
         parent = gui.ElectrumGui.gui
-        self.currencies = [_('None')]
+        self.currencies = [pgettext('Referencing Fiat currency', 'None')]
         if not parent.daemon or not parent.daemon.fx: return
         currencies = [self.currencies[0],*sorted(parent.daemon.fx.get_currencies(parent.daemon.fx.get_history_config()))]
         special = [ 'USD', 'EUR', 'GBP', 'CAD', 'AUD' ]
@@ -366,7 +366,7 @@ class PrefsVC(UITableViewController):
                 if b is not None:
                     b.tag = TAG_FIAT_CURRENCY
                     b.enabled = True
-                    curr = fx.get_currency() if fx and fx.is_enabled() else _('None')
+                    curr = fx.get_currency() if fx and fx.is_enabled() else pgettext('Referencing Fiat currency', 'None')
                     b.setTitle_forState_(curr, UIControlStateNormal)
                     if b.allTargets.count <= 0:
                         b.addTarget_action_forControlEvents_(self, SEL(b'onFiatCurrencyBut:'), UIControlEventPrimaryActionTriggered)
@@ -395,7 +395,7 @@ class PrefsVC(UITableViewController):
                 l.text = _('Source')
                 if b is not None:
                     b.tag = TAG_FIAT_EXCHANGE
-                    b.setTitle_forState_(_("None"), UIControlStateNormal)
+                    b.setTitle_forState_(pgettext('Referencing Fiat rate source', 'None'), UIControlStateNormal)
                     self.setFiatExchangeButtonText_(b)
                     if b.allTargets.count <= 0:
                         b.addTarget_action_forControlEvents_(self, SEL(b'onFiatExchangeBut:'), UIControlEventPrimaryActionTriggered)
@@ -409,7 +409,7 @@ class PrefsVC(UITableViewController):
         ex = fx.config_exchange() if fx else None
         ex = ex if ex in self.exchanges else None
         if ex is None:
-            ex = _("None")
+            ex = pgettext('Referencing Fiat rate source', 'None')
             if self.normalButtonColor is None: self.normalButtonColor = b.titleColorForState_(UIControlStateNormal)
             b.setTitleColor_forState_(self.warnButtonColor,UIControlStateNormal)
         elif self.normalButtonColor is not None:

--- a/ios/ElectronCash/electroncash_gui/ios_native/wallets.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/wallets.py
@@ -8,7 +8,7 @@ from . import utils
 from . import gui
 from . import history
 from . import newwallet
-from electroncash.i18n import _, language
+from electroncash.i18n import _, pgettext, language
 
 from .uikit_bindings import *
 from .custom_objc import *
@@ -593,12 +593,14 @@ def _ShowOptionsForWalletAtIndex(index : int, vc : UIViewController, ipadAnchor 
                              message = _("You are requesting the deletion of the currently active wallet. In order to delete this wallet, please switch to another wallet, then select this option again on this wallet."),
                              actions = [ [_("OK") ] ])
             return
+        # TRANSLATORS: This is the text that the user needs to enter to confirm wallet deletion
+        delete_confirm_text = pgettext("iOS wallet delete confirmation", "delete").lower().strip()
         def DeleteChk() -> None:
             nonlocal tf, placeholder, prefill
             prefill = ''
             if tf:
                 txt = str(tf.text).lower().strip()
-                if txt == 'delete' or txt == _("delete"): # support i18n
+                if txt == 'delete' or txt == delete_confirm_text: # support i18n
                     try:
                         os.remove(info.full_path)
                         parent.set_wallet_use_touchid(info.name, None, clear_asked = True) # clear cached password if any
@@ -607,12 +609,12 @@ def _ShowOptionsForWalletAtIndex(index : int, vc : UIViewController, ipadAnchor 
                     except:
                         parent.show_error(vc = vc, message = str(sys.exc_info()[1]))
                 else:
-                    parent.show_error(vc = vc, title = _("Not Deleted"), message = _("You didn't enter the text 'delete' in the previous dialog. For your own safety, the wallet file was not deleted."))
+                    parent.show_error(vc = vc, title = _("Not Deleted"), message = _("You didn't enter the text '{delete_confirm_text}' in the previous dialog. For your own safety, the wallet file was not deleted.").format(delete_confirm_text=delete_confirm_text)))
             Release()
-        placeholder = _("Type 'delete' to proceed")
+        placeholder = _("Type '{delete_confirm_text}' to proceed").format(delete_confirm_text=delete_confirm_text)
         utils.show_alert(vc = vc,
                          title = _('Delete Wallet'),
-                         message = _("You are about to delete the wallet '{}'. Unless you have other copies of this wallet or you wrote its seed down, you may lose funds!\n\nIn order to proceed, please type the word 'delete' in the box below:").format(info.name),
+                         message = _("You are about to delete the wallet '{wallet_name}'. Unless you have other copies of this wallet or you wrote its seed down, you may lose funds!\n\nIn order to proceed, please type the word '{delete_confirm_text}' in the box below:").format(wallet_name=info.name, delete_confirm_text=delete_confirm_text),
                          actions = [ [ _("Cancel"), Release ], [ _("Delete"), DeleteChk ]], cancel = _("Cancel"), destructive = _('Delete'),
                          uiTextFieldHandlers = [ TfHandler ])
     def DoOpen() -> None:

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -43,6 +43,24 @@ def ngettext(singular: str, plural: str, n: int) -> str:
     global language
     return language.ngettext(singular, plural, n)
 
+def pgettext(context: str, message: str) -> str:
+    """
+    Hack for adding a context to Python gettext.
+
+    Python 3.8 will add native support for pgettext and npgettext, until then we use this hack.
+    """
+    global language
+    formatted = f"{context}\x04{message}"
+    translated = language.gettext(formatted)
+    return message if '\x04' in translated else translated
+
+def npgettext(context: str, singular: str, plural: str, n: int) -> str:
+    global language
+    formatted_singular = f"{context}\x04{singular}"
+    formatted_plural = f"{context}\x04{plural}"
+    translated = language.ngettext(formatted_singular, formatted_plural, n)
+    return message if '\x04' in translated else translated
+
 def set_language(x):
     global language
 


### PR DESCRIPTION
Some words need additional context to be correctly translated, like in the case of the current "None" translation string. For example in German you need to know the gender of what is referenced to correctly translate it. This is different in different parts of the UI and we previously used the wrong form in some places.

Context will allow us to have multiple tranlsations of the same words depending on where they are used.

In gettext, pgettext and similar functions would be used for this. Sadly Python only added these in version 3.8. To support them with lower Python versions, we take advantage of those versions not being aware that the separator of msgctxt and msgid is \x04 and look up a msgid that is combined with the msgctxt.

This also changes a few places to use pgettext for more accurate translations.