### PR TITLE
Add BlockExplorer.one explorer

### DIFF
--- a/lib/web.py
+++ b/lib/web.py
@@ -51,6 +51,9 @@ mainnet_block_explorers = {
     'ViaBTC.com': ('https://www.viabtc.com/bch',
                    Address.FMT_CASHADDR,
                    {'tx': 'tx', 'addr': 'address', 'block' : 'block'}),
+    'BlockExplorer.one': ('https://blockexplorer.one/bch/mainnet',
+                   Address.FMT_CASHADDR,
+                   {'tx': 'tx', 'addr': 'address', 'block' : 'blockHash'}),
 }
 
 DEFAULT_EXPLORER_TESTNET = 'Bitcoin.com'
@@ -59,6 +62,9 @@ testnet_block_explorers = {
     'Bitcoin.com'   : ('https://explorer.bitcoin.com/tbch',
                        Address.FMT_LEGACY,  # For some reason testnet expects legacy and fails on bchtest: addresses.
                        {'tx': 'tx', 'addr': 'address', 'block' : 'block'}),
+    'BlockExplorer.one': ('https://blockexplorer.one/bch/testnet',
+                   Address.FMT_CASHADDR,
+                   {'tx': 'tx', 'addr': 'address', 'block' : 'blockHash'}),
 }
 
 def BE_info():


### PR DESCRIPTION
Recently I was looking for more testnet explorers to add to EC and came across [BlockExplorer.one](https://blockexplorer.one/). I got their permission to use the explorer in EC. They are planning on adding a page listing the services/wallets that use their explorer and want to add EC there. Is this OK @fyookball ?