### PR TITLE
Added support for BIP70 Payment and PaymentACK

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -699,6 +699,16 @@ class Commands:
         self.wallet.sign_payment_request(address, alias, alias_addr, password)
 
     @command('w')
+    def addpayment(self, requestid, paymentfile, gettxns=False):
+        """Add a Payment file for a given payment request"""
+        return self.wallet.add_payment(requestid, paymentfile, self.config, gettxns)
+
+    @command('w')
+    def createack(self, requestid, payment_index, memo=''):
+        """Create a PaymentACK for a given payment made for a given request"""
+        return self.wallet.create_ack(requestid, payment_index, self.config, memo)
+
+    @command('w')
     def rmrequest(self, address):
         """Remove a payment request"""
         return self.wallet.remove_payment_request(address, self.config)
@@ -779,6 +789,7 @@ command_options = {
     'change_addr': ("-c", "Change address. Default is a spare address, or the source address if it's not in the wallet"),
     'nbits':       (None, "Number of bits of entropy"),
     'entropy':     (None, "Custom entropy"),
+    'gettxns':     (None, "Output the transasctions from the payment"),
     'language':    ("-L", "Default language for wordlist"),
     'privkey':     (None, "Private key. Set to '?' to get a prompt."),
     'unsigned':    ("-u", "Do not sign transaction"),

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -366,6 +366,22 @@ def make_unsigned_request(req):
     pr.signature = util.to_bytes('')
     return pr
 
+def get_payment(paymentfile):
+    p = pb2.Payment()
+    try:
+      f = open(paymentfile, "rb")
+      p.ParseFromString(f.read())
+      f.close()
+    except IOError:
+      print (paymentfile + ": Could not open payment file")
+    return p
+
+def create_payment_ack(paymentfile, memo):
+    p = get_payment(paymentfile)
+    ack = pb2.PaymentACK()
+    ack.payment.CopyFrom(p)
+    ack.memo = memo
+    return ack
 
 def sign_request_with_alias(pr, alias, alias_privkey):
     pr.pki_type = 'dnssec+btc'


### PR DESCRIPTION
When an EC merchant receieves a BIP70 Payment from a customer it can be
archived alongside the associated payment request for future reference and for
extracting transaction data. A subsequent PaymentACK can be constructed
from the Payment and a user-defined memo.