### PR TITLE
Add change-address reservation subsystem

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -146,7 +146,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.hardwarewalletdialog = None
         self.require_fee_update = False
         self.cashaddr_toggled_signal = self.gui_object.cashaddr_toggled_signal  # alias for backwards compatibility for plugins -- this signal used to live in each window and has since been refactored to gui-object where it belongs (since it's really an app-global setting)
-        self.force_use_single_change_addr = None  # this is set by the CashShuffle plugin to a single string that will go into the tool-tip explaining why this preference option is disabled (see self.settings_dialog)
         self.tl_windows = []
         self.tx_external_keypairs = {}
         self._tx_dialogs = Weak.Set()
@@ -4473,44 +4472,32 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         per_wallet_tx_widgets.append((notify_tx_cb, None))
 
         usechange_cb = QCheckBox(_('Use change addresses'))
-        if self.force_use_single_change_addr:
-            usechange_cb.setChecked(True)
-            usechange_cb.setEnabled(False)
-            if isinstance(self.force_use_single_change_addr, str):
-                usechange_cb.setToolTip(self.force_use_single_change_addr)
-        else:
-            usechange_cb.setChecked(self.wallet.use_change)
-            usechange_cb.setToolTip(_('Using change addresses makes it more difficult for other people to track your transactions.'))
-            def on_usechange(x):
-                usechange_result = x == Qt.Checked
-                if self.wallet.use_change != usechange_result:
-                    self.wallet.use_change = usechange_result
-                    self.wallet.storage.put('use_change', self.wallet.use_change)
-                    multiple_cb.setEnabled(self.wallet.use_change)
-            usechange_cb.stateChanged.connect(on_usechange)
+        usechange_cb.setChecked(self.wallet.use_change)
+        usechange_cb.setToolTip(_('Using change addresses makes it more difficult for other people to track your transactions.'))
+        def on_usechange(x):
+            usechange_result = x == Qt.Checked
+            if self.wallet.use_change != usechange_result:
+                self.wallet.use_change = usechange_result
+                self.wallet.storage.put('use_change', self.wallet.use_change)
+                multiple_cb.setEnabled(self.wallet.use_change)
+        usechange_cb.stateChanged.connect(on_usechange)
         per_wallet_tx_widgets.append((usechange_cb, None))
 
         multiple_change = self.wallet.multiple_change
         multiple_cb = QCheckBox(_('Use multiple change addresses'))
-        if self.force_use_single_change_addr:
-            multiple_cb.setEnabled(False)
-            multiple_cb.setChecked(False)
-            if isinstance(self.force_use_single_change_addr, str):
-                multiple_cb.setToolTip(self.force_use_single_change_addr)
-        else:
-            multiple_cb.setEnabled(self.wallet.use_change)
-            multiple_cb.setToolTip('\n'.join([
-                _('In some cases, use up to 3 change addresses in order to break '
-                  'up large coin amounts and obfuscate the recipient address.'),
-                _('This may result in higher transactions fees.')
-            ]))
-            multiple_cb.setChecked(multiple_change)
-            def on_multiple(x):
-                multiple = x == Qt.Checked
-                if self.wallet.multiple_change != multiple:
-                    self.wallet.multiple_change = multiple
-                    self.wallet.storage.put('multiple_change', multiple)
-            multiple_cb.stateChanged.connect(on_multiple)
+        multiple_cb.setEnabled(self.wallet.use_change)
+        multiple_cb.setToolTip('\n'.join([
+            _('In some cases, use up to 3 change addresses in order to break '
+              'up large coin amounts and obfuscate the recipient address.'),
+            _('This may result in higher transactions fees.')
+        ]))
+        multiple_cb.setChecked(multiple_change)
+        def on_multiple(x):
+            multiple = x == Qt.Checked
+            if self.wallet.multiple_change != multiple:
+                self.wallet.multiple_change = multiple
+                self.wallet.storage.put('multiple_change', multiple)
+        multiple_cb.stateChanged.connect(on_multiple)
         per_wallet_tx_widgets.append((multiple_cb, None))
 
         def fmt_docs(key, klass):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -225,6 +225,12 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         # The two types of freezing are flagged independently of each other and 'spendable' is defined as a coin that satisfies
         # BOTH levels of freezing.
         self.frozen_coins = set(storage.get('frozen_coins', []))
