### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+[*.py]
+indent_size = 4
+insert_final_newline = true


### PR DESCRIPTION
Default to LF EOL, UTF-8 and space indent. 4 space indent for .py files.

See https://editorconfig.org/