### PR TITLE
Add crash reporter to prefs, Crash reporter layout fixes, & Prefs Layout fixes

### DIFF
--- a/gui/qt/exception_window.py
+++ b/gui/qt/exception_window.py
@@ -74,18 +74,22 @@ class Exception_Window(QWidget):
 
         heading = QLabel('<h2>' + _('Sorry!') + '</h2>')
         main_box.addWidget(heading)
-        main_box.addWidget(QLabel(_('Something went wrong running Electron Cash.')))
+        l = QLabel(_('Something went wrong running Electron Cash.'))
+        l.setWordWrap(True)
+        main_box.addWidget(l)
 
-        main_box.addWidget(QLabel(
-            _('To help us diagnose and fix the problem, you can send us a bug report that contains useful debug '
-              'information:')))
+        l = QLabel(_('To help us diagnose and fix the problem, you can send us'
+                     ' a bug report that contains useful debug information:'))
+        l.setWordWrap(True)
+        main_box.addWidget(l)
 
-        collapse_info = QPushButton(_("Show report contents"))
-        collapse_info.clicked.connect(lambda: QMessageBox.about(self, "Report contents", self.get_report_string()))
-        main_box.addWidget(collapse_info)
-
-        label = QLabel(_("Please briefly describe what led to the error (optional):") +"<br/>"+
-            "<i>"+ _("Feel free to add your email address if you are willing to provide further detail, but note that it will appear in the relevant github issue.") +"</i>")
+        label = QLabel(
+            '<br/>' + _("Please briefly describe what led to the error (optional):")
+            + '<br/><br/>' + '<i>' +
+            _("Feel free to add your email address if you are willing to provide"
+              " further detail, but note that it will appear in the relevant"
+              " github issue.") + '</i>')
+        label.setWordWrap(True)
         label.setTextFormat(QtCore.Qt.RichText)
         main_box.addWidget(label)
 
@@ -94,9 +98,20 @@ class Exception_Window(QWidget):
         self.description_textfield.setFixedHeight(50)
         main_box.addWidget(self.description_textfield)
 
-        main_box.addWidget(QLabel(_("Do you want to send this report?")))
 
         buttons = QHBoxLayout()
+
+        l = QLabel(_("Do you want to send this report?"))
+        l.setWordWrap(True)
+
+        buttons.addWidget(l)
+
+        collapse_info = QPushButton(_("Show report contents"))
+        collapse_info.clicked.connect(lambda: QMessageBox.about(self, "Report contents", self.get_report_string()))
+
+        buttons.addWidget(collapse_info)
+
+        buttons.addStretch(1)
 
         report_button = QPushButton(_('Send Bug Report'))
         report_button.clicked.connect(self.send_report)

--- a/gui/qt/exception_window.py
+++ b/gui/qt/exception_window.py
@@ -71,6 +71,7 @@ class Exception_Window(QWidget):
         self.setMinimumSize(600, 300)
 
         main_box = QVBoxLayout()
+        main_box.setContentsMargins(20,20,20,20)
 
         heading = QLabel('<h2>' + _('Sorry!') + '</h2>')
         main_box.addWidget(heading)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -4106,7 +4106,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         fee_lo.addWidget(customfee_label, 0, 0, 1, 1, Qt.AlignRight)
         fee_lo.addWidget(customfee_e, 0, 1, 1, 1, Qt.AlignLeft)
 
-        feebox_cb = QCheckBox(" " + _('Edit fees manually'))
+        feebox_cb = QCheckBox(_('Edit fees manually'))
         feebox_cb.setChecked(self.config.get('show_fee', False))
         feebox_cb.setToolTip(_("Show fee edit box in send tab."))
         def on_feebox(x):
@@ -4178,9 +4178,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         from . import exception_window as ew
         cr_gb = QGroupBox(_("Crash Reporter"))
-        cr_form = QFormLayout(cr_gb)
-        cr_form.setFormAlignment(Qt.AlignHCenter|Qt.AlignVCenter)
-        cr_chk = QCheckBox(" ")
+        cr_grid = QGridLayout(cr_gb)
+        cr_chk = QCheckBox()
         cr_chk.setChecked(ew.is_enabled(self.config))
         cr_chk.clicked.connect(lambda b: ew.set_enabled(self.config, b))
         cr_help = HelpLabel(_("Crash reporter enabled"),
@@ -4188,7 +4187,13 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                               "It is recommended that you leave this option enabled, so that developers can be notified of any internal bugs. "
                               "When a crash is encountered you are asked if you would like to send a report.\n\n"
                               "Private information is never revealed in crash reports to developers."))
-        cr_form.addRow(cr_chk, cr_help)
+        # The below dance ensures the checkbox is horizontally centered in the widget
+        cr_grid.addWidget(QWidget(), 0, 0, 1, 1)  # dummy spacer
+        cr_grid.addWidget(cr_chk, 0, 1, 1, 1, Qt.AlignRight)
+        cr_grid.addWidget(cr_help, 0, 2, 1, 1, Qt.AlignLeft)
+        cr_grid.addWidget(QWidget(), 0, 3, 1, 1) # dummy spacer
+        cr_grid.setColumnStretch(0, 1)
+        cr_grid.setColumnStretch(3, 1)
 
         # Crash reporter box at bottom of this tab
         misc_widgets.append((cr_gb, None))  # commit crash reporter gb to layout


### PR DESCRIPTION
This adds:

- Crash reporter can now be disabled/enabled from preferences
- Crash reporter layout has been cleaned up
- Preferences pane layout has been cleaned up to waste less real-estate and the 5 prefs tabs have been collapsed into 4.

This closes #1672 .

Screenshots:

---

# macOS

<img width="650" alt="Screen Shot 2019-11-14 at 12 18 50 PM" src="https://user-images.githubusercontent.com/266627/68848614-44ca4d00-06d9-11ea-94c0-3812b98f0ed8.png">

<img width="418" alt="Screen Shot 2019-11-14 at 12 18 36 PM" src="https://user-images.githubusercontent.com/266627/68848616-44ca4d00-06d9-11ea-9586-0d1bf6e2d8b3.png">

# Windows

<img width="655" alt="Screen Shot 2019-11-14 at 12 18 09 PM" src="https://user-images.githubusercontent.com/266627/68848619-4562e380-06d9-11ea-8170-003e1726c75f.png">

<img width="381" alt="Screen Shot 2019-11-14 at 12 18 17 PM" src="https://user-images.githubusercontent.com/266627/68848617-4562e380-06d9-11ea-91ac-fce059e807f9.png">

# Linux

<img width="630" alt="Screen Shot 2019-11-14 at 12 24 17 PM" src="https://user-images.githubusercontent.com/266627/68848881-baceb400-06d9-11ea-8e2e-6d4fdc631714.png">

<img width="414" alt="Screen Shot 2019-11-14 at 12 24 27 PM" src="https://user-images.githubusercontent.com/266627/68848880-baceb400-06d9-11ea-86d1-c755dc19103b.png">