+
+        self.change_reserved = set(Address.from_string(a) for a in storage.get('change_reserved', ()))
+        self.change_reserved_default = [Address.from_string(a) for a in storage.get('change_reserved_default', ())]
+        self.change_unreserved = [Address.from_string(a) for a in storage.get('change_unreserved', ())]
+        self.change_reserved_tmp = set() # in-memory only
+
         # address -> list(txid, height)
         history = storage.get('addr_history',{})
         self._history = self.to_Address_dict(history)
@@ -362,6 +368,13 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             self.cashacct.save()
             if write:
                 self.storage.write()
+
+    def save_change_reservations(self):
+        with self.lock:
+            self.storage.put('change_reserved_default', [a.to_storage_string() for a in self.change_reserved_default])
+            self.storage.put('change_reserved', [a.to_storage_string() for a in self.change_reserved])
+            unreserved = self.change_unreserved + list(self.change_reserved_tmp)
+            self.storage.put('change_unreserved', [a.to_storage_string() for a in unreserved])
 
     def clear_history(self):
         with self.lock:
@@ -1608,6 +1621,106 @@ class Abstract_Wallet(PrintError, SPVDelegate):
     def dust_threshold(self):
         return dust_threshold(self.network)
 
+    def reserve_change_addresses(self, count, temporary=False):
+        """ Reserve and return `count` change addresses. In order
+        of preference, this will return from:
+
+        1. addresses 'freed' by `.unreserve_change_address`,
+        2. addresses in the last 20 (gap limit) of the change list,
+        3. newly-created addresses.
+
+        Of these, only unlabeled, unreserved addresses with no usage history
+        will be returned. If you pass temporary=False (default), this will
+        persist upon wallet saving, otherwise with temporary=True the address
+        will be made available again once the wallet is re-opened.
+
+        On non-deterministic wallets, this returns an empty list.
+        """
+        if count <= 0 or not hasattr(self, 'create_new_address'):
+            return []
+
+        with self.lock:
+            last_change_addrs = self.get_change_addresses()[-self.gap_limit_for_change:]
+            if not last_change_addrs:
+                # this happens in non-deterministic wallets but the above
+                # hasattr check should have caught those.
+                return []
+
+            def gen_change():
+                try:
+                    while True:
+                        yield self.change_unreserved.pop(0)
+                except IndexError:
+                    pass
+                for addr in last_change_addrs:
+                    yield addr
+                while True:
+                    yield self.create_new_address(for_change=True)
+
+            result = []
+            for addr in gen_change():
+                if (   addr in self.change_reserved
+                    or addr in self.change_reserved_tmp
+                    or self.get_num_tx(addr) != 0
+                    or addr in result):
+                    continue
+
+                addr_str = addr.to_storage_string()
+                if self.labels.get(addr_str):
+                    continue
+
+                result.append(addr)
+                if temporary:
+                    self.change_reserved_tmp.add(addr)
+                else:
+                    self.change_reserved.add(addr)
+                if len(result) >= count:
+                    return result
+
+            raise RuntimeError("Unable to generate new addresses") # should not happen
+
+    def unreserve_change_address(self, addr):
+        """ Unreserve an addr that was set by reserve_change_addresses, and
+        also explicitly reschedule this address to be usable by a future
+        reservation. Unreserving is appropriate when the address was never
+        actually shared or used in a transaction, and reduces empty gaps in
+        the change list.
+        """
+        assert addr in self.get_change_addresses()
+        with self.lock:
+            self.change_reserved.discard(addr)
+            self.change_reserved_tmp.discard(addr)
+            self.change_unreserved.append(addr)
+
+    def get_default_change_addresses(self, count):
+        """ Return `count` change addresses from the default reserved list,
+        ignoring and removing used addresses. Reserves more as needed.
+
+        The same default change addresses keep getting repeated until they are
+        actually seen as used in a transaction from the network. Theoretically
+        this could hurt privacy if the user has multiple unsigned transactions
+        open at the same time, but practically this avoids address gaps for
+        normal usage. If you need non-repeated addresses, see
+        `reserve_change_addresses`.
+
+        On non-deterministic wallets, this returns an empty list.
+        """
+        result = []
+        with self.lock:
+            for addr in list(self.change_reserved_default):
+                if len(result) >= count:
+                    break
+                if self.get_num_tx(addr) != 0:
+                    self.change_reserved_default.remove(addr)
+                    continue
+                result.append(addr)
+            need_more = count - len(result)
+            if need_more > 0:
+                new_addrs = self.reserve_change_addresses(need_more)
+                self.change_reserved_default.extend(new_addrs)
+                result.extend(new_addrs)
+            return result
+
     def make_unsigned_transaction(self, inputs, outputs, config, fixed_fee=None, change_addr=None, sign_schnorr=None):
         ''' sign_schnorr flag controls whether to mark the tx as signing with
         schnorr or not. Specify either a bool, or set the flag to 'None' to use
@@ -1632,32 +1745,6 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         for item in inputs:
             self.add_input_info(item)
 
-        # change address
-        if change_addr:
-            change_addrs = [change_addr]
-        else:
-            # This new hook is for 'Cashshuffle Enabled' mode which will:
-            # Reserve a brand new change address if spending shuffled-only *or* unshuffled-only coins and
-            # disregard the "use_change" setting since to preserve privacy we must use a new change address each time.
-            # Pick and lock a new change address. This "locked" change address will not be used by the shuffle threads.
-            # Note that subsequent calls to this function will return the same change address until that address is involved
-            # in a tx and has a history, at which point a new address will get generated and "locked".
-            change_addrs = run_hook("get_change_addrs", self)
-            if not change_addrs: # hook gave us nothing, so find a change addr based on classic Electron Cash rules.
-                addrs = self.get_change_addresses()[-self.gap_limit_for_change:]
-                if self.use_change and addrs:
-                    # New change addresses are created only after a few
-                    # confirmations.  Select the unused addresses within the
-                    # gap limit; if none take one at random
-                    change_addrs = [addr for addr in addrs if
-                                    self.get_num_tx(addr) == 0]
-                    if not change_addrs:
-                        change_addrs = [random.choice(addrs)]
-                else:
-                    change_addrs = [inputs[0]['address']]
-
-        assert all(isinstance(addr, Address) for addr in change_addrs)
-
         # Fee estimator
         if fixed_fee is None:
             fee_estimator = config.estimate_fee
@@ -1666,9 +1753,32 @@ class Abstract_Wallet(PrintError, SPVDelegate):
 
         if i_max is None:
             # Let the coin chooser select the coins to spend
-            max_change = self.max_change_outputs if self.multiple_change else 1
+
+            if change_addr:
+                change_addrs = [change_addr]
+            else:
+                if self.use_change:
+                    change_addrs = self.get_default_change_addresses(
+                            self.max_change_outputs if self.multiple_change else 1)
+                else:
+                    change_addrs = []
+
+                if not change_addrs:
+                    # For some reason we couldn't get any autogenerated
+                    # change address (non-deterministic wallet?). So,
+                    # try to find an input address that belongs to us.
+                    for inp in inputs:
+                        backup_addr = inp['address']
+                        if self.is_mine(backup_addr):
+                            change_addrs = [backup_addr]
+                            break
+                    else:
+                        raise RuntimeError("Can't find a change address!")
+
+            assert all(isinstance(addr, Address) for addr in change_addrs)
+
             coin_chooser = coinchooser.CoinChooserPrivacy()
-            tx = coin_chooser.make_tx(inputs, outputs, change_addrs[:max_change],
+            tx = coin_chooser.make_tx(inputs, outputs, change_addrs,
                                       fee_estimator, self.dust_threshold(), sign_schnorr=sign_schnorr)
         else:
             sendable = sum(map(lambda x:x['value'], inputs))
@@ -1696,6 +1806,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             locktime = 0
         tx.locktime = locktime
         run_hook('make_unsigned_transaction', self, tx)
+
         return tx
 
     def mktx(self, outputs, password, config, fee=None, change_addr=None, domain=None, sign_schnorr=None):
@@ -1814,6 +1925,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         self.save_transactions()
         self.save_verified_tx()  # implicit cashacct.save
         self.storage.put('frozen_coins', list(self.frozen_coins))
+        self.save_change_reservations()
         self.storage.write()
 
     def start_pruned_txo_cleaner_thread(self):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -2395,10 +2395,15 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 # reset the address list to default too, just in case. New synchronizer will pick up the addresses again.
                 self.receiving_addresses, self.change_addresses = self.receiving_addresses[:self.gap_limit], self.change_addresses[:self.gap_limit_for_change]
                 do_addr_save = True
+            self.change_reserved.clear()
+            self.change_reserved_default.clear()
+            self.change_unreserved.clear()
+            self.change_reserved_tmp.clear()
             self.invalidate_address_set_cache()
         if do_addr_save:
             self.save_addresses()
         self.save_transactions()
+        self.save_change_reservations()
         self.save_verified_tx()  # implicit cashacct.save
         self.storage.write()
         self.start_threads(network)

--- a/plugins/shuffle/client.py
+++ b/plugins/shuffle/client.py
@@ -335,7 +335,8 @@ class BackgroundShufflingThread(threading.Thread, PrintError):
         self._last_server_check = 0.0  # timestamp in seconds unix time
         self._dummy_address = Address.from_pubkey(EC_KEY(number_to_string(1337, generator_secp256k1.order())).get_public_key())  # dummy address
         # below 4 vars are related to the "delayed unreserve address" mechanism as part of the bug #70 & #97 workaround and the complexity created by it..
-        self._delayed_unreserve_addresses = dict()  # dict of Address -> time.time() timestamp when its shuffle ended
+        self._delayed_unreserve_new = dict()  # dict of Address -> time.time() timestamp when its shuffle ended
+        self._delayed_unreserve_change = dict()  # dict of Address -> time.time() timestamp when its shuffle ended
         self._last_delayed_unreserve_check = 0.0  # timestamp in seconds unix time
         self._delayed_unreserve_check_interval = 60.0  # check these addresses every 60 seconds.
         self._delayed_unreserve_timeout = 600.0  # how long before the delayed-unreserve addresses expire; 10 minutes
@@ -504,7 +505,9 @@ class BackgroundShufflingThread(threading.Thread, PrintError):
 
     def check_delayed_unreserve_addresses(self):
         ''' Expire addresses put in the "delayed unreserve" dict which are
