### PR TITLE
Run history_list_filter hook on updated labels

### DIFF
--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -199,19 +199,11 @@ class HistoryList(MyTreeWidget):
         if column != 3:
             return
 
-        h_items = self.wallet.get_history(self.get_domain(), reverse=True)
-        item_txid = item.data(0, Qt.UserRole)
-
-        # Find the corresponding item in the wallet history
-        for h_item in h_items:
-             tx_hash, _, _, _, _, _ = h_item
-
-             if tx_hash == item_txid:
-                label = item.data(3, Qt.EditRole)
-                should_skip = run_hook("history_list_filter", self, h_item, label, multi=True) or []
-                if any(should_skip):
-                    item.setHidden(True)
-                return
+        label = item.data(3, Qt.EditRole)
+        # NB: 'h_item' parameter is None due to performance reasons
+        should_skip = run_hook("history_list_filter", self, None, label, multi=True) or []
+        if any(should_skip):
+            item.setHidden(True)
 
     def update_item(self, tx_hash, height, conf, timestamp):
         if not self.wallet: return # can happen on startup if this is called before self.on_update()

--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -189,9 +189,9 @@ class HistoryList(MyTreeWidget):
             item = root.child(i)
             txid = item.data(0, Qt.UserRole)
             h_label = self.wallet.get_label(txid)
-            current_label = item.data(3, Qt.EditRole)
+            current_label = item.text(3)
             item.setText(3, h_label)
-            if (current_label != h_label):
+            if current_label != h_label:
                 self.item_changed(item, 3)
 
     def item_changed(self, item, column):
@@ -199,7 +199,7 @@ class HistoryList(MyTreeWidget):
         if column != 3:
             return
 
-        label = item.data(3, Qt.EditRole)
+        label = item.text(3)
         # NB: 'h_item' parameter is None due to performance reasons
         should_skip = run_hook("history_list_filter", self, None, label, multi=True) or []
         if any(should_skip):

--- a/gui/qt/history_list.py
+++ b/gui/qt/history_list.py
@@ -184,11 +184,18 @@ class HistoryList(MyTreeWidget):
             return
         root = self.invisibleRootItem()
         child_count = root.childCount()
+        filtered_list = []
         for i in range(child_count):
             item = root.child(i)
             txid = item.data(0, Qt.UserRole)
             label = self.wallet.get_label(txid)
             item.setText(3, label)
+            filtered = run_hook("history_list_filter", self, item, label, multi=True) or []
+            if any(filtered):
+                filtered_list.append(item)
+
+        for item in filtered_list:
+            root.removeChild(item)
 
     def update_item(self, tx_hash, height, conf, timestamp):
         if not self.wallet: return # can happen on startup if this is called before self.on_update()

--- a/plugins/fusion/qt.py
+++ b/plugins/fusion/qt.py
@@ -415,6 +415,7 @@ class Plugin(FusionPlugin, QObject):
 
     @hook
     def history_list_filter(self, history_list, h_item, label):
+        # NB: 'h_item' might be None due to performance reasons
         if self._hide_history_txs:
             return bool(label.startswith("CashFusion "))  # this string is not translated for performance reasons
         return None

--- a/plugins/shuffle_deprecated/qt.py
+++ b/plugins/shuffle_deprecated/qt.py
@@ -757,6 +757,7 @@ class Plugin(BasePlugin):
 
     @hook
     def history_list_filter(self, history_list, h_item, label):
+        # NB: 'h_item' might be None due to performance reasons
         if self._hide_history_txs:
             return bool(label.startswith("Shuffle ")  # this string is not translated for performance reasons. _make_label also does not translate this string.
                         and ( any( x for x in BackgroundShufflingThread.SCALE_ARROWS


### PR DESCRIPTION
This way an edited label can be filtered directly instead of during
update of the entire history_list.

This can be seen if someone has CashFusion running and the "Hide
CashFusions" option enabled and proceeds to rename a label to start with
"CashFusion ".
Without this fix the transaction is not hidden until the
wallet is restarted or the "Hide CashFusions" option is toggled off and
on.