### PR TITLE
Add electroncash.de testnet4 server

### DIFF
--- a/lib/servers_testnet4.json
+++ b/lib/servers_testnet4.json
@@ -11,6 +11,15 @@
         "s": "62002",
         "t": "62001",
         "display": "tbch4.loping.net"
+    },
+	"electroncash.de": {
+        "t": "54003",
+        "s": "54004"
+    },
+    "jktsologn7uprtwn7gsgmwuddj6rxsqmwc2vaug7jwcwzm2bxqnfpwad.onion": {
+        "s": "54004",
+        "t": "54003",
+        "display": "electroncash.de"
     }
 }
 


### PR DESCRIPTION
electroncash.de is running testnet4 - feel free to test on:

electroncash.de:54003 tcp
electroncash.de:54004 ssl
jktsologn7uprtwn7gsgmwuddj6rxsqmwc2vaug7jwcwzm2bxqnfpwad.onion:54003 tcp onion
electroncash.de:64003 websocket tcp
electroncash.de:64004 websocket ssl