### PR TITLE
iOS: Fixes for iOS 13.0+ and other miscellany

### DIFF
--- a/ios/CustomCode/CWStatusBarNotification/CWStatusBarNotification.h
+++ b/ios/CustomCode/CWStatusBarNotification/CWStatusBarNotification.h
@@ -209,6 +209,20 @@ typedef NS_ENUM(NSInteger, CWNotificationAnimationType) {
                            forDuration:(NSTimeInterval)duration;
 
 /**
+ * Displays a notification with the indicated message for the indicated
+ * duration.  Calls optional dismissedCompletion upon dismissal completion.
+ * @param message
+ *        The content of the message to be displayed.
+ * @param duration
+ *        The amount of seconds for which the notification should be displayed,
+ *        not including the animate in and out times.
+ * @param dismissedCompletion
+ *        If not nil, the block to call upon dismissal (after duration seconds).
+ */
+- (void)displayNotificationWithMessage:(NSString *)message forDuration:(NSTimeInterval)duration
+                   dismissedCompletion:(void (^)(void))dismissedCompletion;
+
+/**
  * Displays a notification with the indicated attributed string and then 
  * performs the completion block once the notification animates in.
  * @param attributedString

--- a/ios/CustomCode/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/ios/CustomCode/CWStatusBarNotification/CWStatusBarNotification.m
@@ -542,13 +542,21 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
 }
 
 - (void)displayNotificationWithMessage:(NSString *)message forDuration:(NSTimeInterval)duration
+                   dismissedCompletion:(void (^)(void))dismissedCompletion
 {
     [self displayNotificationWithMessage:message completion:^{
         self.dismissHandle = perform_block_after_delay(duration, ^{
-            [self dismissNotification];
+            [self dismissNotificationWithCompletion:dismissedCompletion];
         });
     }];
 }
+
+- (void)displayNotificationWithMessage:(NSString *)message forDuration:(NSTimeInterval)duration
+{
+    [self displayNotificationWithMessage:message forDuration:duration dismissedCompletion:nil];
+}
+
+
 
 - (void)displayNotificationWithAttributedString:(NSAttributedString *)attributedString completion:(void (^)(void))completion
 {

--- a/ios/ElectronCash/electroncash_gui/ios_native/appdelegate.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/appdelegate.py
@@ -41,22 +41,6 @@ class PythonAppDelegate(UIResponder):
         #bgStatus = "Enabled for this app." if UIBackgroundRefreshStatusAvailable == int(application.backgroundRefreshStatus) else "DISABLED"
         #print("Background refresh status: %s\nBackground fetch minimum interval: %f s\nMinimum Keep Alive Timeout: %f s"%(bgStatus,UIApplicationBackgroundFetchIntervalMinimum,UIMinimumKeepAliveTimeout))
 
-        def do_status_bar_workaround():
-            ''' iOS 13.0+ introduced a new "bug" where the top status bar produced by iOS cannot be covered
-            by our popup notification. As a result, if on iOS 13+ and on non-iPhoneX, we must hide the iOS
-            built-in status bar otherwise our "Downloading headers..." status notification gets garbled and
-            intermixed with the iOS status bar. On iPhone X or above, the status bar from iOS is in the
-            notch area, and we avoid that area, so we don't need this workaround for latest phones.
-            Just iPhone 5, 6, 7, 8, etc. Grr. Apple. Why?! '''
-            def should_hide_status_bar():
-                try:
-                    return bool(utils.ios_version_tuple()[0] >= 13 and not utils.is_iphoneX())
-                except Exception as e:
-                    print("ERROR trying to figure out if we should hide the status bar:", repr(e))
-                    return True
-            application.setStatusBarHidden_(should_hide_status_bar())
-        do_status_bar_workaround()
-
         return True
 
     @objc_method

--- a/ios/ElectronCash/electroncash_gui/ios_native/appdelegate.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/appdelegate.py
@@ -41,6 +41,9 @@ class PythonAppDelegate(UIResponder):
         #bgStatus = "Enabled for this app." if UIBackgroundRefreshStatusAvailable == int(application.backgroundRefreshStatus) else "DISABLED"
         #print("Background refresh status: %s\nBackground fetch minimum interval: %f s\nMinimum Keep Alive Timeout: %f s"%(bgStatus,UIApplicationBackgroundFetchIntervalMinimum,UIMinimumKeepAliveTimeout))
 
+        utils.ios13_status_bar_workaround.appdelegate_hook(appdelegate = self,
+                                                           application = application)
+
         return True
 
     @objc_method

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -577,6 +577,7 @@ class ElectrumGui(PrintError):
         def Completion() -> None:
             pass
         self.downloadingNotif_view.removeFromSuperview()
+        utils.ios13_status_bar_workaround.push()
         self.downloadingNotif.displayNotificationWithView_completion_(
             self.downloadingNotif_view,
             Completion
@@ -594,11 +595,12 @@ class ElectrumGui(PrintError):
         def compl() -> None:
             #print("Dismiss completion")
             if (self.downloadingNotif_view is not None
-                and dnf.customView is not None
-                and self.downloadingNotif_view.isDescendantOfView_(dnf.customView)):
+                    and dnf.customView is not None
+                    and self.downloadingNotif_view.isDescendantOfView_(dnf.customView)):
                 activityIndicator = self.downloadingNotif_view.viewWithTag_(1)
                 activityIndicator.animating = False # turn off animation to save CPU cycles
                 self.downloadingNotif_view.removeFromSuperview()
+                utils.ios13_status_bar_workaround.pop()
             dnf.release()
         dnf.dismissNotificationWithCompletion_(compl)
 

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -513,7 +513,7 @@ class ElectrumGui(PrintError):
         #if self.downloadingNotif is not None and self.is_downloading_notif_showing() and self.downloadingNotif_view is not None:
         #    self.dismiss_downloading_notif()
         #    self.show_downloading_notif()
-        pass
+        utils.ios13_status_bar_workaround.on_rotated()
 
     def on_history(self, event, *args):
         utils.NSLog("ON HISTORY '%s' (IsMainThread: %s)",event,str(NSThread.currentThread.isMainThread))

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -235,6 +235,7 @@ class ElectrumGui(PrintError):
         self.refresh_rate_max = 5.0
         self.refresh_rate_current = self.refresh_rate_min
         self.refresh_cost_stats = dict()
+        self.header_dl_start_height = 0
 
         self.keyEnclave = utils.SecureKeyEnclave(self.appDomain)
         self.encPasswords = utils.FileBackedDict(os.path.join(self.config.path, 'enc_pws.json'))
@@ -507,12 +508,6 @@ class ElectrumGui(PrintError):
             utils.NSDeallocObserver(alert).connect(OnDealloc)
 
     def on_rotated(self): # called by PythonAppDelegate after screen rotation
-        #update status bar label width
-
-        # on rotation sometimes the notif gets messed up.. so re-create it
-        #if self.downloadingNotif is not None and self.is_downloading_notif_showing() and self.downloadingNotif_view is not None:
-        #    self.dismiss_downloading_notif()
-        #    self.show_downloading_notif()
         utils.ios13_status_bar_workaround.on_rotated()
 
     def on_history(self, event, *args):
@@ -600,7 +595,7 @@ class ElectrumGui(PrintError):
                 activityIndicator = self.downloadingNotif_view.viewWithTag_(1)
                 activityIndicator.animating = False # turn off animation to save CPU cycles
                 self.downloadingNotif_view.removeFromSuperview()
-                utils.ios13_status_bar_workaround.pop()
+            utils.ios13_status_bar_workaround.pop()
             dnf.release()
         dnf.dismissNotificationWithCompletion_(compl)
 
@@ -708,8 +703,13 @@ class ElectrumGui(PrintError):
                         int(self.daemon.network.is_connected()))
             '''
             if lh is not None and sh is not None and lh >= 0 and sh > 0 and lh < sh:
-                show_dl_pct = int((lh*100.0)/float(sh))
+                self.header_dl_start_height = lh0 = self.header_dl_start_height or lh
+                if lh0 > lh:
+                    # guard in case cached start height is wonky or there was a reorg
+                    self.header_dl_start_height = lh0 = lh
+                show_dl_pct = int(((lh-lh0)*100.0)/float(sh-lh0))
                 walletStatus = wallets.StatusDownloadingHeaders
+                del lh0
 
             if blockHeightChanged:
                 self.refresh_components('history')
@@ -731,6 +731,7 @@ class ElectrumGui(PrintError):
         if show_dl_pct is not None and self.tabController.didLayout:
             self.show_downloading_notif(_("Downloading headers {}% ...").format(show_dl_pct) if show_dl_pct > 0 else None)
         else:
+            self.header_dl_start_height = 0 # reset the counter
             self.dismiss_downloading_notif()
 
         self.walletsVC.status = walletStatus

--- a/ios/ElectronCash/electroncash_gui/ios_native/send.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/send.py
@@ -788,32 +788,6 @@ class SendVC(SendBase):
 
         self.navigationController.pushViewController_animated_(txdetail.CreateTxDetailWithEntry(entry, on_label = newLabel), True)
 
-        # For modal do the following:
-        #self.presentViewController_animated_completion_(txdetail.CreateTxDetailWithEntry(entry, on_label = newLabel, asModalNav = True), True, None)
-        '''
-        # Below was used to generate a "please wait" notification but we optimized the code to be fast so this is no longer needed.. I hope!
-        # Keeping it here in case we see slow loads again for tx detail of unsigned tx's... Feel free to remove this code sometime in the future.
-
-        notif = None
-        txvc = None
-        def onAppear():
-            nonlocal notif
-            nonlocal txvc
-            if notif:
-                utils.dismiss_notification(notif.autorelease())
-                notif = None
-            utils.remove_callback(txvc, 'on_appear')
-
-        txvc = txdetail.CreateTxDetailWithEntry(entry, on_label = newLabel, on_appear = onAppear).retain()
-        def notifCompletion() -> None:
-            self.navigationController.pushViewController_animated_(txvc.autorelease(), True)
-        notif = utils.show_notification("Generating Tx, please wait...", duration = None, multiline = True,
-                                        animationDuration = 0.010,
-                                        #color = (.8,.6,.4,1.0),
-                                        noTapDismiss = True, completion = notifCompletion).retain()
-        '''
-
-
     @objc_method
     def doSend_(self, preview : bool) -> None:
         #if run_hook('abort_send', self):

--- a/ios/ElectronCash/electroncash_gui/ios_native/utils.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/utils.py
@@ -1857,22 +1857,23 @@ class ios13_status_bar_workaround:
         if cls._application is None:
             cls._application = UIApplication.sharedApplication
 
-
     @classmethod
     def _status_bar_hide(cls):
         ''' latch the status bar off '''
+        def sb_height():
+            s = cls._application.statusBarFrame.size
+            return min(s.width, s.height)
+        sb_height_was = sb_height() # save current status bar height for adjustment below...
         cls._application.setStatusBarHidden_(True)
         from . import gui
         g = gui.ElectrumGui.gui
         if g and g.window:
-            g.window.frame = r = UIScreen.mainScreen.bounds
-            # move window down so it doesn't glitch up after we hid the status bar
-            # TODO: FIXME:
-            # - On iPad in windowed mode likely this is wrong. Check/verify/fix
-            #   for iPad/windowed mode
-            if is_portrait():
-                r.origin.y += 20  # TODO: Get this value dynamically rather than hard-coding to future-proof this code!
-                r.size.height -= 20
+            g.window.frame = r = UIScreen.mainScreen.bounds  # this breaks on iPad in windowed mode.... TODO: FIX!
+            # Move window down so it doesn't glitch up after we hid the status bar
+            # Note that `sb_height_was` may be 0 if we didn't have a status bar
+            # visible (ie we are in landscape mode).
+            r.origin.y += sb_height_was
+            r.size.height -= sb_height_was
             g.window.frame = r
 
     @classmethod
@@ -1885,5 +1886,5 @@ class ios13_status_bar_workaround:
         if g and g.window:
             # restore window to its full position.. at this point
             # mainScreen.bounds is under the status bar (if visible)
-            g.window.frame = UIScreen.mainScreen.bounds
+            g.window.frame = UIScreen.mainScreen.bounds # this breaks on iPad in windowed mode.... TODO: FIX!
 #/end ios13_status_bar_workaround

--- a/ios/ElectronCash/electroncash_gui/ios_native/utils.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/utils.py
@@ -744,11 +744,16 @@ def show_notification(message : str,
                       ) -> ObjCInstance:
     cw_notif = CWStatusBarNotification.new().autorelease()
 
+    already_dismissed = False
     def onTap() -> None:
         #print("onTap")
         if onTapCallback is not None: onTapCallback()
         if not cw_notif.notificationIsDismissing and not noTapDismiss:
-            def _compl() -> None: ios13_status_bar_workaround.pop()
+            def _compl() -> None:
+                nonlocal already_dismissed
+                if not already_dismissed:
+                    already_dismissed = True
+                    ios13_status_bar_workaround.pop()
             cw_notif.dismissNotificationWithCompletion_(_compl)
 
     if isinstance(color, UIColor):
@@ -786,7 +791,11 @@ def show_notification(message : str,
         cw_notif.displayNotificationWithMessage_completion_(message, _compl)
     else:
         if duration is None: duration = 2.0
-        def _compl() -> None: ios13_status_bar_workaround.pop()
+        def _compl() -> None:
+            nonlocal already_dismissed
+            if not already_dismissed:
+                already_dismissed = True
+                ios13_status_bar_workaround.pop()
         cw_notif.displayNotificationWithMessage_forDuration_dismissedCompletion_(message, duration, _compl)
     return cw_notif
 


### PR DESCRIPTION
This PR concerns the iOS version only. It includes:

- A fix for the iOS 13.0 "Status Bar" glitch whereby the status bar cannot be drawn over by a UIWindow or UIView (previous iOS versions allowed this).  Our notifications would appear in this area; so a workaround was needed if on iPhone < iPhoneX and if on iOS > 13 when displaying a notification.  (On iPad the workaround would have been too complex so we just unconditionally hide the status bar on iPads.. which is fine since they can always run the app in windowed mode.)

- This PR also fixed an issue with the "Downloading headers XX%..." notification not calculating the percentage in a UX-useful manner.

- This PR also has random small nits/fixes/dead code removal for iOS only.

Note that the real fix to this is to use a different in-app notification mechanism (perhaps some sort of semi-transparent bubble that doesn't clash with the status bar).  But that would be a significant amount of work right now due to the cumbersome nature of Python  <-> ObjC <-> iOS.  

So instead we just do this: we *hide* the status bar when showing a notification and then bring it back when the notification is finished.  Since multiple notifications can occur at once, an atomic counter is used to count the number of notifications that are up on-screen and when the counter drops to zero, we latch the status bar back to visible again.  (Initially when the counter went from 0 -> 1 ie the first notification appeared, we latched the status bar to invisible).

---





---

This PR concludes all the damage iOS13 did to our app.  Now, the app will behave as pre-iOS13 on iOS 13 devices.
