### PR TITLE
Requirements: Add certifi dependency needed by the CashFusion plugin

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -9,3 +9,4 @@ PySocks>=1.6.6
 qdarkstyle==2.6.8
 python-dateutil<2.9
 stem>=1.8.0
+certifi


### PR DESCRIPTION
While the requests library already depends on `certifi`, we should make that dependency explicit. For example Arch Linux uses a patched `requests` library that does not depend on `certifi`, causing the CashFusion plugin to fail to load.