-        >600 seconds old.'''
+        >600 seconds old. For shuffled-output addresses, these are given back
+        to the wallet and can be used for anything. For change addresses, they
+        go back to a pool used for shuffle change only.'''
         if self.stop_flg.is_set():
             return
         now = time.time()
@@ -519,10 +522,15 @@ class BackgroundShufflingThread(threading.Thread, PrintError):
                 # the addresses_cashshuffle_reserved set while we mutate it.
                 # This code path is executed very infrequently so it's not really
                 # a huge hit.
-                for addr, ts in self._delayed_unreserve_addresses.copy().items():
+                for addr, ts in self._delayed_unreserve_new.copy().items():
                     if now - ts > self._delayed_unreserve_timeout:
+                        self._delayed_unreserve_new.pop(addr, None)
+                        self.wallet.unreserve_change_address(addr)
+                        ct += 1
+                for addr, ts in self._delayed_unreserve_change.copy().items():
+                    if now - ts > self._delayed_unreserve_timeout:
+                        self._delayed_unreserve_change.pop(addr, None)
                         self.wallet._addresses_cashshuffle_reserved.discard(addr)
-                        self._delayed_unreserve_addresses.pop(addr, None)
                         ct += 1
             if ct:
                 self.print_error("Freed {} 'delayed unreserve' addresses in {:.02f} msec".format(ct, (time.time()-now)*1e3))
