### PR TITLE
git sanity: enforce "git checkout commithash" actually pulls commit

### DIFF
--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -72,7 +72,7 @@ info "Building squashfskit"
 git clone "https://github.com/squashfskit/squashfskit.git" "$BUILDDIR/squashfskit"
 (
     cd "$BUILDDIR/squashfskit"
-    git checkout -b pinned "$SQUASHFSKIT_COMMIT" || fail "Could not find squashfskit commit $SQUASHFSKIT_COMMIT"
+    git checkout -b pinned "$SQUASHFSKIT_COMMIT^{commit}" || fail "Could not find squashfskit commit $SQUASHFSKIT_COMMIT"
     make -C squashfs-tools mksquashfs || fail "Could not build squashfskit"
 )
 MKSQUASHFS="$BUILDDIR/squashfskit/squashfs-tools/mksquashfs"

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -130,7 +130,7 @@ prepare_wine() {
             git init
             git remote add origin $PYINSTALLER_REPO
             git fetch --depth 1 origin $PYINSTALLER_COMMIT
-            git checkout -b pinned FETCH_HEAD
+            git checkout -b pinned "${$PYINSTALLER_COMMIT}^{commit}"
             rm -fv PyInstaller/bootloader/Windows-*/run*.exe || true  # Make sure EXEs that came with repo are deleted -- we rebuild them and need to detect if build failed
             if [ ${PYI_SKIP_TAG:-0} -eq 0 ] ; then
                 echo "const char *ec_tag = \"tagged by Electron-Cash@$GIT_COMMIT_HASH\";" >> ./bootloader/src/pyi_main.c
@@ -169,7 +169,7 @@ prepare_wine() {
             git init
             git remote add origin $LIBUSB_REPO
             git fetch --depth 1 origin $LIBUSB_COMMIT
-            git checkout -b pinned FETCH_HEAD
+            git checkout -b pinned "${LIBUSB_COMMIT}^{commit}"
             echo "libusb_1_0_la_LDFLAGS += -Wc,-static" >> libusb/Makefile.am
             ./bootstrap.sh || fail "Could not bootstrap libusb"
             host="i686-w64-mingw32"

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -55,7 +55,7 @@ VERSION=`git describe --tags`
 
 # Paramterize
 BUILDDIR=/tmp/electron-cash-build
-LIBSECP_VERSION="69ccf0d2f758b1a4df9cde8222459381e08fc1dc"  # using a commit hash guarantees no repository man-in-the-middle funny business as git is secure when verifying hashes.
+LIBSECP_COMMIT="69ccf0d2f758b1a4df9cde8222459381e08fc1dc"
 # Compute major.minor Python version from above using Bash array magic
 MAJ_MIN=(${PYTHON_VERSION//./ })
 MAJ_MIN=${MAJ_MIN[0]}.${MAJ_MIN[1]}
@@ -195,7 +195,7 @@ verify_hash contrib/osx/libzbar.0.dylib 7b82238dd73e56d9f57913230ea5418c247b292c
 
 info "Building libsecp256k1"
 pushd contrib/secp256k1 || fail "Could not chdir to contrib/secp256k1"
-git checkout $LIBSECP_VERSION || fail "Could not check out secp256k1 $LIBSECP_VERSION"
+git checkout "$LIBSECP_COMMIT^{commit}" || fail "Could not check out secp256k1 $LIBSECP_COMMIT"
 git clean -f -x -q
 ./autogen.sh || fail "Could not run autogen for secp256k1"
 ./configure \

--- a/ios/make_ios_project.sh
+++ b/ios/make_ios_project.sh
@@ -170,7 +170,7 @@ cd scratch || exit 1
 git clone http://www.github.com/cculianu/rubicon-objc
 gitexit="$?"
 cd rubicon-objc
-git checkout send_super_fix
+git checkout "fe054117056d33059a5db8addbc14e8535f08d3b^{commit}" # from branch send_super_fix
 gitexit2="$?"
 cd ..
 cd ..


### PR DESCRIPTION
If there is a collision between a branch name and a commit hash, git will choose the branch, even if the full 40-hex-long commit hash is given. GitHub disallows branches/tags with such a name but git itself does not. By adding the `^{commit}` syntax sugar after a ref name, we can tell git that we want the commit hash to be preferred, and hence we don't need to trust GitHub (only git).

see https://security.stackexchange.com/questions/225411/

from https://github.com/spesmilo/electrum/commit/f5f3394552c4efa46b71e13d1ad3ab171936bd88 adjusted for our repo. Also includes a fix for `make_ios_project.sh` checking out a branch.