### PR TITLE
Add coreutils to mac build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,13 +122,14 @@ Cash to run completely independently of your system configuration.
 Running from source on macOS
 ============================
 
-You need to install **either** `MacPorts <https://www.macports.org>`_  **or** `HomeBrew <https://www.brew.sh>`_.  Follow the instructions on either site for installing (Xcode from `Apple's developer site <https://developer.apple.com>`_ is required for either).  
+You need to install **either** `MacPorts <https://www.macports.org>`_  **or** `HomeBrew <https://www.brew.sh>`_.  Follow the instructions on either site for installing (Xcode from `Apple's developer site <https://developer.apple.com>`_ is required for either).
 
 1. After installing either HomeBrew or MacPorts, clone this repository and switch to the directory: ``git clone https://github.com/Electron-Cash/Electron-Cash && cd Electron-Cash``
 2. Install python 3.6 or 3.7. For brew: ``brew install python3`` or if using MacPorts: ``sudo port install python36``
 3. Install PyQt5: ``python3 -m pip install --user pyqt5``
 4. Install Electron Cash requirements: ``python3 -m pip install --user -r contrib/requirements/requirements.txt``
-5. Compile libsecp256k1 (optional, yet highly recommended): ``./contrib/make_secp``
+5. Compile libsecp256k1 (optional, yet highly recommended): ``./contrib/make_secp``.
+   This requires GNU tools, install with brew: ``brew install coreutils`` or if using MacPorts: ``sudo port install coreutils``
 6. At this point you should be able to just run the sources: ``./electron-cash``
 
 


### PR DESCRIPTION
The `contrib/make_secp` script makes use of GNU utils including `grealpath`,
these are found in the coreutils package.