@@ -604,9 +612,6 @@ class BackgroundShufflingThread(threading.Thread, PrintError):
             l = len(self.wallet._addresses_cashshuffle_reserved)
             self.wallet._addresses_cashshuffle_reserved.clear()
             if l: self.print_error("Freed {} reserved addresses".format(l))
-            if self.wallet._last_change:
-                self.wallet._last_change = None
-                self.print_error("Freed 'last_change'")
             CoinUtils.unfreeze_frozen_by_shuffling(self.wallet)
             self._coins_busy_shuffling.clear()
 
@@ -642,9 +647,8 @@ class BackgroundShufflingThread(threading.Thread, PrintError):
             with self.wallet.lock:
                 if need_to_discard_change_if_errored and thr.protocol and not thr.protocol.did_use_change:
                     # The reserved change output address was definitely not used.
-                    # Immediately unreserve this change_addr so that it doesn't
-                    # 'leak' (create gaps) and so that other threads may reserve
-                    # it for shuffles immediately.
+                    # Immediately unreserve this change_addr so that other threads
+                    # may reserve it for shuffles immediately.
                     self.wallet._addresses_cashshuffle_reserved.discard(thr.change_addr)
                     need_to_discard_change_if_errored = False
                 self.wallet.set_frozen_coin_state([sender], False)
