### PR TITLE
Add index_url override to addrequest command

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -665,7 +665,7 @@ class Commands:
         return self.wallet.get_unused_address().to_ui_string()
 
     @command('w')
-    def addrequest(self, amount, memo='', expiration=None, force=False, payment_url=None):
+    def addrequest(self, amount, memo='', expiration=None, force=False, payment_url=None, index_url=None):
         """Create a payment request, using the first unused address of the wallet.
         The address will be condidered as used after this operation.
         If no payment is received, the address will be considered as unused if the payment request is deleted from the wallet."""
@@ -681,7 +681,7 @@ class Commands:
                 return False
         amount = satoshis(amount)
         expiration = int(expiration) if expiration else None
-        req = self.wallet.make_payment_request(addr, amount, memo, expiration, payment_url = payment_url)
+        req = self.wallet.make_payment_request(addr, amount, memo, expiration, payment_url = payment_url, index_url = index_url)
         self.wallet.add_payment_request(req, self.config)
         out = self.wallet.get_payment_request(addr, self.config)
         return self._format_request(out)
@@ -774,6 +774,7 @@ command_options = {
     'labels':      ("-l", "Show the labels of listed addresses"),
     'nocheck':     (None, "Do not verify aliases"),
     'imax':        (None, "Maximum number of inputs"),
+    'index_url':   (None, 'Override the URL where you would like users to be shown the BIP70 Payment Request'),
     'fee':         ("-f", "Transaction fee (in BCH)"),
     'from_addr':   ("-F", "Source address (must be a wallet address; use sweep to spend from non-wallet address)."),
     'change_addr': ("-c", "Change address. Default is a spare address, or the source address if it's not in the wallet"),

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1706,7 +1706,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                     baseurl = baseurl.replace(*rewrite)
                 out['request_url'] = os.path.join(baseurl, 'req', key[0], key[1], key, key)
                 out['URI'] += '&r=' + out['request_url']
-                out['index_url'] = os.path.join(baseurl, 'index.html') + '?id=' + key
+                if not 'index_url' in out:
+                    out['index_url'] = os.path.join(baseurl, 'index.html') + '?id=' + key
                 websocket_server_announce = config.get('websocket_server_announce')
                 if websocket_server_announce:
                     out['websocket_server'] = websocket_server_announce
@@ -1745,7 +1746,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         return status, conf
 
     def make_payment_request(self, addr, amount, message, expiration=None, *,
-                             op_return=None, op_return_raw=None, payment_url=None):
+                             op_return=None, op_return_raw=None, payment_url=None, index_url=None):
         assert isinstance(addr, Address)
         if op_return and op_return_raw:
             raise ValueError("both op_return and op_return_raw cannot be specified as arguments to make_payment_request")
@@ -1761,6 +1762,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         }
         if payment_url:
             d['payment_url'] = payment_url + "/" + _id
+        if index_url:
+            d['index_url'] = index_url + "/" + _id
         if op_return:
             d['op_return'] = op_return
         if op_return_raw:


### PR DESCRIPTION
Normally addrequest will only generate a url for a static page using GET
request key/value format (e.g. mydomain.com/index.html?id=abcdefghij).
By adding the --index_url option to addrequest, users can override this
format and specify the url they want to use for displaying BIP70 payment
requests.