### PR TITLE
allow plugins to register daemon commands using decorator

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -396,10 +396,10 @@ if __name__ == '__main__':
         fd, server = daemon.get_fd_or_server(config)
         if fd is not None:
             plugins = init_plugins(config, config.get('gui', 'qt'))
-            d = daemon.Daemon(config, fd, True)
+            d = daemon.Daemon(config, fd, True, plugins)
             d.start()
             try:
-                d.init_gui(config, plugins)
+                d.init_gui()
             finally:
                 d.stop()  # Cleans up lockfile gracefully
                 d.join(timeout=5.0)
@@ -423,8 +423,8 @@ if __name__ == '__main__':
                     if pid:
                         print_stderr("starting daemon (PID %d)" % pid)
                         os._exit(0)  # exit without calling atexit handlers, in case there are any from e.g. a plugin, etc.
-                init_plugins(config, 'cmdline')
-                d = daemon.Daemon(config, fd, False)
+                plugins = init_plugins(config, 'cmdline')
+                d = daemon.Daemon(config, fd, False, plugins)
                 d.start()
                 if config.get('websocket_server'):
                     from electroncash import websockets

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -940,7 +940,8 @@ def get_parser():
     add_global_options(parser_gui)
     # daemon
     parser_daemon = subparsers.add_parser('daemon', help="Run Daemon")
-    parser_daemon.add_argument("subcommand", choices=['start', 'status', 'stop', 'load_wallet', 'close_wallet'], nargs='?')
+    parser_daemon.add_argument("subcommand", nargs='?', help="start, stop, status, load_wallet, close_wallet. Other commands may be added by plugins.")
+    parser_daemon.add_argument("subargs", nargs='*', metavar='arg', help="additional arguments (used by plugins)")
     #parser_daemon.set_defaults(func=run_daemon)
     add_network_options(parser_daemon)
     add_global_options(parser_daemon)

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -138,8 +138,9 @@ def get_rpc_credentials(config):
 
 class Daemon(DaemonThread):
 
-    def __init__(self, config, fd, is_gui):
+    def __init__(self, config, fd, is_gui, plugins):
         DaemonThread.__init__(self)
+        self.plugins = plugins
         self.config = config
         if config.get('offline'):
             self.network = None
@@ -334,7 +335,9 @@ class Daemon(DaemonThread):
         super().stop()
 
 
-    def init_gui(self, config, plugins):
+    def init_gui(self):
+        config = self.config
+        plugins = self.plugins
         gui_name = config.get('gui', 'qt')
         if gui_name in ['lite', 'classic']:
             gui_name = 'qt'

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -185,7 +185,11 @@ class Daemon(DaemonThread):
     def run_daemon(self, config_options):
         config = SimpleConfig(config_options)
         sub = config.get('subcommand')
-        assert sub in [None, 'start', 'stop', 'status', 'load_wallet', 'close_wallet']
+        subargs = config.get('subargs')
+        if subargs and sub in [None, 'start', 'stop', 'status']:
+            return "Unexpected arguments: {!r}. {!r} takes no options.".format(subargs, sub)
+        if subargs and sub in ['load_wallet', 'close_wallet']:
+            return "Unexpected arguments: {!r}. Provide options to {!r} using the -w and -wp options.".format(subargs, sub)
         if sub in [None, 'start']:
             response = "Daemon already running"
         elif sub == 'load_wallet':
@@ -221,6 +225,8 @@ class Daemon(DaemonThread):
         elif sub == 'stop':
             self.stop()
             response = "Daemon stopped"
+        else:
+            return "Unrecognized subcommand {!r}".format(sub)
         return response
 
     def run_gui(self, config_options):

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -187,6 +187,7 @@ class Daemon(DaemonThread):
         config = SimpleConfig(config_options)
         sub = config.get('subcommand')
         subargs = config.get('subargs')
+        plugin_cmd = self.plugins.daemon_commands.get(sub)
         if subargs and sub in [None, 'start', 'stop', 'status']:
             return "Unexpected arguments: {!r}. {!r} takes no options.".format(subargs, sub)
         if subargs and sub in ['load_wallet', 'close_wallet']:
@@ -226,6 +227,9 @@ class Daemon(DaemonThread):
         elif sub == 'stop':
             self.stop()
             response = "Daemon stopped"
+        elif plugin_cmd is not None:
+            # note that daemon's own commands take precedence, i.e., a plugin CANNOT override 'load_wallet'.
+            response = plugin_cmd(self, config)
         else:
             return "Unrecognized subcommand {!r}".format(sub)
         return response


### PR DESCRIPTION
While we can't add new @commands in plugins (since it's too late), we can have the daemon RPC accept arbitrary subcommands and dispatch them to plugins, when desired.

Note in order to get this working on the non-GUI daemon, you have to add a `cmdline.py` to your plugin with a GUI-free implementation of the `class Plugin:`, then put `available_for = ['qt', 'cmdline']` in your plugin's `__init__.py`. In principle also you should do this for `stdio` and `text` which are alternative non-graphical GUIs; each of these can just be short stub files.

I've tested this on a sample plugin and it works well.

~~The usage of metaclass is inspired by this: https://stackoverflow.com/a/3054505/5667904~~
The usage of scan-class-on-init is inspired by  #1669