@@ -660,14 +664,14 @@ class BackgroundShufflingThread(threading.Thread, PrintError):
                         # to mark these addresses to be unreserved at a later
                         # time rather than right away.
                         now = time.time()
-                        self._delayed_unreserve_addresses[thr.addr_new_addr] = now
+                        self._delayed_unreserve_new[thr.addr_new_addr] = now
                         if need_to_discard_change_if_errored:
-                            self._delayed_unreserve_addresses[thr.change_addr] = now
+                            self._delayed_unreserve_change[thr.change_addr] = now
                         self.print_error("Shuffle of coin {} did reach the 'tentative' stage. Will unreserve its reserved addresses in {} minutes."
                                          .format(sender, self._delayed_unreserve_timeout / 60.0))
                     else:
                         # unreserve addresses that were previously reserved iff error
-                        self.wallet._addresses_cashshuffle_reserved.discard(thr.addr_new_addr)
+                        self.wallet.unreserve_change_address(thr.addr_new_addr)
                         if need_to_discard_change_if_errored:
                             self.wallet._addresses_cashshuffle_reserved.discard(thr.change_addr)
             thr.already_did_cleanup = True  # mark this thread as 'cleaned up'. this is necessary because this function may reenter with this thread again later and doing the clean-up twice would create bugs as it would unreserve addresses, etc, that may already be taken

--- a/plugins/shuffle/coin_utils.py
+++ b/plugins/shuffle/coin_utils.py
@@ -368,6 +368,7 @@ class CoinUtils(PrintError):
         wallet.storage.put(ConfKeys.PerWallet.CHANGE_SHARED_WITH_OTHERS,
                            [a.to_storage_string()
                             for a in wallet._shuffle_change_shared_with_others.copy()])
+        wallet.save_change_reservations()
         if write:
             wallet.storage.write()
 
@@ -527,42 +528,38 @@ class CoinUtils(PrintError):
             ret.append( (sum(c['value'] for c in l), len(l)) )
         return tuple(ret)
 
-    # Called from either the wallet code or the shufflethread.
-    # The wallet code calls this when spending either shuffled-only or unshuffled-only coins in a tx.
+    # Called from the shufflethread.
     # for_shufflethread may be a bool or an int. If int:
