### PR TITLE
add another lowfee net reject message

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -1808,8 +1808,10 @@ class Network(util.DaemonThread):
             # We get this message whenever any of this transaction's outputs are already in confirmed utxo set (and are unspent).
             # For confirmed txn with all outputs already spent, we will see "missing inputs" instead.
             return _("The transaction already exists in the blockchain.")
-        elif r'insufficient priority' in server_msg:
-            return _("The transaction was rejected due to paying insufficient fees and/or for being of extremely low priority.")
+        elif r'insufficient priority' in server_msg or r'rate limited free transaction' in server_msg:
+            return _("The transaction was rejected due to paying insufficient fees.")
+        elif r'mempool min fee not met' in server_msg:
+            return _("The transaction was rejected due to paying insufficient fees (possibly due to network congestion).")
         elif r'bad-txns-premature-spend-of-coinbase' in server_msg:
             return _("Transaction could not be broadcast due to an attempt to spend a coinbase input before maturity.")
         elif r"txn-already-in-mempool" in server_msg or r"txn-already-known" in server_msg:


### PR DESCRIPTION
Long story behind this one, but hopefully informative. Let's start off with an explanation of lowfee messages (for ABC as of today -- see src/validation.cpp AcceptToMemoryPoolWorker)

- If the mempool is congested, the fee floor rises. The mempool congestion
  floor is the first feerate check, and produces 'mempool min fee not met'.
  We don't normally see this.
- If the fee is below the regular limit (typically 1 sat/byte) then we will
  get 'insufficient priority' EXCEPT.....
  if the transaction is 'high priority' (burns lots of coin days) then
  it will bypass the 1 sat/byte check, and move on to the free limiter.
- If the free limiter rejects a transaction then you get:
  'rate limited free transaction'
- By default, the free limiter allows 0 free transactions. In other words
  even if your transaction is high priority, it will get rejected anyway,
  but with the message 'rate limited free transaction' instead of
  'insufficient priority'.

But wait, why don't we see that message ever? Well, the free limiter is
disabled (lets all "high priority txns" through) for `sendrawtransaction`,
but enabled for the p2p/relay layer. This means you can accidentally
broadcast a lowfee transaction and have it stuck on your electrumx server,
never to be mined. grrr

I would like to update this so it doesn't happen, see:
https://reviews.bitcoinabc.org/D4730
This will activate the free limiter (which defaults to 0 free transactions)
for `sendrawtransaction`, so you never get that stuck low fee situation.
As a result, ElectrumX servers will now start throwing up 'rate limited
free transaction' for *some* low fee transactions (the ones they would have
accepted annyoingly before) and 'insufficient priority' for all other low
fee transactions. In anticipation of that, let's add this error message.

These error messages are so confusing but that's how it is.