### PR TITLE
Build: Install libxkbcommon-x11 in AppImage

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1604
+++ b/contrib/build-linux/appimage/Dockerfile_ub1604
@@ -21,6 +21,7 @@ RUN apt-get update -q && \
         libpcsclite-dev=1.8.14-1ubuntu1.16.04.1 \
         swig=3.0.8-0ubuntu3 \
         software-properties-common=0.96.20.9 \
+        libxkbcommon-x11-0=0.5.0-1ubuntu2.1 \
         && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get update -q && \

--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -22,6 +22,7 @@ RUN apt-get update -q && \
         gettext=0.19.8.1-6ubuntu0.1 \
         libzbar0=0.10+doc-10.1build2 \
         faketime=0.9.7-2 \
+        libxkbcommon-x11-0=0.8.0-1ubuntu0.1 \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -162,6 +162,8 @@ cp -f "$CONTRIB/build-linux/appimage/scripts/test-fontconfig.py" "$APPDIR" || fa
 # libfreetype needs a recent enough zlib
 cp -f /lib/x86_64-linux-gnu/libz.so.1 "$APPDIR"/usr/lib/x86_64-linux-gnu || fail "Could not copy zlib"
 
+# some distros lack libxkbcommon-x11
+cp -f /usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so.0 "$APPDIR"/usr/lib/x86_64-linux-gnu || fail "Could not copy libxkbcommon-x11"
 
 info "Stripping binaries of debug symbols"
 # "-R .note.gnu.build-id" also strips the build id


### PR DESCRIPTION
Newer distributions do not install `libxkbcommon-x11` by default anymore and Qt depends on it.

Fixes #1773