-    # 0    : not for shuffle threads, use the one wallet-global 'reserved' change guaranteed to not have any history, which won't ever conflict with the shuffle threads (used in 'Send' tab)
-    # 1    : for 'change' address use in shuffle threads. This address will be marked as having been 'announced' and will not be eligible to be used as a shuffled output address or in the Send tab as a change address for a user-created TX
-    # >=2  : for 'shuffled output' address use in shuffle threads. This address is guaranteed to have never been shared over the network with other shufflers AND to be unused
+    # 0    : unused, previously was for modifying `wallet.make_unsigned_transaction` behaviour in non-shuffle uses.
+    # 1    : for 'shuffle change' address. This address is reserved and if failed, it will be reused as a change address in a future shuffle.
+    # >=2  : for 'shuffled output' address. This is reserved solely for a single shuffle. If failed, it will be available as a normal address
     @staticmethod
     def get_new_change_address_safe(wallet, for_shufflethread=0):
         for_shufflethread = int(for_shufflethread or 0) # coerce to int in case it was a bool or None
+        if for_shufflethread == 0:
+            raise NotImplementedError
+
+        if for_shufflethread == 2:
+            return wallet.reserve_change_addresses(1, temporary=True)[0]
+
+        assert for_shufflethread == 1
         with wallet.lock:
-            if not for_shufflethread and wallet._last_change and not wallet.get_address_history(wallet._last_change):
-                # if they keep hitting preview on the same tx, give them the same change each time
-                return wallet._last_change
-            change = None
-            for address in wallet.get_unused_addresses(for_change=True):
-                if (address not in wallet._addresses_cashshuffle_reserved
-                        and (for_shufflethread == 1 or address not in wallet._shuffle_change_shared_with_others)):
-                    change = address
-                    break
-            while not change:
-                address = wallet.create_new_address(for_change=True)
-                if (address not in wallet._addresses_cashshuffle_reserved
-                        and (for_shufflethread == 1 or address not in wallet._shuffle_change_shared_with_others)):
-                    change = address
-            wallet._addresses_cashshuffle_reserved.add(change)
-            if not for_shufflethread:
-                # new change address generated for code outside the shuffle threads. cache and return it next time.
-                wallet._last_change = change
-            if for_shufflethread == 1:
-                # this was either a 'change' output for the shuffle thread
-                # Mark it as having been somewhat privacy-reduced so that if
-                # this function is called with for_shufflethread=2 or 0, we
-                # won't ever give this particular change address out again).
-                # See issue clifordsymack#105
-                wallet._shuffle_change_shared_with_others.add(change)
-            return change
+            # preferably, grab an already-reserved shuffle change addr that has
+            # been abandoned by a prior shuffle.
+            for address in wallet._shuffle_change_shared_with_others:
+                if wallet.get_num_tx(address) != 0:
+                    # Skip used addrs. These will eventually get discarded when saving.
+                    continue
+                if address not in wallet._addresses_cashshuffle_reserved:
+                    wallet._addresses_cashshuffle_reserved.add(address)
+                    return address
+
+            # otherwise, grab a fresh one
+            address = wallet.reserve_change_addresses(1)[0]
+            wallet._addresses_cashshuffle_reserved.add(address)
+            wallet._shuffle_change_shared_with_others.add(address)
+
+        return address
 
     @staticmethod
     @profiler

--- a/plugins/shuffle/qt.py
+++ b/plugins/shuffle/qt.py
@@ -424,7 +424,6 @@ def monkey_patches_apply(window):
         if window.network:
             window.network.register_callback(window._shuffle_network_callback, ['new_transaction'])
         window._shuffle_patched_ = True
-        window.force_use_single_change_addr = _("CashShuffle is enabled: change address logic will be handled by CashShuffle (to preserve privacy).")
         print_error("[shuffle] Patched window")
 
     def patch_utxo_list(utxo_list):
@@ -448,21 +447,8 @@ def monkey_patches_apply(window):
         wallet._shuffled_address_cache = set()
         wallet._addresses_cashshuffle_reserved = set()
         wallet._reshuffles = set()
-        wallet._last_change = None
         CoinUtils.load_shuffle_change_shared_with_others(wallet)  # sets wallet._shuffle_change_shared_with_others
