### PR TITLE
Requirements: Remove protobuf <3.9 constraint

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -2,7 +2,7 @@ pyaes>=0.1a1
 ecdsa>=0.9
 requests
 qrcode
-protobuf<3.9
+protobuf
 dnspython
 jsonrpclib-pelix
 PySocks>=1.6.6


### PR DESCRIPTION
This was added in 0e6d3499862d1ca51eca3870357a0b89a0940a6b.

The original error was:

```
Cannot load wallet:
Conflict register for file "messages.proto": Address is already defined in file "plugins/shuffle/protobuf/message.proto". Please fix the conflict by adding package name on the proto file, or use different name for the duplication.
```

Our own proto files have since been fixed and Trezor have fixed
their proto files as well:

https://github.com/trezor/trezor-common/commit/279bc1f220d38db9562ac9e22d61c5b94a854f9f#diff-a21d059874674d8247b316b869766a60

I tested this with protobuf-3.11.3 and haven't encountered any errors.