### PR TITLE
Add germany.bitcoincashgrowth.rocks to servers.json

### DIFF
--- a/lib/servers.json
+++ b/lib/servers.json
@@ -136,6 +136,10 @@
         "s": "50002",
         "t": "50001",
         "version": "1.4"
+    },
+    "germany.bitcoincashgrowth.rocks": {
+        "pruning": "-",
+        "s": "50002",
+        "version": "0.7.0"
     }
 }
-


### PR DESCRIPTION
I'm not that sure of the meaning of the syntax, but it is the "Electrum Rust Server 0.7.0" shipped by Bitcoin Unlimited. Also, the bitcoind server is not pruned, but I'm unsure if that is what the second line refers to, so I just left it to resemble all the other entries.


