### PR TITLE
Do not include binaries in the source distribution

### DIFF
--- a/contrib/make_linux_sdist
+++ b/contrib/make_linux_sdist
@@ -20,12 +20,11 @@ export EC_PACKAGE_VERSION EC_PACKAGE_NAME
 info "Making SrcDist for version: ${EC_PACKAGE_NAME}-${EC_PACKAGE_VERSION} ..."
 
 "$contrib"/make_locale && \
-    "$contrib"/make_packages && \
-    python3 setup.py sdist --enable-secp --enable-zbar --enable-tor --format=zip,gztar || fail "Failed."
+    python3 setup.py sdist --format=zip,gztar || fail "Failed."
 
 unset EC_PACKAGE_VERSION EC_PACKAGE_NAME
 
-info "Linux source distribution (including compiled libseck256k1 & libzbar) has been placed in dist/"
+info "Source distribution has been placed in dist/"
 
 popd
 popd


### PR DESCRIPTION
Works well with Fedora RPM that is included in the official Fedora repository