### PR TITLE
Added create/restore functionality in RPC, fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ xcuserdata/
 
 # IntelliJ Pycharm IDE
 /.idea
+# vs code
+.vscode/
+# mypy
+.mypy_cache/

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -41,6 +41,7 @@ from .i18n import _
 from .transaction import Transaction, multisig_script
 from .paymentrequest import PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
 from .plugins import run_hook
+from .wallet import create_new_wallet, restore_wallet_from_text
 
 known_commands = {}
 
@@ -171,17 +172,39 @@ class Commands:
         return ' '.join(sorted(known_commands.keys()))
 
     @command('')
-    def create(self):
-        """Create a new wallet"""
-        raise BaseException('Not a JSON-RPC command')
+    def create(self, passphrase=None, password=None, encrypt_file=True, seed_type=None, wallet_path=None):
+        """Create a new wallet.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
+        d = create_new_wallet(path=wallet_path,
+                              passphrase=passphrase,
+                              password=password,
+                              encrypt_file=encrypt_file,
+                              seed_type=seed_type,
+                              config=self.config)
+        return {
+            'seed': d['seed'],
+            'path': d['wallet'].storage.path,
+            'msg': d['msg'],
+        }
 
-    @command('wn')
-    def restore(self, text):
+    @command('')
+    def restore(self, text, passphrase=None, password=None, encrypt_file=True, wallet_path=None):
         """Restore a wallet from text. Text can be a seed phrase, a master
