### PR TITLE
Android fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 /electrum.py
 contrib/pyinstaller/
 Electron_Cash.egg-info/
+locale/
 .devlocaltmp/
 *_trial_temp
 packages

--- a/android/app/src/main/java/org/electroncash/electroncash3/Dialog.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Dialog.kt
@@ -293,6 +293,9 @@ abstract class PasswordDialog<Result> : TaskLauncherDialog<Result>() {
 
     /** Attempt to perform the operation with the given password. If the operation fails, this
      * method should throw either a ToastException, or an InvalidPassword PyException (most
-     * Python functions that take passwords will do this automatically). */
+     * Python functions that take passwords will do this automatically).
+     *
+     * This method is called on a background thread. It should not access user interface
+     * objects in any way, as they may be destroyed by rotation and other events. */
     abstract fun onPassword(password: String): Result
 }

--- a/android/app/src/main/java/org/electroncash/electroncash3/Util.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Util.kt
@@ -70,7 +70,7 @@ fun showDialog(activity: FragmentActivity, frag: DialogFragment, target: Fragmen
         if (target != null) {
             frag.setTargetFragment(target, 0)
         }
-        frag.show(fm, tag)
+        frag.showNow(fm, tag)
     }
 }
 

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -30,9 +30,7 @@ import sys
 from typing import Dict
 from collections import namedtuple
 
-from . import locale as ec_locale  # Causes translation files to be extracted on Android.
-
-LOCALE_DIR = os.path.dirname(ec_locale.__file__)
+LOCALE_DIR = os.path.join(os.path.dirname(__file__), 'locale')
 language = gettext.translation('electron-cash', LOCALE_DIR, fallback=True)
 
 def _(x):

--- a/lib/locale/.gitignore
+++ b/lib/locale/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!__init__.py

--- a/lib/locale/__init__.py
+++ b/lib/locale/__init__.py
@@ -1,2 +1,0 @@
-# This directory has an __init__.py so it can be passed to `extractPackages` in
-# android/app/build.gradle.

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,6 @@ setup(
     },
     packages=[
         'electroncash',
-        'electroncash.locale',  # work-around for Android platform limitations
         'electroncash.qrreaders',
         'electroncash.slp',
         'electroncash.utils',


### PR DESCRIPTION
@cculianu: The workaround of making the `locale` directory a Python package is no longer needed in the current version of Chaquopy, so I've restored the previous way of finding it. Does that look alright to you?