### PR TITLE
Made PyQt5 optional by default and installable by [full] or [gui] extra requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,9 +141,11 @@ setup(
     },
     name=os.environ.get('EC_PACKAGE_NAME') or "Electron Cash",
     version=os.environ.get('EC_PACKAGE_VERSION') or version.PACKAGE_VERSION,
-    install_requires=requirements + ['pyqt5'],
+    install_requires=requirements,
     extras_require={
         'hardware': requirements_hw,
+        'gui': ['pyqt5'],
+        'all': requirements_hw + ['pyqt5']
     },
     packages=[
         'electroncash',


### PR DESCRIPTION
This pull request makes PyQt5 not install-able by default by setup.py, which allows more control for users what to install, as some users don't use GUI interface and use daemon or some CLI integrations instead, where pyqt5 is an extra 60-120 MB and also it makes it impossible to install it without some additional packages on light linuxes(especially when building slim docker images), like alpine linux.
PyQt5 can now be installed by running `pip install .[gui]` or `pip install .[full]`
It might needed to be documented in README and discussed further.
I have checked all the binary builds, all the builds install PyQt5 by using `contrib/requirements/requirements-binaries.txt`, so the setup.py install_requires of pyqt5 is not neccesary.
The only build which doesn't do so is srcdist(`contrib/make_packages`), but probably it is intentional?
Exact lines(or a little bit above or below them due to changes) of where binary builds install PyQt5 by not using setup.py require:
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/make_packages#L12
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/make_linux_sdist#L23
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/build-linux/srcdist_docker/build.sh#L85
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/build-linux/srcdist_docker/_build.sh#L29
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/build-linux/appimage/build.sh#L98
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/build-linux/appimage/_build.sh#L114
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/requirements/requirements-binaries.txt#L1
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/osx/make_osx#L192
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/build-wine/build.sh#L93
https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/build-wine/_build.sh#L156