### PR TITLE
Add support for the ASERTi3-2d DAA for the Nov. 15th, 2020 Upgrade

### DIFF
--- a/lib/asert_daa.py
+++ b/lib/asert_daa.py
@@ -20,6 +20,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os
 
 from collections import namedtuple
 from typing import Optional
@@ -38,6 +39,20 @@ def bits_to_target(bits: int) -> int:
     else:
         return word << (8 * (size - 3))
 
+def _get_asert_activation_mtp():
+    """ Returns 1605441600 (Nov 15, 2020 12:00:00 UTC) or whatever override may
+    be set by the env variable ASERT_MTP """
+    default_mtp = 1605441600  # Nov 15, 2020 12:00:00 UTC
+    mtp = os.environ.get('ASERT_MTP', default_mtp)
+    try: mtp = int(mtp)
+    except: pass
+    if not isinstance(mtp, int) or mtp <= 1510600000:
+        print_error("Error: Environment variable ASERT_MTP ignored because it is invalid: {}".format(str(mtp)))
+        mtp = default_mtp
+    if mtp != default_mtp:
+        print_error("ASERT_MTP of {} will be used".format(mtp))
+    return mtp
+
 class Anchor(namedtuple("Anchor", "height bits prev_time")):
     pass
 
@@ -45,7 +60,7 @@ class ASERTDaa:
     """ Parameters and methods for the ASERT DAA. Instances of these live in
     networks.TestNet, networks.MainNet as part of the chain params. """
 
-    MTP_ACTIVATION_TIME = 1605441600  # Nov 15, 2020 12:00:00 UTC
+    MTP_ACTIVATION_TIME = _get_asert_activation_mtp()  # Normally Nov. 15th, 2020 UTC 12:00:00
 
     IDEAL_BLOCK_TIME = 10 * 60  # 10 mins
     TAU = 2 * 24 * 3600  # for mainnet, testnet has 3600 (1 hour) half-life
@@ -141,4 +156,3 @@ class ASERTDaa:
             return self.MAX_BITS
 
         return self.target_to_bits(target)
-

--- a/lib/asert_daa.py
+++ b/lib/asert_daa.py
@@ -21,6 +21,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from collections import namedtuple
+from typing import Optional
+
 from .util import print_error
 
 def bits_to_target(bits: int) -> int:
@@ -35,6 +38,8 @@ def bits_to_target(bits: int) -> int:
     else:
         return word << (8 * (size - 3))
 
