### PR TITLE
Build: Fix regression causing newer glibc to be pulled into AppImage

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1604
+++ b/contrib/build-linux/appimage/Dockerfile_ub1604
@@ -20,6 +20,12 @@ RUN apt-get update -q && \
         libdbus-1-3=1.10.6-1ubuntu3.4 \
         libpcsclite-dev=1.8.14-1ubuntu1.16.04.1 \
         swig=3.0.8-0ubuntu3 \
+        software-properties-common=0.96.20.9 \
+        && \
+    add-apt-repository ppa:git-core/ppa && \
+    apt-get update -q && \
+    apt-get install -qy \
+        git=1:2.25.0-1~ppa0~ubuntu16.04.1 \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
@@ -38,7 +44,6 @@ RUN sed -i -e 's/xenial/bionic/' /etc/apt/sources.list
 # platforms we support.
 RUN apt-get update -q && \
     apt-get install -qy \
-        git=1:2.17.1-1ubuntu0.5 \
         zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
         libfreetype6=2.8.1-2ubuntu2 \
         libfontconfig1=2.12.6-0ubuntu2 \


### PR DESCRIPTION
In fd3701fd6c64a726fd201e53e77c0cf4e33a5598 we added a new git version to the AppImage build image to support shallow submodule updates.

The problem with this is that it causes a newer glibc to be pulled into the image which breaks older Linux distributions.

As a solution to this we use a git PPA by the Ubuntu Git maintainers that is compiled for Ubuntu 16.04:

https://launchpad.net/~git-core/+archive/ubuntu/ppa?field.series_filter=xenial

Due to a change in git 2.22 shallow clones will fail when using the default git protocol version, so we set protocol.version to version 2 instead. See:

https://public-inbox.org/git/20191013064314.GA28018@sigill.intra.peff.net/