### PR TITLE
Wallet.py: Fix warning about "is" with a literal

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1553,7 +1553,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
 
     def get_label(self, tx_hash):
         label = self.labels.get(tx_hash, '')
-        if label is '':
+        if not label:
             label = self.get_default_label(tx_hash)
         return label
 


### PR DESCRIPTION
```
lib/wallet.py:1556: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if label is '':
```