-        public key, a master private key, a list of bitcoin cash addresses
-        or bitcoin cash private keys. If you want to be prompted for your
-        seed, type '?' or ':' (concealed) """
-        raise BaseException('Not a JSON-RPC command')
+        public key, a master private key, a list of bitcoin addresses
+        or bitcoin private keys.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
+        d = restore_wallet_from_text(text,
+                                     path=wallet_path,
+                                     passphrase=passphrase,
+                                     password=password,
+                                     encrypt_file=encrypt_file,
+                                     config=self.config)
+        return {
+            'path': d['wallet'].storage.path,
+            'msg': d['msg'],
+        }
 
     @command('wp')
     def password(self, password=None, new_password=None):

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -788,6 +788,7 @@ param_descriptions = {
 command_options = {
     'password':    ("-W", "Password"),
     'new_password':(None, "New Password"),
+    'encrypt_file':(None, "Whether the file on disk should be encrypted with the provided password"),
     'receiving':   (None, "Show only receiving addresses"),
     'change':      (None, "Show only change addresses"),
     'frozen':      (None, "Show only frozen addresses"),
@@ -801,8 +802,10 @@ command_options = {
     'from_addr':   ("-F", "Source address (must be a wallet address; use sweep to spend from non-wallet address)."),
     'change_addr': ("-c", "Change address. Default is a spare address, or the source address if it's not in the wallet"),
     'nbits':       (None, "Number of bits of entropy"),
+    'seed_type':   (None, "The type of seed to create, e.g. 'standard' or 'segwit'"),
     'entropy':     (None, "Custom entropy"),
     'language':    ("-L", "Default language for wordlist"),
+    'passphrase':  (None, "Seed extension"),
     'privkey':     (None, "Private key. Set to '?' to get a prompt."),
     'unsigned':    ("-u", "Do not sign transaction"),
     'locktime':    (None, "Set locktime block number"),
@@ -916,9 +919,11 @@ def add_global_options(parser):
     group.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False, help="Show debugging information")
     group.add_argument("-D", "--dir", dest="electron_cash_path", help="electron cash directory")
     group.add_argument("-P", "--portable", action="store_true", dest="portable", default=False, help="Use local 'electron_cash_data' directory")
-    group.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path")
     group.add_argument("-wp", "--walletpassword", dest="wallet_password", default=None, help="Supply wallet password")
     group.add_argument("--testnet", action="store_true", dest="testnet", default=False, help="Use Testnet")
+
+def add_wallet_option(parser):
+    parser.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path")
 
 def get_parser():
     # create main parser
@@ -944,6 +949,7 @@ def get_parser():
     parser_gui.add_argument("-R", "--relax_warnings", action="store_true", dest="relaxwarn", default=False, help="Disables certain warnings that might be annoying during development and/or testing")
     add_network_options(parser_gui)
     add_global_options(parser_gui)
+    add_wallet_option(parser_gui)
     # daemon
     parser_daemon = subparsers.add_parser('daemon', help="Run Daemon")
     parser_daemon.add_argument("subcommand", choices=['start', 'status', 'stop', 'load_wallet', 'close_wallet'], nargs='?')
@@ -958,6 +964,9 @@ def get_parser():
         if cmdname == 'restore':
             p.add_argument("-o", "--offline", action="store_true", dest="offline", default=False, help="Run offline")
         for optname, default in zip(cmd.options, cmd.defaults):
+            if optname in ['wallet_path', 'wallet']:
+                add_wallet_option(p)
+                continue
             a, help = command_options[optname]
             b = '--' + optname
             action = "store_true" if type(default) is bool else 'store'

--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -129,6 +129,7 @@ class Mnemonic(object):
     def mnemonic_to_seed(self, mnemonic, passphrase):
         PBKDF2_ROUNDS = 2048
         mnemonic = normalize_text(mnemonic)
+        passphrase = passphrase or ''
         passphrase = normalize_text(passphrase)
         return hashlib.pbkdf2_hmac('sha512', mnemonic.encode('utf-8'), b'electrum' + passphrase.encode('utf-8'), iterations = PBKDF2_ROUNDS)
 
@@ -161,7 +162,9 @@ class Mnemonic(object):
         i = self.mnemonic_decode(seed)
         return i % custom_entropy == 0
 
-    def make_seed(self, seed_type='standard', num_bits=132, custom_entropy=1):
+    def make_seed(self, seed_type=None, num_bits=132, custom_entropy=1):
+        if seed_type is None:
+            seed_type = 'standard'
         prefix = version.seed_prefix(seed_type)
         # increase num_bits in order to obtain a uniform distibution for the last word
         bpw = math.log(len(self.wordlist), 2)

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -204,7 +204,7 @@ class SimpleConfig(PrintError):
 
         # command line -w option
         if self.get('wallet_path'):
-            return os.path.join(self.get('cwd'), self.get('wallet_path'))
+            return os.path.join(self.get('cwd', ''), self.get('wallet_path'))
 
         # path in config file
         path = self.get('default_wallet_path')

--- a/lib/tests/test_wallet.py
+++ b/lib/tests/test_wallet.py
@@ -27,7 +27,7 @@ class WalletTestCase(unittest.TestCase):
     def setUp(self):
         super(WalletTestCase, self).setUp()
         self.user_dir = tempfile.mkdtemp()
-        self.config = SimpleConfig({'electrum_path': self.user_dir})
+        self.config = SimpleConfig({'electron_cash_path': self.user_dir})
 
         self.wallet_path = os.path.join(self.user_dir, "somewallet")
 

--- a/lib/tests/test_wallet.py
+++ b/lib/tests/test_wallet.py
@@ -8,6 +8,9 @@ import json
 from io import StringIO
 from ..storage import WalletStorage, FINAL_SEED_VERSION
 from .. import wallet
+from ..wallet import create_new_wallet, restore_wallet_from_text
+from ..simple_config import SimpleConfig
+from ..address import Address
 
 
 class FakeSynchronizer(object):
@@ -24,6 +27,7 @@ class WalletTestCase(unittest.TestCase):
     def setUp(self):
         super(WalletTestCase, self).setUp()
         self.user_dir = tempfile.mkdtemp()
+        self.config = SimpleConfig({'electrum_path': self.user_dir})
 
         self.wallet_path = os.path.join(self.user_dir, "somewallet")
 
@@ -68,3 +72,68 @@ class TestWalletStorage(WalletTestCase):
         with open(self.wallet_path, "r") as f:
             contents = f.read()
         self.assertEqual(some_dict, json.loads(contents))
+
+class TestCreateRestoreWallet(WalletTestCase):
+
+    def test_create_new_wallet(self):
+        passphrase = 'mypassphrase'
+        password = 'mypassword'
+        encrypt_file = True
+        d = create_new_wallet(path=self.wallet_path,
+                              passphrase=passphrase,
+                              password=password,
+                              encrypt_file=encrypt_file,
+                              config=self.config)
+        wallet = d['wallet']  # type: Standard_Wallet
+        wallet.check_password(password)
+        self.assertEqual(passphrase, wallet.keystore.get_passphrase(password))
+        self.assertEqual(d['seed'], wallet.keystore.get_seed(password))
+        self.assertEqual(encrypt_file, wallet.storage.is_encrypted())
+
+    def test_restore_wallet_from_text_mnemonic(self):
+        text = 'head frost nest keep flavor winner pretty mimic truly sense snack laugh'
+        passphrase = 'mypassphrase'
+        password = 'mypassword'
+        encrypt_file = True
+        d = restore_wallet_from_text(text,
+                                     path=self.wallet_path,
+                                     passphrase=passphrase,
+                                     password=password,
+                                     encrypt_file=encrypt_file,
+                                     config=self.config)
+        wallet = d['wallet']  # type: Standard_Wallet
+        self.assertEqual(passphrase, wallet.keystore.get_passphrase(password))
+        self.assertEqual(text, wallet.keystore.get_seed(password))
+        self.assertEqual(encrypt_file, wallet.storage.is_encrypted())
+        self.assertEqual(Address.from_string('qrrqa5sv8xrg7lrq3l4c3ememxfwwsa09gcgf0r5jf'), wallet.get_receiving_addresses()[0])
+
+    def test_restore_wallet_from_text_xpub(self):
+        text = 'xpub6CUzEfgtza7ZNtfDGYwHPnbPMPiQh93mAbP6v7C3ozUgkZq4tXSgYb9qqZ62oh8RCeexdSF7ZJmTzCm5bdWLB3zSMF8rNfuY8kccNAsdF4d'
+        d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
+        wallet = d['wallet']  # type: Standard_Wallet
+        self.assertEqual(text, wallet.keystore.get_master_public_key())
+        self.assertEqual(Address.from_string('qzrseeup3rhehuaf9e6nr3sgm6t5eegufu96l404mu'), wallet.get_receiving_addresses()[0])
+
+    def test_restore_wallet_from_text_xprv(self):
+        text = 'xprv9y4nb6Akxru8R68sYGrihutfqUgMNxmiF83ViTf65MobJrRRyHWc1M8mSZJSmZ1nQCJntxmF99sKGkkcQQGziECvdkwA4kqxsH5srNAzRin'
+        d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
+        wallet = d['wallet']  # type: Standard_Wallet
+        self.assertEqual(text, wallet.keystore.get_master_private_key(password=None))
+        self.assertEqual(Address.from_string('qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9'), wallet.get_receiving_addresses()[0])
+
+    def test_restore_wallet_from_text_addresses(self):
+        text = 'qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9'
+        d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
+        wallet = d['wallet']  # type: Abstract_Wallet
+        self.assertEqual(Address.from_string('qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9'), wallet.get_receiving_addresses()[0])
+        self.assertEqual(1, len(wallet.get_receiving_addresses()))
+
+    def test_restore_wallet_from_text_privkeys(self):
+        text = 'Kz7FS9Adyj6RgSVGx5YLjZPanUhuze4yvcziZ1qLA24a3GJJZvBr'
+        d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
+        wallet = d['wallet']  # type: Abstract_Wallet
+        addr0 = wallet.get_receiving_addresses()[0]
+        self.assertEqual(Address.from_string('qzrseeup3rhehuaf9e6nr3sgm6t5eegufu96l404mu'), addr0)
+        self.assertEqual('Kz7FS9Adyj6RgSVGx5YLjZPanUhuze4yvcziZ1qLA24a3GJJZvBr',
+                         wallet.export_private_key(addr0, password=None))
+        self.assertEqual(1, len(wallet.get_receiving_addresses()))

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -48,7 +48,8 @@ from .bitcoin import *
 from .version import *
 from .keystore import load_keystore, Hardware_KeyStore, Imported_KeyStore, BIP32_KeyStore, xpubkey_to_address
 from . import networks
-from .storage import multisig_type
+from . import keystore
+from .storage import multisig_type, WalletStorage
 
 from . import transaction
 from .transaction import Transaction
@@ -60,6 +61,7 @@ from .verifier import SPV, SPVDelegate
 from . import schnorr
 from . import ecc_fast
 from .blockchain import NULL_HASH_HEX
+from .mnemonic import Mnemonic
 
 
 from . import paymentrequest
@@ -2797,3 +2799,65 @@ class Wallet(object):
         if wallet_type in wallet_constructors:
             return wallet_constructors[wallet_type]
         raise UnknownWalletType("Unknown wallet type: " + str(wallet_type))
+
+
+def create_new_wallet(*, path, config, passphrase=None, password=None,
+                      encrypt_file=True, seed_type=None, gap_limit=None) -> dict:
+    """Create a new wallet"""
+    storage = WalletStorage(path)
+    if storage.file_exists():
+        raise Exception("Remove the existing wallet first!")
+
+    seed = Mnemonic('en').make_seed(seed_type)
+    k = keystore.from_seed(seed, passphrase, False)
+    storage.put('keystore', k.dump())
+    storage.put('wallet_type', 'standard')
+    if gap_limit is not None:
+        storage.put('gap_limit', gap_limit)
+    wallet = Wallet(storage)
+    wallet.update_password(old_pw=None, new_pw=password, encrypt=encrypt_file)
+    wallet.synchronize()
+    msg = "Please keep your seed in a safe place; if you lose it, you will not be able to restore your wallet."
+
+    wallet.storage.write()
+    return {'seed': seed, 'wallet': wallet, 'msg': msg}
+
+
+def restore_wallet_from_text(text, *, path, config,
+                             passphrase=None, password=None, encrypt_file=True,
+                             gap_limit=None) -> dict:
+    """Restore a wallet from text. Text can be a seed phrase, a master
+    public key, a master private key, a list of bitcoin addresses
+    or bitcoin private keys."""
+    storage = WalletStorage(path)
+    if storage.file_exists():
+        raise Exception("Remove the existing wallet first!")
+
+    text = text.strip()
+    if keystore.is_address_list(text):
+        wallet = ImportedAddressWallet.from_text(storage, text)
+        wallet.save_addresses()
+    elif keystore.is_private_key_list(text,):
+        k = keystore.Imported_KeyStore({})
+        storage.put('keystore', k.dump())
+        wallet = ImportedPrivkeyWallet.from_text(storage, text, password)
+    else:
+        if keystore.is_master_key(text):
+            k = keystore.from_master_key(text)
+        elif keystore.is_seed(text):
+            k = keystore.from_seed(text, passphrase, False)
+        else:
+            raise Exception("Seed or key not recognized")
+        storage.put('keystore', k.dump())
+        storage.put('wallet_type', 'standard')
+        if gap_limit is not None:
+            storage.put('gap_limit', gap_limit)
+        wallet = Wallet(storage)
+
+    wallet.update_password(old_pw=None, new_pw=password, encrypt=encrypt_file)
+    wallet.synchronize()
+    msg = ("This wallet was restored offline. It may contain more addresses than displayed. "
+           "Start a daemon and use load_wallet to sync its history.")
+
+    wallet.storage.write()
+    return {'wallet': wallet, 'msg': msg}

--- a/setup.py
+++ b/setup.py
@@ -119,20 +119,16 @@ if sys.platform in ('win32', 'cygwin'):
         ],
     }
 
-extras_require = {
-    'hardware': requirements_hw,
-    'gui': ['pyqt5'],
-}
-extras_require['full'] = [pkg for sublist in list(extras_require.values()) for pkg in sublist]
-
 setup(
     cmdclass={
         'sdist': MakeAllBeforeSdist,
     },
     name=os.environ.get('EC_PACKAGE_NAME') or "Electron Cash",
     version=os.environ.get('EC_PACKAGE_VERSION') or version.PACKAGE_VERSION,
-    install_requires=requirements,
-    extras_require=extras_require,
+    install_requires=requirements + ['pyqt5'],
+    extras_require={
+        'hardware': requirements_hw,
+    },
     packages=[
         'electroncash',
         'electroncash.locale',  # work-around for Android platform limitations

--- a/setup.py
+++ b/setup.py
@@ -119,16 +119,20 @@ if sys.platform in ('win32', 'cygwin'):
         ],
     }
 
+extras_require = {
+    'hardware': requirements_hw,
+    'gui': ['pyqt5'],
+}
+extras_require['full'] = [pkg for sublist in list(extras_require.values()) for pkg in sublist]
+
 setup(
     cmdclass={
         'sdist': MakeAllBeforeSdist,
     },
     name=os.environ.get('EC_PACKAGE_NAME') or "Electron Cash",
     version=os.environ.get('EC_PACKAGE_VERSION') or version.PACKAGE_VERSION,
-    install_requires=requirements + ['pyqt5'],
-    extras_require={
-        'hardware': requirements_hw,
-    },
+    install_requires=requirements,
+    extras_require=extras_require,
     packages=[
         'electroncash',
         'electroncash.locale',  # work-around for Android platform limitations


### PR DESCRIPTION
This pull request adds ability to use create and restore from RPC.
This is mostly a backport(with some fixes specific to electron cash) from electrum to electron cash.
Also I made PyQt5 not a mandatory requirement, so to install pyqt5 too, you would need
`pip install .[full]` or `pip install .[gui]`
Binary building might be adjusted to include this dependency.
I have also fixed some issues I met when adding this functionality.
Tests are for that are added too.