### PR TITLE
BUGFIX bip39 passphrases are not lowercase

### DIFF
--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -741,7 +741,7 @@ def bip44_derivation_145(account_id):
 
 def bip39_normalize_passphrase(passphrase):
     """ This is called by some plugins """
-    return Mnemonic.normalize_text(passphrase or '')
+    return Mnemonic.normalize_text(passphrase or '', is_passphrase=True)
 
 def bip39_to_seed(seed: str, passphrase: str) -> bytes:
     """This is called by some plugins """


### PR DESCRIPTION
Since February, the code reused the normalize routine for mnemonics also
for passphrases.  This had the unintentional side-effect of converting
passphrases to lower-case. This commit fixes it.

Also the accents are no longer stripped from mnemonic words, to conform
to the BIP39 standard.

Incompatibility: If you created a BIP39 wallet with a passphrase that is
not lower-case it would instead have created the wallet for the lower-case
passphrase.  So if your passphrase doesn't work after updating, you may
try it with the lower-case passphrase again.