### PR TITLE
Android (phase 4): Add ability to delete closed wallets

### DIFF
--- a/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
@@ -225,7 +225,9 @@ class MainActivity : AppCompatActivity(R.layout.main) {
             }
             R.id.menuChangePassword -> showDialog(this, ChangePasswordDialog())
             R.id.menuShowSeed-> { showDialog(this, ShowSeedPasswordDialog()) }
-            R.id.menuDelete -> showDialog(this, DeleteWalletConfirmDialog())
+            R.id.menuDelete -> showDialog(this, DeleteWalletConfirmDialog().apply {
+                arguments = Bundle().apply { putString("walletName", daemonModel.walletName) }
+            })
             R.id.menuClose -> showDialog(this, CloseWalletDialog())
             else -> throw Exception("Unknown item $item")
         }
@@ -387,22 +389,48 @@ class OpenWalletDialog : PasswordDialog<String>() {
     override fun onPostExecute(result: String) {
         daemonModel.commands.callAttr("select_wallet", result)
     }
+
+    override fun onBuildDialog(builder: AlertDialog.Builder) {
+        super.onBuildDialog(builder)
+        builder.setNeutralButton(R.string.Delete_wallet, null)
+    }
+
+    override fun onShowDialog() {
+        super.onShowDialog()
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+            val walletName = arguments!!.getString("walletName")!!
+            showDialog(activity!!, DeleteWalletConfirmDialog().apply {
+                arguments = Bundle().apply { putString("walletName", walletName) }
+            })
+            dismiss()
+        }
+    }
 }
 
 
 class DeleteWalletConfirmDialog : AlertDialogFragment() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
-        val message = getString(R.string.do_you_want_to_delete, daemonModel.walletName) +
+        val walletName = arguments!!.getString("walletName")!!
+        val message = getString(R.string.do_you_want_to_delete, walletName) +
                       "\n\n" + getString(R.string.if_your)
         builder.setTitle(R.string.confirm_delete)
             .setMessage(message)
             .setPositiveButton(R.string.delete, { _, _ ->
-                showDialog(activity!!, DeleteWalletDialog())})
+                showDialog(activity!!, DeleteWalletDialog().apply {
+                    arguments = Bundle().apply { putString("walletName", walletName) }
+                })
+            })
             .setNegativeButton(android.R.string.cancel, null)
     }
 }
 
+
 class DeleteWalletDialog : CloseWalletDialog() {
+    override fun onPreExecute() {
+        walletName = arguments!!.getString("walletName")!!
+        daemonModel.commands.callAttr("select_wallet", null)
+    }
+
     override fun doInBackground() {
         super.doInBackground()
         daemonModel.commands.callAttr("delete_wallet", walletName)

--- a/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
@@ -428,7 +428,9 @@ class DeleteWalletConfirmDialog : AlertDialogFragment() {
 class DeleteWalletDialog : CloseWalletDialog() {
     override fun onPreExecute() {
         walletName = arguments!!.getString("walletName")!!
-        daemonModel.commands.callAttr("select_wallet", null)
+        if (walletName == daemonModel.walletName) {
+            daemonModel.commands.callAttr("select_wallet", null)
+        }
     }
 
     override fun doInBackground() {

--- a/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
@@ -380,10 +380,11 @@ class AboutDialog : AlertDialogFragment() {
 
 
 class OpenWalletDialog : PasswordDialog<String>() {
+    val walletName by lazy { arguments!!.getString("walletName")!! }
+
     override fun onPassword(password: String): String {
-        val name = arguments!!.getString("walletName")!!
-        daemonModel.loadWallet(name, password)
-        return name
+        daemonModel.loadWallet(walletName, password)
+        return walletName
     }
 
     override fun onPostExecute(result: String) {
@@ -398,7 +399,6 @@ class OpenWalletDialog : PasswordDialog<String>() {
     override fun onShowDialog() {
         super.onShowDialog()
         dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
-            val walletName = arguments!!.getString("walletName")!!
             showDialog(activity!!, DeleteWalletConfirmDialog().apply {
                 arguments = Bundle().apply { putString("walletName", walletName) }
             })


### PR DESCRIPTION
This adds a "Delete wallet" button to the wallet-open password prompt, making it possible to delete wallets without first needing to unlock them.  This should help when the wallet password is irretrievably lost for example.  Clicking the button takes you through the normal wallet deletion process with a confirmation dialogue and reminder to save your seed.