### PR TITLE
transaction.py: don't append value when serializing inputs with scriptSig

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -664,7 +664,8 @@ class Transaction:
         s += script
         s += int_to_hex(txin.get('sequence', 0xffffffff - 1), 4)
         # offline signing needs to know the input value
-        if ('value' in txin   # Legacy txs
+        if ('value' in txin
+            and txin.get('scriptSig') is None
             and not (estimate_size or self.is_txin_complete(txin))):
             s += int_to_hex(txin['value'], 8)
         return s


### PR DESCRIPTION
fixes #1628
continues the theme of #1637 -- if an input has scriptSig, it *is*
essentially complete.

If people are doing smart contracts and need to save unsigned transactions,
my recommendation for the initial wallet:

- txin['type'] = 'unknown'
- set txin['scriptSig'] to anything you want, but I recommend making sure
  the first couple of bytes are 0000 or ffff, something like that, which
  ensures it won't get misinterpreted as one of the special input types.
  You can even embed metadata or signatures here, go wild.

Upon loading the transaction, Electron Cash will think that input is of
an unknown type (good) but also thinks it is complete (wrong). As a result,
the user will be presented with the ability to broadcast the tx, which
will of course fail. It's your job as smart contract author to do something
about that. Perhaps we can add a hook at the end of
`Transaction.deserialize()`?