+class Anchor(namedtuple("Anchor", "height bits prev_time")):
+    pass
 
 class ASERTDaa:
     """ Parameters and methods for the ASERT DAA. Instances of these live in
@@ -51,6 +56,8 @@ class ASERTDaa:
     MAX_BITS = 0x1d00ffff
 
     MAX_TARGET = bits_to_target(MAX_BITS)
+
+    anchor: Optional[Anchor] = None
 
     def __init__(self, is_testnet=False):
         if is_testnet:

--- a/lib/asert_daa.py
+++ b/lib/asert_daa.py
@@ -1,0 +1,133 @@
+# Electron Cash - lightweight Bitcoin Cash client
+# Copyright (C) 2020 The Electron Cash Developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from .util import print_error
+
+
+class ASERTDaa:
+    """ Parameters and methods for the ASERT DAA. Instances of these live in
+    networks.TestNet, networks.MainNet as part of the chain params. """
+
+    MTP_ACTIVATION_TIME = 1605441600  # Nov 15, 2020 12:00:00 UTC
+
+    IDEAL_BLOCK_TIME = 10 * 60  # 10 mins
+    TAU = 2 * 24 * 3600  # for mainnet, testnet has 3600 (1 hour) half-life
+    # Integer implementation uses these for fixed point math
+    RBITS = 16  # number of bits after the radix for fixed-point math
+    RADIX = 1 << RBITS
+    # POW Limit
+    MAX_BITS = 0x1d00ffff
+
+    @staticmethod
+    def bits_to_target(bits: int) -> int:
+        size = bits >> 24
+        assert size <= 0x1d
+
+        word = bits & 0x00ffffff
+        assert 0x8000 <= word <= 0x7fffff
+
+        if size <= 3:
+            return word >> (8 * (3 - size))
+        else:
+            return word << (8 * (size - 3))
+
+    MAX_TARGET = bits_to_target(MAX_BITS)
+
+    def __init__(self, is_testnet=False):
+        if is_testnet:
+            # From ASERT spec, testnet has 1 hour half-life
+            self.TAU = 3600
+
+    def target_to_bits(self, target: int) -> int:
+        assert target > 0
+        if target > self.MAX_TARGET:
+            print_error('Warning: target went above maximum ({} > {})'.format(target, self.MAX_TARGET))
+            target = self.MAX_TARGET
+        size = (target.bit_length() + 7) // 8
+        mask64 = 0xffffffffffffffff
+        if size <= 3:
+            compact = (target & mask64) << (8 * (3 - size))
+        else:
+            compact = (target >> (8 * (size - 3))) & mask64
+
+        if compact & 0x00800000:
+            compact >>= 8
+            size += 1
+
+        assert compact == (compact & 0x007fffff)
+        assert size < 256
+        return compact | size << 24
+
+    @staticmethod
+    def bits_to_work(bits: int) -> int:
+        return (2 << 255) // (ASERTDaa.bits_to_target(bits) + 1)
+
+    @staticmethod
+    def target_to_hex(target: int) -> str:
+        h = hex(target)[2:]
+        return '0' * (64 - len(h)) + h
+
+    def next_bits_aserti3_2d(self, anchor_bits: int, time_diff: float, height_diff: int) -> int:
+        """ Integer ASERTI algorithm, based on Jonathan Toomim's
+        `next_bits_aserti` implementation in mining.py (see
+        https://github.com/jtoomim/difficulty) """
+
+        target = self.bits_to_target(anchor_bits)
+
+        # Ultimately, we want to approximate the following ASERT formula, using
+        # only integer (fixed-point) math:
+        #     new_target = old_target * 2^((time_diff -
+        #     IDEAL_BLOCK_TIME*(height_diff+1)) / TAU)
+
+        # First, we'll calculate the exponent, using floor division. The
+        # assertion checks a type constraint of the C++ implementation which
+        # uses a 64-bit signed integer for the exponent. If inputs violate that,
+        # then the implementation will diverge.
+        assert(abs(time_diff - self.IDEAL_BLOCK_TIME * (height_diff+1)) < (1<<(63-self.RBITS)))
+        exponent = int(((time_diff - self.IDEAL_BLOCK_TIME*(height_diff+1)) * self.RADIX) / self.TAU)
+
+        # Next, we use the 2^x = 2 * 2^(x-1) identity to shift our exponent into the (0, 1] interval.
+        shifts = exponent >> self.RBITS
+        exponent -= shifts * self.RADIX
+        assert(exponent >= 0 and exponent < 65536)
+
+        # Now we compute an approximated target * 2^(fractional part) * 65536
+        # target * 2^x ~= target * (1 + 0.695502049*x + 0.2262698*x**2 + 0.0782318*x**3)
+        target *= self.RADIX + ((195766423245049*exponent + 971821376*exponent**2 + 5127*exponent**3 + 2**47)>>(self.RBITS*3))
+
+        # Next, we shift to multiply by 2^(integer part). Python doesn't allow
+        # shifting by negative integers, so:
+        if shifts < 0:
+            target >>= -shifts
+        else:
+            target <<= shifts
+        # Remove the 65536 multiplier we got earlier
+        target >>= self.RBITS
+
+        if target == 0:
+            return self.target_to_bits(1)
+        if target > self.MAX_TARGET:
+            return self.MAX_BITS
+
+        return self.target_to_bits(target)
+

--- a/lib/asert_daa.py
+++ b/lib/asert_daa.py
@@ -78,8 +78,6 @@ class ASERTDaa:
         if is_testnet:
             # From ASERT spec, testnet has 1 hour half-life
             self.TAU = 3600
-            # DELETE ME XXX HACK TODO: for testing our forked testnet testing
-            self.MTP_ACTIVATION_TIME = 1597096200
 
     @staticmethod
     def bits_to_target(bits: int) -> int:  return bits_to_target(bits)

--- a/lib/asert_daa.py
+++ b/lib/asert_daa.py
@@ -23,7 +23,7 @@
 import os
 
 from collections import namedtuple
-from typing import Optional
+from typing import Optional, Union
 
 from .util import print_error
 
@@ -111,7 +111,7 @@ class ASERTDaa:
         h = hex(target)[2:]
         return '0' * (64 - len(h)) + h
 
-    def next_bits_aserti3_2d(self, anchor_bits: int, time_diff: float, height_diff: int) -> int:
+    def next_bits_aserti3_2d(self, anchor_bits: int, time_diff: Union[float, int], height_diff: int) -> int:
         """ Integer ASERTI algorithm, based on Jonathan Toomim's
         `next_bits_aserti` implementation in mining.py (see
         https://github.com/jtoomim/difficulty) """

--- a/lib/asert_daa.py
+++ b/lib/asert_daa.py
@@ -23,6 +23,18 @@
 
 from .util import print_error
 
+def bits_to_target(bits: int) -> int:
+    size = bits >> 24
+    assert size <= 0x1d
+
+    word = bits & 0x00ffffff
+    assert 0x8000 <= word <= 0x7fffff
+
+    if size <= 3:
+        return word >> (8 * (3 - size))
+    else:
+        return word << (8 * (size - 3))
+
 
 class ASERTDaa:
     """ Parameters and methods for the ASERT DAA. Instances of these live in
@@ -38,25 +50,17 @@ class ASERTDaa:
     # POW Limit
     MAX_BITS = 0x1d00ffff
 
-    @staticmethod
-    def bits_to_target(bits: int) -> int:
-        size = bits >> 24
-        assert size <= 0x1d
-
-        word = bits & 0x00ffffff
-        assert 0x8000 <= word <= 0x7fffff
-
-        if size <= 3:
-            return word >> (8 * (3 - size))
-        else:
-            return word << (8 * (size - 3))
-
     MAX_TARGET = bits_to_target(MAX_BITS)
 
     def __init__(self, is_testnet=False):
         if is_testnet:
             # From ASERT spec, testnet has 1 hour half-life
             self.TAU = 3600
+            # DELETE ME XXX HACK TODO: for testing our forked testnet testing
+            self.MTP_ACTIVATION_TIME = 1597096200
+
+    @staticmethod
+    def bits_to_target(bits: int) -> int:  return bits_to_target(bits)
 
     def target_to_bits(self, target: int) -> int:
         assert target > 0
@@ -80,7 +84,7 @@ class ASERTDaa:
 
     @staticmethod
     def bits_to_work(bits: int) -> int:
-        return (2 << 255) // (ASERTDaa.bits_to_target(bits) + 1)
+        return (2 << 255) // (bits_to_target(bits) + 1)
 
     @staticmethod
     def target_to_hex(target: int) -> str:

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -435,13 +435,14 @@ class Blockchain(util.PrintError):
 
         # NOV 13 HF DAA and/or ASERT DAA
 
-        prevheight = height -1
+        prevheight = height - 1
         daa_mtp = self.get_median_time_past(prevheight, chunk)
 
+
+        # ASERTi3-2d DAA activated on Nov. 15th 2020 HF
         if daa_mtp >= networks.net.ASERT_DAA.MTP_ACTIVATION_TIME:
             header_ts = header['timestamp']
             prev_ts = prior['timestamp']
-            # ASERTi3-2d DAA activated on Nov. 15th 2020 HF
             if networks.net.TESTNET:
                 # testnet 20 minute rule
                 if header_ts - prev_ts > 20*60:
@@ -452,7 +453,7 @@ class Blockchain(util.PrintError):
             anchor_bits = 0x1d00923b
             anchor_prev_time = 1597096679
 
-            return networks.net.ASERT_DAA.next_bits_aserti3_2d(anchor_bits, prev_ts - anchor_prev_time, (height-1) - anchor_height)
+            return networks.net.ASERT_DAA.next_bits_aserti3_2d(anchor_bits, prev_ts - anchor_prev_time, prevheight - anchor_height)
 
 
         # Mon Nov 13 19:06:40 2017 DAA HF

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -425,15 +425,11 @@ class Blockchain(util.PrintError):
 
     _cached_asert_anchor: Optional[asert_daa.Anchor] = None  # cached Anchor, per-Blockchain instance
     def get_asert_anchor(self, prevheader, mtp, chunk=None):
-        # XXX DELME TODO TESTNG - HARDCODED for testing
-        #return asert_daa.Anchor(1400614,     # anchor: height
-        #                        0x1d00923b,  # anchor: bits
-        #                        1597096679)  # anchor: *previous* block ts
         if networks.net.asert_daa.anchor is not None:
             # Checkpointed (hard-coded) value exists, just use that
             return networks.net.asert_daa.anchor
         if (self._cached_asert_anchor is not None
-            and self._cached_asert_anchor.height <= prevheader['block_height']):
+                and self._cached_asert_anchor.height <= prevheader['block_height']):
             return self._cached_asert_anchor
         # ****
         # This may be slow -- we really should be leveraging the hard-coded

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -25,6 +25,8 @@ import os
 import sys
 import threading
 
+from typing import Optional
+
 from . import asert_daa
 from . import networks
 from . import util
@@ -421,16 +423,21 @@ class Blockchain(util.PrintError):
 
         return blocks1['block_height']
 
+    _cached_asert_anchor: Optional[asert_daa.Anchor] = None  # cached Anchor, per-Blockchain instance
     def get_asert_anchor(self, prevheader, mtp, chunk=None):
         # XXX DELME TODO TESTNG - HARDCODED for testing
-        return asert_daa.Anchor(1400614,     # anchor: height
-                                0x1d00923b,  # anchor: bits
-                                1597096679)  # anchor: *previous* block ts
-
-        # **** DO NOT USE THE BELOW CODE! ****
-        # The below is terrible and slow. Code is left here
-        # to illustrate the concept of what we want to do.
-        # **** DO NOT USE THE BELOW CODE! ****
+        #return asert_daa.Anchor(1400614,     # anchor: height
+        #                        0x1d00923b,  # anchor: bits
+        #                        1597096679)  # anchor: *previous* block ts
+        if networks.net.asert_daa.anchor is not None:
+            return networks.net.asert_daa.anchor
+        if self._cached_asert_anchor is not None:
+            return self._cached_asert_anchor
+        # ****
+        # This may be slow -- we really should be leveraging the hard-coded
+        # checkpointed value. TODO: add hard-coded value to networks.py after
+        # Nov. 15th 2020 HF to ASERT DAA
+        # ****
         anchor = prevheader
         while mtp >= networks.net.asert_daa.MTP_ACTIVATION_TIME:
             ht = anchor['block_height']
@@ -438,14 +445,16 @@ class Blockchain(util.PrintError):
             # mtp >= activation time, so figure out the anchor params
             prev = self.read_header(ht - 1, chunk)
             if prev is None:
-                self.print_error("find_asert_anchor missing header {}".format(ht - 1))
+                self.print_error("get_asert_anchor missing header {}".format(ht - 1))
                 return None
             prev_mtp = self.get_median_time_past(ht - 1, chunk)
             if prev_mtp < networks.net.asert_daa.MTP_ACTIVATION_TIME:
                 # Ok, use this as anchor
                 bits = anchor['bits']
-                return asert_daa.Anchor(ht, bits, prev['timestamp'])
+                self._cached_asert_anchor = asert_daa.Anchor(ht, bits, prev['timestamp'])
+                return self._cached_asert_anchor
             mtp = prev_mtp
+            anchor = prev
 
     def get_bits(self, header, chunk=None):
         '''Return bits for the given height.'''
@@ -475,11 +484,8 @@ class Blockchain(util.PrintError):
                 if header_ts - prev_ts > 20*60:
                     return MAX_BITS
 
-            if networks.net.asert_daa.anchor is None:
-                networks.net.asert_daa.anchor = self.get_asert_anchor(prior, daa_mtp, chunk)
-                
-            anchor = networks.net.asert_daa.anchor
-            assert anchor is not None, "Failed to find ASERT anchor block"
+            anchor = self.get_asert_anchor(prior, daa_mtp, chunk)
+            assert anchor is not None, "Failed to find ASERT anchor block for chain {!r}".format(self)
 
             return networks.net.asert_daa.next_bits_aserti3_2d(anchor.bits,
                                                                prev_ts - anchor.prev_time,

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -432,7 +432,8 @@ class Blockchain(util.PrintError):
         if networks.net.asert_daa.anchor is not None:
             # Checkpointed (hard-coded) value exists, just use that
             return networks.net.asert_daa.anchor
-        if self._cached_asert_anchor is not None:
+        if (self._cached_asert_anchor is not None
+            and self._cached_asert_anchor.height <= prevheader['block_height']):
             return self._cached_asert_anchor
         # ****
         # This may be slow -- we really should be leveraging the hard-coded

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -440,7 +440,7 @@ class Blockchain(util.PrintError):
 
 
         # ASERTi3-2d DAA activated on Nov. 15th 2020 HF
-        if daa_mtp >= networks.net.ASERT_DAA.MTP_ACTIVATION_TIME:
+        if daa_mtp >= networks.net.asert_daa.MTP_ACTIVATION_TIME:
             header_ts = header['timestamp']
             prev_ts = prior['timestamp']
             if networks.net.TESTNET:
@@ -453,7 +453,7 @@ class Blockchain(util.PrintError):
             anchor_bits = 0x1d00923b
             anchor_prev_time = 1597096679
 
-            return networks.net.ASERT_DAA.next_bits_aserti3_2d(anchor_bits, prev_ts - anchor_prev_time, prevheight - anchor_height)
+            return networks.net.asert_daa.next_bits_aserti3_2d(anchor_bits, prev_ts - anchor_prev_time, prevheight - anchor_height)
 
 
         # Mon Nov 13 19:06:40 2017 DAA HF

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -433,13 +433,30 @@ class Blockchain(util.PrintError):
             raise Exception("get_bits missing header {} with chunk {!r}".format(height - 1, chunk))
         bits = prior['bits']
 
-        #NOV 13 HF DAA
+        # NOV 13 HF DAA and/or ASERT DAA
 
         prevheight = height -1
         daa_mtp = self.get_median_time_past(prevheight, chunk)
 
-        #if (daa_mtp >= 1509559291):  #leave this here for testing
-        if (daa_mtp >= 1510600000):
+        if daa_mtp >= networks.net.ASERT_DAA.MTP_ACTIVATION_TIME:
+            header_ts = header['timestamp']
+            prev_ts = prior['timestamp']
+            # ASERTi3-2d DAA activated on Nov. 15th 2020 HF
+            if networks.net.TESTNET:
+                # testnet 20 minute rule
+                if header_ts - prev_ts > 20*60:
+                    return MAX_BITS
+
+            # XXX DELME TODO TESTNG - HARDCODED for testing
+            anchor_height = 1400614
+            anchor_bits = 0x1d00923b
+            anchor_prev_time = 1597096679
+
+            return networks.net.ASERT_DAA.next_bits_aserti3_2d(anchor_bits, prev_ts - anchor_prev_time, (height-1) - anchor_height)
+
+
+        # Mon Nov 13 19:06:40 2017 DAA HF
+        if daa_mtp >= 1510600000:
 
             if networks.net.TESTNET:
                 # testnet 20 minute rule

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -24,6 +24,8 @@
 
 import json, pkgutil
 
+from .asert_daa import ASERTDaa
+
 def _read_json_dict(filename):
     try:
         data = pkgutil.get_data(__name__, filename)
@@ -34,6 +36,7 @@ def _read_json_dict(filename):
 
 class AbstractNet:
     TESTNET = False
+    ASERT_DAA = ASERTDaa()
 
 
 class MainNet(AbstractNet):
@@ -78,6 +81,7 @@ class MainNet(AbstractNet):
 
 class TestNet(AbstractNet):
     TESTNET = True
+    ASERT_DAA = ASERTDaa(is_testnet=True)
     WIF_PREFIX = 0xef
     ADDRTYPE_P2PKH = 111
     ADDRTYPE_P2PKH_BITPAY = 111  # Unsure

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -36,7 +36,7 @@ def _read_json_dict(filename):
 
 class AbstractNet:
     TESTNET = False
-    ASERT_DAA = ASERTDaa()
+    asert_daa = ASERTDaa()
 
 
 class MainNet(AbstractNet):
@@ -81,7 +81,7 @@ class MainNet(AbstractNet):
 
 class TestNet(AbstractNet):
     TESTNET = True
-    ASERT_DAA = ASERTDaa(is_testnet=True)
+    asert_daa = ASERTDaa(is_testnet=True)
     WIF_PREFIX = 0xef
     ADDRTYPE_P2PKH = 111
     ADDRTYPE_P2PKH_BITPAY = 111  # Unsure

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -65,8 +65,8 @@ class MainNet(AbstractNet):
     #    network.synchronous_get(("blockchain.block.header", [height, height]))
     #
     # Consult the ElectrumX documentation for more details.
-    VERIFICATION_BLOCK_MERKLE_ROOT = "fcf0ac1b7d7efc16d93e8ec9211def5977827482420b5210718731ecd6c4edb4"
-    VERIFICATION_BLOCK_HEIGHT = 592911
+    VERIFICATION_BLOCK_MERKLE_ROOT = "575401e2c601590926742fc806339d99dfdbd65b867231c3d799ea9a22cf9355"
+    VERIFICATION_BLOCK_HEIGHT = 645000
 
     # Version numbers for BIP32 extended keys
     # standard: xprv, xpub
@@ -98,8 +98,8 @@ class TestNet(AbstractNet):
     BITCOIN_CASH_FORK_BLOCK_HEIGHT = 1155876
     BITCOIN_CASH_FORK_BLOCK_HASH = "00000000000e38fef93ed9582a7df43815d5c2ba9fd37ef70c9a0ea4a285b8f5"
 
-    VERIFICATION_BLOCK_MERKLE_ROOT = "c3cc7a7b6fe5e0ff19b750ae200ae93664b3abf09bf510e26e15ba338afe1f1a"
-    VERIFICATION_BLOCK_HEIGHT = 1273800
+    VERIFICATION_BLOCK_MERKLE_ROOT = "05389f1534c30b86268c5ea87ad9b121ed90db814267e63f5f0c6bd9c089d362"
+    VERIFICATION_BLOCK_HEIGHT = 1400000
 
     # Version numbers for BIP32 extended keys
     # standard: tprv, tpub


### PR DESCRIPTION
Summary
---

- Default activation is for MTP >= 1605441600, which is taken from BCHN sources chainparams.cpp and corresponds to the Nov. 15th 2020 12:00:00 UTC upgrade time.
- Can override activation time for testing via the `ASERT_MTP=` environment variable

Test Plan
---

You can test this now by hitting one of the ASERT testnet servers.  Either mine or imaginary username's server. 
1. Start `electron-cash` in testnet mode, specifying the hard fork MTP we set up:

    **`$ ASERT_MTP=1597096200 ./electron-cash -v --testnet`**

2. Hit either my server or im_uname's server: 
  - `blackie.c3-soft.com` port `61002`
  - `testnet.imaginary.cash` port `50002`

You should notice that there is a fork and your client should reject the other chain in the console output (cannot connect header, bad chunk messages).

3. Start electron-cash again WITHOUT the `ASERT_MTP` env var, and see it be able to use the other chains, but not the `ASERT` chains that I and im_uname are running.

**NOTE**: Electron Cash has known bugs when switching forks and also there may be bugs in electron cash when switching between the different chains if `ASERT_MTP=` is set in the env var, then you restart again without it set.  This may be because headers previously marked as good now become bad and vice-versa.  To reset EC to a default state if you encounter this, see the comment below: https://github.com/Electron-Cash/Electron-Cash/pull/1954#issuecomment-671992186

Merge Plan
---

Kindly squash when merging.
