### PR TITLE
Plugins: Fix to @hook / @run_hook mechanism

### DIFF
--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -525,7 +525,8 @@ def run_hook(name, *args):
                 results.append(r)
 
     if results:
-        assert len(results) == 1, results
+        if len(results) > 1:
+            print_error(f"run_hook: got more than 1 result from @hook '{name}':", results)
         return results[0]
 
 

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -22,26 +22,27 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from collections import namedtuple, defaultdict
 import codecs
-import traceback
-import os
 import imp
 import json
+import os
 import pkgutil
-import sys
-import time
 import shutil
+import sys
 import threading
+import time
+import traceback
 import zipimport
 
+from collections import namedtuple, defaultdict
+from enum import IntEnum
+from typing import Callable, Optional
+
+from . import bitcoin
+from . import version
 from .i18n import _
 from .util import print_error, user_dir, make_dir
 from .util import profiler, PrintError, DaemonThread, UserCancelled, ThreadJob
-from . import bitcoin
-from . import version
-from enum import IntEnum
-from typing import Callable, Optional
 
 plugin_loaders = {}
 hooks = defaultdict(list)


### PR DESCRIPTION
As per a Telegram chat with @markblundeberg  -- we realized that:

The @hook decorator was registering functions globally for all plugins,
even ones not decorated with @hook would get picked up.

This change fixes it so that only functions decorated with @hook get
picked up.

~~**This commit is not 100% ready for merge to mainline.  I still have to do
some due diligence and verify no extant plugins DEPENDED on the old
behavior for correct operation!**~~

EDIT: It turns out this PR is safe to merge.  I ran through all the code and verified all hook-like-functions are indeed decorated with `@hook`.

