### PR TITLE
Some typos fixed and removed electrum-merchant requirement

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -425,12 +425,6 @@ if __name__ == '__main__':
                 if config.get('websocket_server'):
                     from electroncash import websockets
                     websockets.WebSocketServer(config, d.network).start()
-                if config.get('requests_dir'):
-                    path = os.path.join(config.get('requests_dir'), 'index.html')
-                    if not os.path.exists(path):
-                        print("Requests directory not configured.")
-                        print("You can configure it using https://github.com/spesmilo/electrum-merchant")
-                        sys.exit(1)
                 d.join()
                 sys.exit(0)
             else:

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -137,7 +137,7 @@ class BaseWizard(util.PrintError):
         title = _("Import Bitcoin Addresses")
         message = _("Enter a list of Bitcoin Cash addresses (this will create a watching-only wallet), or a list of private keys.")
         if bitcoin.is_bip38_available():
-            message += " " + _("BIP38 encrpted keys are supported.")
+            message += " " + _("BIP38 encyrpted keys are supported.")
         self.add_xpub_dialog(title=title, message=message, run_next=self.on_import,
                              is_valid=v, allow_multi=True)
 

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -820,10 +820,11 @@ arg_types = {
 config_variables = {
 
     'addrequest': {
-        'requests_dir': 'directory where a bip70 file will be written.',
-        'ssl_privkey': 'Path to your SSL private key, needed to sign the request.',
+        'requests_dir': 'Directory where BIP70 payment request files will be written.',
+        'ssl_privkey': 'Path to your SSL private key, needed to sign payment requests.',
         'ssl_chain': 'Chain of SSL certificates, needed for signed requests. Put your certificate at the top and the root CA at the end',
         'url_rewrite': 'Parameters passed to str.replace(), in order to create the r= part of bitcoincash: URIs. Example: \"(\'file:///var/www/\',\'https://electron-cash.org/\')\"',
+        'payment_url': 'URL where wallets will send signed payments (optional but recommended)',
     },
     'listrequests':{
         'url_rewrite': 'Parameters passed to str.replace(), in order to create the r= part of bitcoincash: URIs. Example: \"(\'file:///var/www/\',\'https://electron-cash.org/\')\"',

--- a/lib/interface.py
+++ b/lib/interface.py
@@ -310,7 +310,7 @@ class Interface(util.PrintError):
         self.pipe.clean_up()
 
     def queue_request(self, *args):  # method, params, _id
-        '''Queue a request, later to be send with send_requests when the
+        '''Queue a request, later to be sent with send_requests when the
         socket is available for writing.
         '''
         self.request_time = time.time()


### PR DESCRIPTION
Electrum Merchant is the only use-as-is solution for BIP70 payment requests in Electron Cash but there are other solutions that allow for greater flexibility by setting index_url to something other than the index.html file provided by that package. Even still, this check is not necessary to allow electrum-merchant to function or even avoid a crash in the case that it is not installed properly (the link will simply be dead).