### PR TITLE
Travis: Make it work again for Python 3.6, 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
-sudo: false
+os: linux
+dist: bionic
 language: python
 python:
-    - 3.5
     - 3.6
+    - 3.7
+    - 3.8
 install:
   - pip install -r contrib/requirements/requirements-travis.txt
 cache:

--- a/contrib/requirements/requirements-travis.txt
+++ b/contrib/requirements/requirements-travis.txt
@@ -1,3 +1,3 @@
 tox
-python-coveralls
+coveralls
 tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py36, py37, py38
 
 [testenv]
 deps=


### PR DESCRIPTION
* Fixed the `.travis.yml` warnings
* We need Bionic as otherwise Qt errors
* Use `coveralls` instead of `python-coveralls` package as the latter is broken
* Add Python 3.7 and 3.8 to the tox configuration