### PR TITLE
Add core wallet libs for SLP

### DIFF
--- a/lib/coinchooser.py
+++ b/lib/coinchooser.py
@@ -166,11 +166,17 @@ class CoinChooserBase(PrintError):
         return change, dust
 
     def make_tx(self, coins, outputs, change_addrs, fee_estimator,
-                dust_threshold, sign_schnorr=False):
+                dust_threshold, sign_schnorr=False, *, mandatory_coins=[]):
         '''Select unspent coins to spend to pay outputs.  If the change is
         greater than dust_threshold (after adding the change output to
         the transaction) it is kept, otherwise none is sent and it is
         added to the transaction fee.'''
+
+        # Remove mandatory_coin items from coin chooser's list
+        for c in mandatory_coins:
+            for coin in coins.copy():
+                if coin['prevout_hash'] == c['prevout_hash'] and coin['prevout_n'] == c['prevout_n']:
+                    coins.remove(coin)
 
         # Deterministic randomness from coins
         utxos = [c['prevout_hash'] + str(c['prevout_n']) for c in coins]
@@ -185,17 +191,21 @@ class CoinChooserBase(PrintError):
         def sufficient_funds(buckets):
             '''Given a list of buckets, return True if it has enough
             value to pay for the transaction'''
-            total_input = sum(bucket.value for bucket in buckets)
-            total_size = sum(bucket.size for bucket in buckets) + base_size
+            mandatory_coins_bucket = self.bucketize_coins(mandatory_coins, sign_schnorr=sign_schnorr)
+            mandatory_input = sum(coin.value for coin in mandatory_coins_bucket)
+            mandatory_input_size = sum(coin.size for coin in mandatory_coins_bucket)
+            total_input = sum(bucket.value for bucket in buckets) + mandatory_input
+            total_size = sum(bucket.size for bucket in buckets) + mandatory_input_size + base_size
             return total_input >= spent_amount + fee_estimator(total_size)
 
         # Collect the coins into buckets, choose a subset of the buckets
         buckets = self.bucketize_coins(coins, sign_schnorr=sign_schnorr)
-        buckets = self.choose_buckets(buckets, sufficient_funds,
-                                      self.penalty_func(tx))
+        buckets = self.choose_buckets(buckets, sufficient_funds, self.penalty_func(tx))
 
+        tx.add_inputs(mandatory_coins)
         tx.add_inputs([coin for b in buckets for coin in b.coins])
-        tx_size = base_size + sum(bucket.size for bucket in buckets)
+        mandatory_coin_size = sum(bucket.size for bucket in self.bucketize_coins(mandatory_coins))
+        tx_size = base_size + sum(bucket.size for bucket in buckets) + mandatory_coin_size
 
         # This takes a count of change outputs and returns a tx fee;
         # each pay-to-bitcoin-address output serializes as 34 bytes

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -44,6 +44,7 @@ class MainNet(AbstractNet):
     ADDRTYPE_P2SH = 5
     ADDRTYPE_P2SH_BITPAY = 40
     CASHADDR_PREFIX = "bitcoincash"
+    SLPADDR_PREFIX = "simpleledger"
     HEADERS_URL = "http://bitcoincash.com/files/blockchain_headers"
     GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
     DEFAULT_PORTS = {'t': '50001', 's': '50002'}
@@ -84,6 +85,7 @@ class TestNet(AbstractNet):
     ADDRTYPE_P2SH = 196
     ADDRTYPE_P2SH_BITPAY = 196  # Unsure
     CASHADDR_PREFIX = "bchtest"
+    SLPADDR_PREFIX = "slptest"
     HEADERS_URL = "http://bitcoincash.com/files/testnet_headers"
     GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
     DEFAULT_PORTS = {'t':'51001', 's':'51002'}

--- a/lib/slp/exceptions.py
+++ b/lib/slp/exceptions.py
@@ -26,3 +26,7 @@ class OPReturnTooLarge(SerializingError):
 # Other exceptions
 class NoMintingBatonFound(Error):
     pass
+
+class NotEnoughFundsSlp(Exception): pass
+
+class NotEnoughUnfrozenFundsSlp(Exception): pass


### PR DESCRIPTION
This is merge includes the core code in wallet.py for SLP, but it has been reorganized into the lib/slp module organization.

With this merge, the Electron Cash wallet is able to open up slp-style wallets.  Updates were made to allow slp wallets to be opened/closed by mainline and then reopened with EC SLP without interference.  The SLP wallet data is maintained completely separately between the wallets.  The mainline version stores all SLP data under the `"slp"` wallet key, whereas the EC SLP stores various slp data root level keys in the wallet file.  This way there is no interference between the two EC versions.