### PR TITLE
[satochip] Patch "Recovered authentikey does not correspond to registered authentikey" error

### DIFF
--- a/plugins/satochip/CardConnector.py
+++ b/plugins/satochip/CardConnector.py
@@ -16,6 +16,11 @@ from electroncash.i18n import _
 import base64
 import traceback
 
+MSG_WARNING= ("Before you request bitcoins to be sent to addresses in this "
+                    "wallet, ensure you can pair with your device, or that you have "
+                    "its seed (and passphrase, if any).  Otherwise all bitcoins you "
+                    "receive will be unspendable.")
+
 # simple observer that will print on the console the card connection events.
 class LogCardConnectionObserver( CardConnectionObserver, PrintError ):
     def update( self, cardconnection, ccevent ):
@@ -253,10 +258,10 @@ class CardConnector(PrintError):
         response, sw1, sw2 = self.card_transmit(apdu)
         if sw1==0x9c and sw2==0x14:
             self.print_error("card_bip32_get_authentikey(): Seed is not initialized => Raising error!")
-            raise UninitializedSeedError('Seed is not initialized')
+            raise UninitializedSeedError("Satochip seed is not initialized!\n\n "+MSG_WARNING)
         if sw1==0x9c and sw2==0x04:
             self.print_error("card_bip32_get_authentikey(): Satochip is not initialized => Raising error!")
-            raise UninitializedSeedError('Satochip is not initialized! You should create a new wallet!')
+            raise UninitializedSeedError('Satochip is not initialized! You should create a new wallet!\n\n'+MSG_WARNING)
         # compute corresponding pubkey and send to chip for future use
         if (sw1==0x90) and (sw2==0x00):
             authentikey = self.card_bip32_set_authentikey_pubkey(response)

--- a/plugins/satochip/CardDataParser.py
+++ b/plugins/satochip/CardDataParser.py
@@ -23,6 +23,10 @@ from electroncash.bitcoin import Hash
 
 from .ecc import ECPubkey, msg_magic, InvalidECPointException
 
+MSG_WARNING= ("Before you request bitcoins to be sent to addresses in this "
+                    "wallet, ensure you can pair with your device, or that you have "
+                    "its seed (and passphrase, if any).  Otherwise all bitcoins you "
+                    "receive will be unspendable.")
 
 class CardDataParser:
 
@@ -51,7 +55,7 @@ class CardDataParser:
         # if already initialized, check that authentikey match value retrieved from storage!
         if (self.authentikey_from_storage is not None):
             if  self.authentikey != self.authentikey_from_storage:
-                raise ValueError("Recovered authentikey does not correspond to registered authentikey!")
+                raise ValueError("The seed used to create this wallet file no longer matches the seed of the Satochip device!\n\n"+MSG_WARNING)
 
         return self.authentikey
 
@@ -89,7 +93,7 @@ class CardDataParser:
         signature2= response[(msg2_size+2):(msg2_size+2+sig2_size)]
         authentikey= self.get_pubkey_from_signature(self.authentikey_coordx, msg2, signature2)
         if authentikey != self.authentikey:
-            raise ValueError("Recovered authentikey does not correspond to registered authentikey!")
+            raise ValueError("The seed used to create this wallet file no longer matches the seed of the Satochip device!\n\n"+MSG_WARNING)
 
         return (self.pubkey, self.chaincode)
 

--- a/plugins/satochip/satochip.py
+++ b/plugins/satochip/satochip.py
@@ -42,7 +42,6 @@ except:
     print_error("[satochup] satochip will not not be available")
     raise
 
-
 # debug: smartcard reader ids
 SATOCHIP_VID= 0x096E
 SATOCHIP_PID= 0x0503
@@ -481,6 +480,7 @@ class SatochipPlugin(HW_PluginBase):
             raise Exception(_('Failed to create a client for this device.') + '\n' +
                             _('Make sure it is in the correct state.'))
         client.handler = self.create_handler(wizard)
+        client.cc.parser.authentikey_from_storage=None # https://github.com/simpleledger/Electron-Cash-SLP/pull/101#issuecomment-561238614
 
         # check applet version
         while True:

--- a/plugins/satochip/satochip.py
+++ b/plugins/satochip/satochip.py
@@ -683,10 +683,10 @@ class SatochipPlugin(HW_PluginBase):
         wizard.seed_type = 'bip39' if is_bip39 else bitcoin.seed_type(seed)
         if wizard.seed_type == 'bip39':
             f = lambda passphrase: self.derive_bip39_seed(seed, passphrase)
-            wizard.passphrase_dialog(run_next=f, is_restoring=True) if is_ext else f('')
+            wizard.passphrase_dialog(run_next=f) if is_ext else f('')
         elif wizard.seed_type in ['standard', 'segwit']:
             f = lambda passphrase: self.derive_bip32_seed(seed, passphrase)
-            wizard.passphrase_dialog(run_next=f, is_restoring=True) if is_ext else f('')
+            wizard.passphrase_dialog(run_next=f) if is_ext else f('')
         elif wizard.seed_type == 'old':
             raise Exception('Unsupported seed type', wizard.seed_type)
         elif bitcoin.is_any_2fa_seed_type(wizard.seed_type):


### PR DESCRIPTION
When using passphrase with seed, user sometimes get an error: Recovered authentikey does not correspond to registered authentikey!
See https://github.com/simpleledger/Electron-Cash-SLP/pull/101#issuecomment-561238614

I was able to reproduce the bug with the following setup:
* create a wallet 'w1' using a seed1 stored on Satochip.
* reset seed1 on Satochip and close wallet (and EC)
* when Electron Cash is run again, old wallet w1 opens by default, however this wallet is not valid anymore since it is related to an old seed
* when creating a new wallet w2 from wizard with a new seed2, EC will however check compatibility with w1, thus raising an error.

This PR also improves error messages when pairing Satochip with the wrong wallet file.