### PR TITLE
Event: Replace forced main thread invocation with function decorator

### DIFF
--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -33,7 +33,7 @@ import PyQt5.QtCore as QtCore
 
 from electroncash.i18n import _, pgettext
 from electroncash import networks
-from electroncash.util import print_error, Weak, PrintError
+from electroncash.util import print_error, Weak, PrintError, in_main_thread
 from electroncash.network import serialize_server, deserialize_server, get_eligible_servers
 from electroncash.plugins import run_hook
 from electroncash.tor import TorController
@@ -571,6 +571,7 @@ class NetworkChoiceLayout(QObject, PrintError):
         elif not run_hook('on_network_dialog_jumpto', self, location):
             self.print_error(f"jumpto: unknown location '{location}'")
 
+    @in_main_thread
     def on_tor_port_changed(self, controller: TorController):
         if not controller.active_socks_port or not controller.is_enabled() or not self.tor_use:
             return
@@ -816,6 +817,7 @@ class NetworkChoiceLayout(QObject, PrintError):
     def set_tor_enabled(self, enabled: bool):
         self.network.tor_controller.set_enabled(enabled)
 
+    @in_main_thread
     def on_tor_status_changed(self, controller):
         if controller.status in (TorController.Status.STARTED, TorController.Status.READY):
             self.tor_enabled.setChecked(True)

--- a/lib/util.py
+++ b/lib/util.py
@@ -878,6 +878,13 @@ def do_in_main_thread(func, *args, **kwargs):
     else:
         Handlers.do_in_main_thread(func, *args, **kwargs)
 
+def in_main_thread(func):
+    """
+    Function decorator that runs the decorated function in the main thread.
+    """
+    def wrapper(*args, **kwargs):
+        do_in_main_thread(func, *args, **kwargs)
+    return wrapper
 
 class Weak:
     '''

--- a/lib/utils/event.py
+++ b/lib/utils/event.py
@@ -1,7 +1,5 @@
 import weakref
 
-from electroncash.util import do_in_main_thread
-
 # Based on: https://stackoverflow.com/a/2022629
 # By Longpoke (https://stackoverflow.com/users/80243)
 class Event(list):
@@ -9,10 +7,6 @@ class Event(list):
 
     A list of callable objects. Calling an instance of this will cause a
     call to each item in the list in ascending order by index.
-
-    Note that in Electron Cash, calling this list (if using the Qt GUI) will
-    guarantee the calls are sent to the main thread's event loop. Thus it's safe
-    to use this as an improvised signal/slot mechanism with GUI code.
 
     The list can also contain WeakMethods using the append_weak and
     insert_weak methods. When a weak method is dead, it will be removed
@@ -51,9 +45,7 @@ class Event(list):
                 else:
                     # it's good, proceed with dereferenced strong_method
                     method = strong_method
-            # contract is callbacks always are in the main thread to make GUI
-            # code's life easier.
-            do_in_main_thread(method, *args, **kwargs)
+            method(*args, **kwargs)
 
     def __repr__(self):
         return "Event(%s)" % list.__repr__(self)


### PR DESCRIPTION
The `Event` class currently forces every method call to happen on the main thread. There are some use cases where this is not a good idea, so this should be removed. Instead we add the function decorator `@in_main_thread` that invokes the decorated function in the main thread. Every event handler that touches GUI objects or needs to run in the main thread for some other reason needs to be decorated.
