### PR TITLE
ZBar: Fix Windows build DLL imports

### DIFF
--- a/contrib/make_zbar
+++ b/contrib/make_zbar
@@ -9,6 +9,10 @@ pkgname="zbar"
 info "Building $pkgname..."
 
 pushd "$here"/$pkgname || fail "Could not chdir to $here/$pkgname"
+if [ "$BUILD_TYPE" = "wine" ] ; then
+    echo "libzbar_la_LDFLAGS += -Wc,-static" >> zbar/Makefile.am
+    echo "LDFLAGS += -Wc,-static" >> Makefile.am
+fi
 if ! [ -x configure ] ; then
     autoreconf -vfi || fail "Could not run autoreconf for $pkgname. Please make sure you have automake and libtool installed, and try again."
 fi


### PR DESCRIPTION
When improving the build scripts to add Tor support (eda015908e9d6ea9a0adfbda9db55b929c0926ba) we forgot to transfer some Windows specific flags into the new ZBar build scripts, which resulted in the binary depending on additional .dll files that were not bundled into the installer, causing the QR scanner not to work for most users. This patch restores the flags.