### PR TITLE
Satochip wip

### DIFF
--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -155,9 +155,12 @@ prepare_wine() {
         PYINSTALLER_COMMIT=1a8b2d47c277c451f4e358d926a47c096a5615ec
 
         # Satochip pyscard
-        PYSCARD_FILENAME=pyscard-1.9.8-cp36-cp36m-win32.whl  # python 3.6, 32-bit
-        PYSCARD_URL=https://ci.appveyor.com/api/buildjobs/j60tkykj6vh0ppiy/artifacts/dist%2Fpyscard-1.9.8-cp36-cp36m-win32.whl
-        PYSCARD_SHA256=4641b5db53fb3562671b7b7c685ddf8f715180e2809106fb2a9361dfad553b4b
+        # PYSCARD_FILENAME=pyscard-1.9.8-cp36-cp36m-win32.whl  # python 3.6, 32-bit
+        # PYSCARD_URL=https://ci.appveyor.com/api/buildjobs/j60tkykj6vh0ppiy/artifacts/dist%2Fpyscard-1.9.8-cp36-cp36m-win32.whl
+        # PYSCARD_SHA256=4641b5db53fb3562671b7b7c685ddf8f715180e2809106fb2a9361dfad553b4b
+        PYSCARD_FILENAME=pyscard-1.9.9-cp36-cp36m-win32.whl  # python 3.6, 32-bit
+        PYSCARD_URL=https://ci.appveyor.com/api/buildjobs/3uiua5o4llvpegbp/artifacts/dist%2Fpyscard-1.9.9-cp36-cp36m-win32.whl
+        PYSCARD_SHA256=99d2b450f322f9ed9682fd2a99d95ce781527e371006cded38327efca8158fe7
 
         ## These settings probably don't need change
         export WINEPREFIX=$HOME/wine64

--- a/plugins/satochip/CardConnector.py
+++ b/plugins/satochip/CardConnector.py
@@ -67,8 +67,9 @@ class CardConnector(PrintError):
     # v0.6: bip32 optimization: speed up computation during derivation of non-hardened child
     # v0.7: add 2-Factor-Authentication (2FA) support
     # v0.8: support seed reset and pin change
+    # v0.9: patch message signing for alts
     SATOCHIP_PROTOCOL_MAJOR_VERSION=0
-    SATOCHIP_PROTOCOL_MINOR_VERSION=8
+    SATOCHIP_PROTOCOL_MINOR_VERSION=9
 
     # define the apdus used in this script
     BYTE_AID= [0x53,0x61,0x74,0x6f,0x43,0x68,0x69,0x70] #SatoChip

--- a/plugins/satochip/satochip.py
+++ b/plugins/satochip/satochip.py
@@ -437,7 +437,7 @@ class SatochipPlugin(HW_PluginBase):
         self.print_error("detect_smartcard_reader")#debugSatochip
         self.cardtype = AnyCardType()
         try:
-            cardrequest = CardRequest(timeout=5, cardType=self.cardtype)
+            cardrequest = CardRequest(timeout=0.1, cardType=self.cardtype)
             cardservice = cardrequest.waitforcard()
             self.print_error("detect_smartcard_reader: found card!")#debugSatochip
             return [Device(path="/satochip",
@@ -447,7 +447,7 @@ class SatochipPlugin(HW_PluginBase):
                            usage_page=0)]
                            #transport_ui_string='ccid')]
         except CardRequestTimeoutException:
-            self.print_error('time-out: no card inserted during last 5s')
+            self.print_error('time-out: no card found')
             return []
         except Exception as exc:
             self.print_error("Error during connection:", repr(exc), f"\n{traceback.format_exc()}")


### PR DESCRIPTION
 Minor changes: reduced smartcard timout and updated satochip version

A timeout of 0.1s is sufficient if the card reader is connected and the card is already inserted. Otherwise, the card is not detected and user must restart the discovery process using the back button in the wizzard.

The satochip firmware version supported has been updated to v0.9. (v0.9 is a patch that allows message signing for altcoins with a custom format. There is no impact for Bitcoin Cash.). During wallet creation, the electrum client checks the version of the satochip to ensure that it supports the latest features. If not, a warning is displayed to the user.