### PR TITLE
Improvements to GUI & CLI export history facility + nits

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -33,12 +33,14 @@ from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 
+from electroncash import cashacct
+from electroncash import web
+
 from electroncash.address import Address, PublicKey, ScriptOutput
 from electroncash.bitcoin import base_encode
 from electroncash.i18n import _, ngettext
 from electroncash.plugins import run_hook
-from electroncash import web
-from electroncash import cashacct
+from electroncash.transaction import Transaction, InputValueMissing
 
 from electroncash.util import bfh, Weak, PrintError
 from .util import *
@@ -347,9 +349,8 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         fee = None
         try:
             fee = self.tx.get_fee()
-        except (KeyError, TypeError, ValueError):
-            # 'value' key missing or bad from an input
-            pass
+        except InputValueMissing:
+            ''' 'value' key missing or bad from an input '''
         return fee
 
     def update(self):
@@ -384,6 +385,11 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         self.tx_hash_e.setText(tx_hash or _('Unknown'))
         if fee is None:
             fee = self.try_calculate_fee()
+        if fee is None:
+            # see if we can grab the fee from the wallet internal cache which
+            # sometimes has fees for tx's not entirely 'is_mine'
+            if self.wallet and self.tx_hash:
+                fee = self.wallet.tx_fees.get(self.tx_hash)
         if desc is None:
             self.tx_desc.hide()
         else:
@@ -433,11 +439,10 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         run_hook('transaction_dialog_update', self)
 
     def is_fetch_input_data(self):
-        # default on if network.auto_connect is True, otherwise use config value.
-        return bool(self.wallet.network and self.main_window.config.get('fetch_input_data', self.wallet.network.auto_connect))
+        return self.main_window.is_fetch_input_data()
 
     def set_fetch_input_data(self, b):
-        self.main_window.config.set_key('fetch_input_data', bool(b))
+        self.main_window.set_fetch_input_data(b)
         if self.is_fetch_input_data():
             self.initiate_fetch_input_data(bool(self.try_calculate_fee() is None))
         else:
@@ -466,6 +471,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         self.dl_input_chk = chk = QCheckBox(_("&Download input data"))
         chk.setChecked(self.is_fetch_input_data())
         chk.clicked.connect(self.set_fetch_input_data)
+        chk.setToolTip(_("If this is checked, accurate fee and input value data will be retrieved from the network"))
         hbox.addWidget(chk)
         hbox.addStretch(1)
         if not self.wallet.network:


### PR DESCRIPTION
Export history how can optionally also download input data to get 100% accurate fees on all tx's. This is specified in the CLI via `--use_net`.  Can also optionally specify a timeout in the CLI for the input fetcher (in case it takes too long) via `--timeout`.

`--show_fiat` has been improved to also show fee value in fiat (along regular satoshis).

Also in this PR:

-  Refactored/enchanced some utility functions from `gui/qt/utils.py` to either be less broken or more useful. 
- GUI Export history has the above options now too (both to download inputs and/or specify a timeout). GUI export history also has a new checkbox "include adddresses" which is useful if you want to know the addresses in a tx in history.
