### PR TITLE
Qr scanner: Fix non-ideal resolutions resulting in lowest possible

### DIFF
--- a/gui/qt/qrreader/camera_dialog.py
+++ b/gui/qt/qrreader/camera_dialog.py
@@ -201,7 +201,7 @@ class QrReaderCameraDialog(PrintError, MessageBoxMixin, QDialog):
 
 
         # Sort the usable resolutions, least number of pixels first, get the first element
-        resolution = sorted(candidate_resolutions, key=lambda r: r.width() * r.height())[0]
+        resolution = sorted(candidate_resolutions, key=lambda r: r.width() * r.height(), reverse=not is_ideal)[0]
         format_str = 'chosen resolution is {}x{}'
         self.print_error(format_str.format(resolution.width(), resolution.height()))
 


### PR DESCRIPTION
When the Qr scanner has to fall back to using non-ideal resolutions it still sorts them so the lowest possible one is used. This is wrong as with non-ideal resolutions we want the highest one to be used.