### PR TITLE
Add Bitcoin Unlimited managed Electrum server to the white list

### DIFF
--- a/lib/servers.json
+++ b/lib/servers.json
@@ -151,5 +151,11 @@
         "s": "50002",
         "t": "50001",
         "version": "1.4"
+    },
+    "electrs.bitcoinunlimited.info": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4"
     }
 }


### PR DESCRIPTION
The instance is comprised a BU full node (1.7) and an ElectrsCash
electrum server (1.0) and run on pretty beefy machine we setup to
provide a robust instance.