### PR TITLE
Remove unused sip dependency for Python 3.8 compatibility 

### DIFF
--- a/contrib/requirements/requirements-binaries.txt
+++ b/contrib/requirements/requirements-binaries.txt
@@ -1,6 +1,4 @@
 PyQt5>=5.12.3
 pycryptodomex<3.7
 websocket-client
-PyQt5-sip>=4.19.17
-sip==4.19.8
 psutil==5.6.1


### PR DESCRIPTION
The sip module is not needed. We also remove the PyQt5-sip dependency as PyQt5 already has a dependency on the correct version. This makes Python 3.8 usable as PyQt5-sip Python 3.8 wheels are only built for newer versions.