### PR TITLE
Tests: Fix failing host name test and add wildcard tests

### DIFF
--- a/lib/tests/test_interface.py
+++ b/lib/tests/test_interface.py
@@ -19,8 +19,20 @@ class TestInterface(unittest.TestCase):
         self.assertFalse(i.check_host_name(
             peercert={'subjectAltName': []}, name=''))
         self.assertTrue(i.check_host_name(
-            peercert={'subjectAltName': [('DNS', 'foo.bar.com')]},
+            peercert={'subjectAltName': (('DNS', 'foo.bar.com'),)},
             name='foo.bar.com'))
         self.assertTrue(i.check_host_name(
-            peercert={'subject': [('commonName', 'foo.bar.com')]},
+            peercert={'subjectAltName': (('DNS', '*.bar.com'),)},
             name='foo.bar.com'))
+        self.assertFalse(i.check_host_name(
+            peercert={'subjectAltName': (('DNS', '*.bar.com'),)},
+            name='sub.foo.bar.com'))
+        self.assertTrue(i.check_host_name(
+            peercert={'subject': ((('commonName', 'foo.bar.com'),),)},
+            name='foo.bar.com'))
+        self.assertTrue(i.check_host_name(
+            peercert={'subject': ((('commonName', '*.bar.com'),),)},
+            name='foo.bar.com'))
+        self.assertFalse(i.check_host_name(
+            peercert={'subject': ((('commonName', '*.bar.com'),),)},
+            name='sub.foo.bar.com'))


### PR DESCRIPTION
In 4.1.0 we added support for wildcard certificates which caused the tests to fail. The test was passing data in a format `ssl.match_hostname` did not expect, so the test had to be fixed.

This also adds tests for wildcard certificates and tests the second level sub domains of wildcard certificates fail the test.

closes #1923