### PR TITLE
Added addtransaction arg to payto/paytomany

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -510,7 +510,7 @@ class Commands:
         return bitcoin.verify_message(address, sig, message)
 
     def _mktx(self, outputs, fee=None, change_addr=None, domain=None, nocheck=False,
-              unsigned=False, password=None, locktime=None, op_return=None, op_return_raw=None):
+              unsigned=False, password=None, locktime=None, op_return=None, op_return_raw=None, addtransaction=False):
         if op_return and op_return_raw:
             raise ValueError('Both op_return and op_return_raw cannot be specified together!')
         self.nocheck = nocheck
@@ -540,23 +540,27 @@ class Commands:
         if not unsigned:
             run_hook('sign_tx', self.wallet, tx)
             self.wallet.sign_transaction(tx, password)
+        if addtransaction:
+            self.wallet.add_transaction(tx.txid(), tx)
+            self.wallet.add_tx_to_history(tx.txid())
+            self.wallet.save_transactions()
         return tx
 
     @command('wp')
     def payto(self, destination, amount, fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None,
-              op_return=None, op_return_raw=None):
+              op_return=None, op_return_raw=None, addtransaction=False):
         """Create a transaction. """
         tx_fee = satoshis(fee)
         domain = from_addr.split(',') if from_addr else None
-        tx = self._mktx([(destination, amount)], tx_fee, change_addr, domain, nocheck, unsigned, password, locktime, op_return, op_return_raw)
+        tx = self._mktx([(destination, amount)], tx_fee, change_addr, domain, nocheck, unsigned, password, locktime, op_return, op_return_raw, addtransaction=addtransaction)
         return tx.as_dict()
 
     @command('wp')
-    def paytomany(self, outputs, fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None):
+    def paytomany(self, outputs, fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None, addtransaction=False):
         """Create a multi-output transaction. """
         tx_fee = satoshis(fee)
         domain = from_addr.split(',') if from_addr else None
-        tx = self._mktx(outputs, tx_fee, change_addr, domain, nocheck, unsigned, password, locktime)
+        tx = self._mktx(outputs, tx_fee, change_addr, domain, nocheck, unsigned, password, locktime, addtransaction=addtransaction)
         return tx.as_dict()
 
     @command('w')
@@ -844,6 +848,7 @@ param_descriptions = {
 }
 
 command_options = {
+    'addtransaction': (None, 'Whether transaction is to be used for broadcasting afterwards. Adds transaction to the wallet'),
     'balance':     ("-b", "Show the balances of listed addresses"),
     'change':      (None, "Show only change addresses"),
     'change_addr': ("-c", "Change address. Default is a spare address, or the source address if it's not in the wallet"),

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -540,10 +540,10 @@ class Commands:
         if not unsigned:
             run_hook('sign_tx', self.wallet, tx)
             self.wallet.sign_transaction(tx, password)
-        if addtransaction:
-            self.wallet.add_transaction(tx.txid(), tx)
-            self.wallet.add_tx_to_history(tx.txid())
-            self.wallet.save_transactions()
+            if addtransaction:
+                self.wallet.add_transaction(tx.txid(), tx)
+                self.wallet.add_tx_to_history(tx.txid())
+                self.wallet.save_transactions()
         return tx
 
     @command('wp')

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1442,8 +1442,9 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         with self.lock:
             for addr in itertools.chain(list(self.txi.get(txid, {}).keys()), list(self.txo.get(txid, {}).keys())):
                 cur_hist = self._history.get(addr, list())
-                cur_hist.append((txid, 0))
-                self._history[addr] = cur_hist
+                if not txid in itertools.chain(*cur_hist):
+                    cur_hist.append((txid, 0))
+                    self._history[addr] = cur_hist
 
     def get_history(self, domain=None, *, reverse=False):
         # get domain

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -38,6 +38,7 @@ import time
 import threading
 from collections import defaultdict
 from functools import partial
+import itertools
 
 from .i18n import ngettext
 from .util import NotEnoughFunds, ExcessiveFee, PrintError, UserCancelled, profiler, format_satoshis, format_time, finalization_print_error, to_string
@@ -1436,6 +1437,13 @@ class Abstract_Wallet(PrintError, SPVDelegate):
 
         if self.network:
             self.network.trigger_callback('on_history', self)
+
+    def add_tx_to_history(self, txid):
+        with self.lock:
+            for addr in itertools.chain(list(self.txi.get(txid, {}).keys()), list(self.txo.get(txid, {}).keys())):
+                cur_hist = self._history.get(addr, list())
+                cur_hist.append((txid, 0))
+                self._history[addr] = cur_hist
 
     def get_history(self, domain=None, *, reverse=False):
         # get domain

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1442,7 +1442,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         with self.lock:
             for addr in itertools.chain(list(self.txi.get(txid, {}).keys()), list(self.txo.get(txid, {}).keys())):
                 cur_hist = self._history.get(addr, list())
-                if not txid in itertools.chain(*cur_hist):
+                if not any(True for x in cur_hist if x[0] == txid):
                     cur_hist.append((txid, 0))
                     self._history[addr] = cur_hist
 


### PR DESCRIPTION
This PR is a backport of https://github.com/spesmilo/electrum/pull/6532
It makes it possible to use payto/paytomany+broadcast commands in concurrent environments when turning addtransaction flag on by adding tx to local history before a full network round-trip.