### PR TITLE
[fusion] Consolidating better, misc cleanup

### DIFF
--- a/plugins/fusion/qt.py
+++ b/plugins/fusion/qt.py
@@ -1388,8 +1388,7 @@ class FusionsWindow(ServerFusionsBaseMixin, QDialog):
         reselect_fusions.discard(None)
         reselect_items = []
         tree.clear()
-        fusions_and_times = sorted(self.plugin.fusions.items(), key=lambda x:x[1], reverse=True)
-        for fusion,t in fusions_and_times:
+        for fusion in reversed(self.plugin.get_all_fusions()):
             wname = fusion.target_wallet.diagnostic_name()
             status, status_ext = fusion.status
             item = QTreeWidgetItem( [ wname, status, status_ext] )


### PR DESCRIPTION
- Make it so that consolidation is always actually shrinking wallet utxo set by each fusion having max of 3 outputs (thus minimum of 8 inputs). This way it always has an endpoint.
- Misc cleanups of locking in plugin.py
- Misc other cleanups in plugin.py