-        # Paranoia -- force wallet into this single change address mode in case
-        # other code (plugins, etc) generate tx's. We don't want tx generation
-        # code to clobber our shuffle tx output addresses.
-        change_addr_policy_1 = (bool(wallet.storage.get('use_change')), bool(wallet.storage.get('multiple_change')))
-        change_addr_policy_2 = (bool(wallet.use_change), bool(wallet.multiple_change))
-        desired_policy = (True, False)
-        if any(policy != desired_policy for policy in (change_addr_policy_1, change_addr_policy_2)):
-            wallet.use_change, wallet.multiple_change = desired_policy
-            wallet.storage.put('use_change', desired_policy[0])
-            wallet.storage.put('multiple_change', desired_policy[1])
-            wallet.print_error("CashShuffle forced change address policy to: use_change={}, multiple_change={}"
-                               .format(desired_policy[0], desired_policy[1]))
-        # More paranoia -- in case app crashed, unfreeze coins frozen by last
+        # Paranoia -- in case app crashed, unfreeze coins frozen by last
         # app run.
         CoinUtils.unfreeze_frozen_by_shuffling(wallet)
         wallet._shuffle_patched_ = True
@@ -488,7 +474,6 @@ def monkey_patches_remove(window):
         delattr(window, 'send_tab_shuffle_extra')
         delattr(window, 'background_process')
         delattr(window, '_shuffle_patched_')
-        window.force_use_single_change_addr = None
         print_error("[shuffle] Unpatched window")
         # Note that at this point an additional monkey patch: 'window.__disabled_sendtab_extra__' may stick around until the plugin is unloaded altogether
 
@@ -514,7 +499,6 @@ def monkey_patches_remove(window):
         delattr(wallet, "_is_shuffled_cache")
         delattr(wallet, "_shuffled_address_cache")
         delattr(wallet, '_shuffle_patched_')
-        delattr(wallet, "_last_change")
         delattr(wallet, "_reshuffles")
         CoinUtils.store_shuffle_change_shared_with_others(wallet) # save _shuffle_change_shared_with_others to storage -- note this doesn't call storage.write() for performance reasons.
         delattr(wallet, '_shuffle_change_shared_with_others')
@@ -955,14 +939,6 @@ class Plugin(BasePlugin):
             rets += [_("{} {} are busy shuffling").format(window.format_amount(totInProg).strip(), window.base_unit())]
 
         return ') ('.join(rets) or None
-
-    @hook
-    def get_change_addrs(self, wallet):
-        for window in self.windows:
-            if wallet == window.wallet:
-                change_addrs = [wallet.cashshuffle_get_new_change_address()]
-                wallet.print_error("CashShuffle: reserving change address",change_addrs[0].to_ui_string())
-                return change_addrs
 
     @hook
     def do_clear(self, w):


### PR DESCRIPTION
This is a first pass at trying to decouple the address reservation system from cashshuffle. I've tested it in various ways and it works, but I can't test everything. No rush to merge this, but I'm going to build fusion assuming that something like `wallet.reserve_change_addresses` exists.

For the wallet:

- `make_unsigned_transaction` reserves addresses and keeps using those
until they actually appear in a tx.
- Plugins can also reserve addresses, which blocks them from ever being
used by `make_unsigned_transaction`, or by other plugins.
- The old rule of not filling in old gaps is respected. When we restore
from seed, it's safe to assume those gaps were there for a good reason.
- De-reservation is possible. These aren't just freed from reservation
but rather are actively scheduled to be used soon (regardless of the
old-gap rule).
- Reservations may be temporary, meaning they are automatically
de-reserved upon reloading the wallet.

For shuffle plugin:

- remove the hooking into `wallet.make_unsigned_transaction`.
- remove plugin's restriction on the change/multi-change settings for
  non-shuffle transactions.
- internally, `_addresses_cashshuffle_reserved` now only used for
  shuffle-change addrs; shuffled-output addrs are reserved directly
  from wallet, but only temporarily and they will return back to fully-
  available addresses if not used. This replicates previous behaviour.
- One small behaviour change: Previously, shuffle would fill any old
gap in the change address list, because it used `get_unused_addresses`.
This uses the new reservation system which follows the traditional rule
to not fill old gaps of unknown origin. Note however that recent gaps
created by shuffle will always be filled eventually, due to the
unreserving system.