### PR TITLE
AppImage: Improve binary stripping

### DIFF
--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -180,13 +180,14 @@ cp -f /lib/x86_64-linux-gnu/libz.so.1 "$APPDIR"/usr/lib/x86_64-linux-gnu || fail
 
 info "Stripping binaries of debug symbols"
 # "-R .note.gnu.build-id" also strips the build id
+# "-R .comment" also strips the GCC version information
 strip_binaries()
 {
   chmod u+w -R "$APPDIR"
   {
     printf '%s\0' "$APPDIR/usr/bin/python3.6"
     find "$APPDIR" -type f -regex '.*\.so\(\.[0-9.]+\)?$' -print0
-  } | xargs -0 --no-run-if-empty --verbose -n1 strip -R .note.gnu.build-id
+  } | xargs -0 --no-run-if-empty --verbose strip -R .note.gnu.build-id -R .comment
 }
 strip_binaries
 


### PR DESCRIPTION
Slightly reduces file size, improves build speed and makes build more reproducible.

The `.comment` section contained GCC version information which could cause different build output from just a minor update in GCC. The information is not needed so we `strip` this.

The strip command was invoked using `xargs`, spawning a new process for each file. This is inefficient as `xargs` can correctly run the `strip` command with multiple file names.