### PR TITLE
Tor: Ignore noisy "not an HTTP proxy" messages from TorDetector

### DIFF
--- a/lib/tor/controller.py
+++ b/lib/tor/controller.py
@@ -109,9 +109,15 @@ class TorController(PrintError):
     _listener_re = re.compile(r".*\[notice\] Opened ([^ ]*) listener on (.*)$")
     _endpoint_re = re.compile(r".*:(\d*)")
 
+    # If a log string matches any of the included regex it is ignored
+    _ignored_res = [
+        re.compile(r".*This port is not an HTTP proxy.*"), # This is caused by the network dialog TorDetector
+    ]
+
     def _tor_msg_handler(self, message: str):
         if util.is_verbose:
-            self.print_msg(message)
+            if all(not regex.match(message) for regex in TorController._ignored_res):
+                self.print_msg(message)
 
         # Check if this is a "Opened listener" message and extract the information
         # into the active_socks_port and active_control_port variables


### PR DESCRIPTION
When the network dialog is open on the proxy tab, the `TorDetector` will run in an interval, which will cause the log to be spammed with messages saying "This port is not an HTTP proxy". Those can be ignored.