### PR TITLE
Android: Address the new required `plugins` parameter added by RP #1670.

### DIFF
--- a/android/app/src/main/python/electroncash_gui/android/console.py
+++ b/android/app/src/main/python/electroncash_gui/android/console.py
@@ -82,7 +82,7 @@ class AndroidCommands(commands.Commands):
 
         # Initialize here rather than in start() so the DaemonModel has a chance to register
         # its callback before the daemon threads start.
-        self.daemon = daemon.Daemon(self.config, fd, False)
+        self.daemon = daemon.Daemon(self.config, fd, False, None)
         self.network = self.daemon.network
         self.network.register_callback(self._on_callback, CALLBACKS)
         self.daemon_running = False


### PR DESCRIPTION
Exactly as with fd42160, the Android version needed updated to support
the new Daemon() constructor.