### PR TITLE
nit: remove whitespace from export address list

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3735,8 +3735,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                                             if Address.is_valid(x))
                         outaddrs_filtered = (x for x in (item.get('output_addresses') or [])
                                              if Address.is_valid(x))
-                        cols.append( ', '.join(inaddrs_filtered) )
-                        cols.append( ', '.join(outaddrs_filtered) )
+                        cols.append( ','.join(inaddrs_filtered) )
+                        cols.append( ','.join(outaddrs_filtered) )
                     lines.append(cols)
                 else:
                     if has_fiat_columns and ccy:


### PR DESCRIPTION
I assume exported addresses will mostly be used by automated systems like I use. Because of that, having address list in export with no extra whitespace is slightly more parse-friendly.