### PR TITLE
RPA Paycodes

### DIFF
--- a/lib/cashaddr.py
+++ b/lib/cashaddr.py
@@ -84,6 +84,7 @@ def _pack_addr_data(kind, addr_hash):
         encoded_size |= 0x04
     encoded_size |= (len(addr_hash) - 20 * offset) // (4 * offset)
 
+    
     # invalid size?
     if ((len(addr_hash) - 20 * offset) % (4 * offset) != 0
             or not 0 <= encoded_size <= 7):
@@ -118,7 +119,7 @@ def _decode_payload(addr):
         raise ValueError('address prefix is missing: {}'.format(addr))
     if not all(33 <= ord(x) <= 126 for x in prefix):
         raise ValueError('invalid address prefix: {}'.format(prefix))
-    if not (8 <= len(payload) <= 124):
+    if not (8 <= len(payload) <= 256):
         raise ValueError('address payload has invalid length: {}'
                          .format(len(addr)))
     try:
@@ -143,7 +144,7 @@ def _decode_payload(addr):
 PUBKEY_TYPE = 0
 SCRIPT_TYPE = 1
 
-def decode(address):
+def decode(address,rpa_paycode = False):
     '''Given a cashaddr address, return a triple
 
           (prefix, kind, hash)
@@ -166,10 +167,11 @@ def decode(address):
     version = decoded[0]
     addr_hash = bytes(decoded[1:])
     size = (version & 0x03) * 4 + 20
+    
     # Double the size, if the 3rd bit is on.
     if version & 0x04:
         size <<= 1
-    if size != len(addr_hash):
+    if size != len(addr_hash) and not rpa_paycode:
         raise ValueError('address hash has length {} but expected {}'
                          .format(len(addr_hash), size))
 

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -104,7 +104,7 @@ class Software_KeyStore(KeyStore):
         decrypted = ec.decrypt_message(message)
         return decrypted
 
-    def sign_transaction(self, tx, password, *, use_cache=False):
+    def sign_transaction(self, tx, password, *, use_cache=False, ndata=b''):
         if self.is_watching_only():
             return
         # Raise if password is not correct.
@@ -115,7 +115,7 @@ class Software_KeyStore(KeyStore):
             keypairs[k] = self.get_private_key(v, password)
         # Sign
         if keypairs:
-            tx.sign(keypairs, use_cache=use_cache)
+            tx.sign(keypairs, use_cache=use_cache, ndata=ndata)
 
 
 class Imported_KeyStore(Software_KeyStore):

--- a/lib/rpa_paycode.py
+++ b/lib/rpa_paycode.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -*- mode: python3 -*-
+# This file (c) 2020 Jonald Fyookball
+# Part of the Electron Cash SPV Wallet
+# License: MIT
+'''
+This implements the functionality for RPA (Reusable Payment Address) aka Paycodes
+'''
+
+from . import cashaddr
+from . import bitcoin
+from . import transaction
+from . import address
+from decimal import Decimal as PyDecimal
+from .bitcoin import COIN, TYPE_ADDRESS, sha256 
+from .address import Address, AddressError,Base58,PublicKey
+from .transaction import Transaction
+
+def satoshis(amount):
+    # satoshi conversion must not be performed by the parser
+    return int(COIN*PyDecimal(amount)) if amount not in ['!', None] else amount
+ 
+def resolver(wallet,x,nocheck):
+    if x is None:
+        return None
+    out = wallet.contacts.resolve(x)
+    if out.get('type') == 'openalias' and nocheck is False and out.get('validated') is False:
+        raise BaseException('cannot verify alias', x)
+    return out['address']
+
+def mktx(wallet, config, outputs, fee=None, change_addr=None, domain=None, nocheck=False,
+              unsigned=False, password=None, locktime=None, op_return=None, op_return_raw=None):
+    if op_return and op_return_raw:
+        raise ValueError('Both op_return and op_return_raw cannot be specified together!')
+     
+    domain = None if domain is None else map(self._resolver, domain)
+    final_outputs = []
+    if op_return:
+        final_outputs.append(OPReturn.output_for_stringdata(op_return))
+    elif op_return_raw:
+        try:
+            op_return_raw = op_return_raw.strip()
+            tmp = bytes.fromhex(op_return_raw).hex()
+            assert tmp == op_return_raw.lower()
+            op_return_raw = tmp
+        except Exception as e:
+            raise ValueError("op_return_raw must be an even number of hex digits") from e
+        final_outputs.append(OPReturn.output_for_rawhex(op_return_raw))
+         
+    for address, amount in outputs:
+        address = resolver(wallet,address,nocheck)
+        amount = satoshis(amount)
+        final_outputs.append((TYPE_ADDRESS, address, amount))
+         
+    coins = wallet.get_spendable_coins(domain, config)
+    tx = wallet.make_unsigned_transaction(coins, final_outputs, config, fee, change_addr)
+    if locktime != None:
+        tx.locktime = locktime
+    if not unsigned:
+        run_hook('sign_tx', wallet, tx) 
+        wallet.sign_transaction(tx, password)
+    return tx
+
+def calculate_paycode_shared_secret(private_key,public_key,outpoint):
+    
+    # private key is expected to be an integer.
+    # public_key is expected to be bytes.
+    # outpoint is expected to be a string.
+    # returns the paycode shared secret as bytes
+        
+    from fastecdsa import keys, curve
+    from fastecdsa.point import Point 
+        
+    # Public key is expected to be compressed.  Change into a point object.   
+    pubkey_point = bitcoin.ser_to_point(public_key)
+    fastecdsa_point = Point(pubkey_point.x(),pubkey_point.y(),curve.secp256k1) 
+        
+    # Multiply the public and private points together
+    ecdh_product = fastecdsa_point * private_key
+    ecdh_x = ecdh_product.x
+    ecdh_x_bytes = ecdh_x.to_bytes(33,byteorder="big")
+        
+    # Get the hash of the product
+    sha_ecdh_x_bytes = sha256(ecdh_x_bytes)
+    sha_ecdh_x_as_int = int.from_bytes(sha_ecdh_x_bytes,byteorder="big")
+  
+    # Hash the outpoint string
+    hash_of_outpoint = sha256(outpoint)
+    hash_of_outpoint_as_int = int.from_bytes(hash_of_outpoint,byteorder="big")
+        
+    # Sum the ECDH hash and the outpoint Hash 
+    grand_sum = sha_ecdh_x_as_int + hash_of_outpoint_as_int
+
+    # Hash the final result
+    grand_sum_hex = hex(grand_sum)
+    shared_secret = sha256(grand_sum_hex) 
+        
+    return shared_secret
+
+def generate_address_from_pubkey_and_secret(parent_pubkey,secret):
+  
+    # parent_pubkey and secret are expected to be bytes
+    # This function generates a receiving address based on CKD.
+        
+    new_pubkey = bitcoin.CKD_pub(parent_pubkey,secret,0)[0]
+        
+    use_uncompressed = False
+
+    # Currently, just uses compressed keys, but if this ever changes to require uncompressed points:
+    if use_uncompressed:
+        pubkey_point = bitcoin.ser_to_point(new_pubkey)
+        point_x=pubkey_point.x()
+        point_y=pubkey_point.y()
+        uncompressed="04"+hex(pubkey_point.x())[2:]+hex(pubkey_point.y())[2:] 
+        new_pubkey = bytes.fromhex(uncompressed)
+                    
+    addr = Address.from_pubkey(new_pubkey)
+    return addr
+        
+         
+def generate_privkey_from_secret(parent_privkey,secret):
+  
+    # parent_privkey and secret are expected to be bytes
+    # This function generates a receiving address based on CKD.
+        
+    new_privkey = bitcoin.CKD_priv(parent_privkey,secret,0)[0].hex()
+    return new_privkey   
+
+
+def rpa_generate_paycode(wallet,prefix_size="08"):
+    
+    #prefix size should be either 0x04 , 0x08, 0x0C, 0x10
+    
+    # Fields of the paycode
+    version = "01"
+    scanpubkey = wallet.derive_pubkeys(0,0)
+    spendpubkey = wallet.derive_pubkeys(0,1)
+    expiry = "00000000"
+      
+    # Concatenate        
+    payloadstring = version + prefix_size  + scanpubkey + spendpubkey + expiry
+        
+    # Convert to bytes
+    payloadbytes = bytes.fromhex(payloadstring)
+        
+    # Generate paycode "address" via cashaddr function
+    prefix="paycode"
+    retval = cashaddr.encode_full(prefix,cashaddr.PUBKEY_TYPE,payloadbytes)       
+
+    return retval
+    
+    
+def rpa_generate_transaction_from_paycode(wallet, config, amount,  rpa_paycode=None, fee= None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None,
+              op_return=None, op_return_raw=None):
+        
+    if not wallet.is_schnorr_enabled():
+        print ("You must enable schnorr signing on this wallet for RPA.  Exiting.")
+        return 0
+        
+    # Initialize variable for the final return value.
+    final_raw_tx = 0
+        
+    # Decode the paycode
+    rprefix, kind, addr_hash= cashaddr.decode(rpa_paycode,True)
+    paycode_hex = addr_hash.hex() 
+        
+    # Parse paycode
+    paycode_field_version = paycode_hex[0:2]
+    paycode_field_prefix_size = paycode_hex [2:4]
+    paycode_field_scan_pubkey = paycode_hex [4:70]
+    paycode_field_spend_pubkey = paycode_hex [70:136]
+    paycode_field_expiry = paycode_hex [136:144]
+    paycode_field_checksum = paycode_hex [ 144: 154]
+                
+    # Initialize a few variables for the transaction
+    tx_fee = satoshis(fee)
+    domain = from_addr.split(',') if from_addr else None 
+        
+    # Initiliaze a few variables for grinding
+    tx_matches_paycode_prefix = False
+    grind_nonce = 0
+    grinding_version = "1"     
+        
+    if paycode_field_prefix_size == "04":
+        prefix_chars=1
+    elif paycode_field_prefix_size == "08":
+        prefix_chars=2
+    elif paycode_field_prefix_size == "0C":
+        prefix_chars=3
+    elif paycode_field_prefix_size == "10":
+        prefix_chars=4
+    else:
+        raise BaseException("Invalid prefix size. Must be 4,8,12, or 16 bits.")
+             
+    print ("Attempting to grind a matching prefix.  This may take a few minutes.  Please be patient.") 
+        
+    # While loop for grinding.  Keep grinding until txid prefix matches paycode scanpubkey prefix.
+    while not tx_matches_paycode_prefix:
+            
+        # Calculate ndata for grinding.  Ndata is passed through the stack as an input into RFC 6979
+        grind_nonce_string = str(grind_nonce)
+        grinding_message = rpa_paycode + grind_nonce_string + grinding_version
+        ndata = sha256(grinding_message) 
+      
+        # Construct the transaction, initially with a dummy destination
+        rpa_dummy_address = wallet.dummy_address().to_string(0)
+        unsigned = True 
+        tx = mktx(wallet, config, [(rpa_dummy_address, amount)], tx_fee, change_addr, domain, nocheck, unsigned, password, locktime, op_return, op_return_raw)
+                      
+        # Use the first input (input zero) for our shared secret
+        input_zero = tx._inputs[0]
+            
+        # Fetch our own private key for the coin
+        bitcoin_addr = input_zero["address"]
+        private_key_wif_format = wallet.export_private_key(bitcoin_addr,password)
+        private_key_int_format = int.from_bytes(Base58.decode_check(private_key_wif_format)[1:33],byteorder="big")
+                             
+        # Grab the outpoint  (the colon is intentionally ommitted from the string)
+        outpoint_string = str(input_zero["prevout_hash"])+str(input_zero["prevout_n"])
+            
+        # Format the pubkey in preparation to get the shared secret
+        scanpubkey_bytes =  bytes.fromhex(paycode_field_scan_pubkey) 
+            
+        # Calculate shared secret
+        shared_secret = calculate_paycode_shared_secret(private_key_int_format,scanpubkey_bytes,outpoint_string)   
+            
+        # Get the real destination for the transaction
+        rpa_destination_address=generate_address_from_pubkey_and_secret(bytes.fromhex(paycode_field_spend_pubkey),shared_secret).to_string(0)
+              
+        # Swap the dummy destination for the real destination
+        tx.rpa_paycode_swap_dummy_for_destination(rpa_dummy_address, rpa_destination_address)
+            
+        # Sort the inputs and outputs deterministically
+        tx.BIP_LI01_sort()
+        
+        # Now we need to sign the transaction after the outputs are known 
+        wallet.sign_transaction(tx, password,ndata=ndata)
+                               
+        # Generate the raw transaction
+        raw_tx_string = tx.as_dict()["hex"]
+            
+        # Get the TxId for this raw Tx.
+        double_hash_tx = bytearray(sha256(sha256(bytes.fromhex(raw_tx_string))))
+        double_hash_tx.reverse()
+        txid=double_hash_tx.hex()
+            
+        # Check if we got a successful match.  If so, exit.
+        if txid[0:prefix_chars].upper() == paycode_field_scan_pubkey[2:prefix_chars+2].upper():
+            print ("Grinding successful after ",grind_nonce," iterations.")
+            print ("Transaction Id: ",txid)
+            print ("prefix is ",txid[0:prefix_chars].upper())
+            final_raw_tx = raw_tx_string
+            tx_matches_paycode_prefix = True  # <<-- exit 
+            
+        # Increment the nonce
+        grind_nonce+=1
+             
+    return final_raw_tx
+    
+def rpa_extract_private_key_from_transaction(wallet,raw_tx, password=None):
+    
+    # Initialize return value.  Will return 0 if no private key can be found.
+    retval = 0
+    
+    # Deserialize the raw transaction
+    unpacked_tx = Transaction.deserialize(Transaction(raw_tx))
+       
+    # Get a list of output addresses (we will need this for later to check if our key matches)
+    output_addresses = []
+    outputs = unpacked_tx["outputs"]
+    for i in outputs:
+        output_addresses.append(i['address'].to_string(0))
+      
+    # Variables for looping
+    number_of_inputs = len (unpacked_tx["inputs"])
+    input_index = 0        
+    process_inputs = True     
+     
+    # Process each input until we find one that creates the shared secret to get a private key for an output 
+    while process_inputs:     
+          
+        # Grab the outpoint
+        single_input = unpacked_tx["inputs"][input_index]   
+        prevout_hash = single_input["prevout_hash"]
+        prevout_n = str(single_input["prevout_n"])   # n is int. convert to str.
+        outpoint_string = prevout_hash + prevout_n 
+        
+        # Get the pubkey of the sender from the scriptSig. 
+        scriptSig = bytes.fromhex(single_input["scriptSig"])
+        d={} 
+        parsed_scriptSig = transaction.parse_scriptSig(d,scriptSig)
+        sender_pubkey = bytes.fromhex(d["pubkeys"][0]) 
+        
+        # We need the private key that corresponds to the scanpubkey.
+        # In this implementation, this is the one that goes with receiving address 0
+        scanpubkey = wallet.derive_pubkeys(0,0) 
+        
+        # Fetch our own private (scan) key out of the wallet.
+        scan_bitcoin_addr = Address.from_pubkey(scanpubkey)
+        scan_private_key_wif_format = wallet.export_private_key(scan_bitcoin_addr,password)
+        scan_private_key_int_format = int.from_bytes(Base58.decode_check(scan_private_key_wif_format)[1:33],byteorder="big")
+        
+        # Calculate shared secret   
+        shared_secret = calculate_paycode_shared_secret(scan_private_key_int_format,sender_pubkey,outpoint_string)    
+  
+        # Get the spendpubkey for our paycode.  
+        # In this implementation, simply: receiving address 1.
+        spendpubkey = wallet.derive_pubkeys(0,1)
+        
+        # Get the destination address for the transaction
+        destination=generate_address_from_pubkey_and_secret(bytes.fromhex(spendpubkey),shared_secret).to_string(0) 
+         
+        # Fetch our own private (spend) key out of the wallet.
+        spendpubkey = wallet.derive_pubkeys(0,1)
+        spend_bitcoin_addr = Address.from_pubkey(spendpubkey)
+        spend_private_key_wif_format = wallet.export_private_key(spend_bitcoin_addr,password)
+        spend_private_key_int_format = int.from_bytes(Base58.decode_check(spend_private_key_wif_format)[1:33],byteorder="big")
+        
+        # Generate the private key for the money being received via paycode
+        privkey = generate_privkey_from_secret(bytes.fromhex(hex(spend_private_key_int_format)[2:]),shared_secret)
+      
+        # Check the address matches
+        if destination in output_addresses:
+            process_inputs = False
+            retval = privkey
+        
+        # Increment the input 
+        input_index+=1
+        
+        # If this was the last input, stop.
+        if input_index >= number_of_inputs:
+            process_inputs = False
+     
+    return retval
+        
+         
+    

--- a/lib/schnorr.py
+++ b/lib/schnorr.py
@@ -118,7 +118,7 @@ def nonce_function_rfc6979(order, privkeybytes, msg32, algo16=b'', ndata=b''):
     return k
 
 
-def sign(privkey, message_hash):
+def sign(privkey, message_hash,ndata=b''):
     '''Create a Schnorr signature.
 
     Returns a 64-long bytes object (the signature), or raise ValueError
@@ -139,7 +139,7 @@ def sign(privkey, message_hash):
     if _secp256k1_schnorr_sign:
         sig = create_string_buffer(64)
         res = _secp256k1_schnorr_sign(
-            secp256k1.secp256k1.ctx, sig, message_hash, privkey, None, None
+            secp256k1.secp256k1.ctx, sig, message_hash, privkey, None, ndata
         )
         if not res:
             # Looking at the libsecp256k1 code, we can see that this will
@@ -161,7 +161,7 @@ def sign(privkey, message_hash):
         pubbytes = point_to_ser(pubpoint, comp=True)
 
         k = nonce_function_rfc6979(order, privkey, message_hash,
-                                   algo16=b'Schnorr+SHA256\x20\x20')
+                                   algo16=b'Schnorr+SHA256\x20\x20',ndata=ndata)
         R = k * G
         if jacobi(R.y(), fieldsize) == -1:
             k = order - k

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -511,6 +511,36 @@ class Transaction:
                        for sig in self._inputs[input_idx].get('signatures', []))
         return False
 
+    def rpa_paycode_swap_dummy_for_destination(self,rpa_dummy_address, rpa_destination_address):
+        # This method was created for RPA - reusable payment address.  
+        # It swaps out a dummy destination address for the rpa-generated address.
+        # WARNING: This is not recommended for use outside of RPA since it could
+        # be dangerous to change the destination address of a transaction.
+ 
+        # This method expects cashaddr strings for parameters rpa_dummy_address and rpa_destination_address
+  
+        length = len (self._outputs)
+        i = 0
+        
+        while i < length:           
+            # Grab the address of each output...
+            loop_iteration_output = self._outputs[i]
+            loop_iteration_address = loop_iteration_output[1]
+             
+            # Compare the address to see if its the one we need to swap.  Note: 0 for the to_string = CASHADDR format
+            if loop_iteration_address.to_string(0) == rpa_dummy_address:
+                # Do the swap
+                rpa_replacement_address = Address.from_string(rpa_destination_address)
+                rpa_replacement_output = list(loop_iteration_output)
+                rpa_replacement_output[1]= rpa_replacement_address
+                self._outputs[i]=tuple(rpa_replacement_output)
+            i +=1
+            
+        # It is necessary to re-initialize "raw" so the output swap becomes part of transaction when it is later serialized
+        self.raw = None
+        return 0
+        
+
     def deserialize(self):
         if self.raw is None:
             return
@@ -909,14 +939,14 @@ class Transaction:
         return sig
 
     @staticmethod
-    def _schnorr_sign(pubkey, sec, pre_hash):
+    def _schnorr_sign(pubkey, sec, pre_hash,ndata=b''):
         pubkey = bytes.fromhex(pubkey)
-        sig = schnorr.sign(sec, pre_hash)
+        sig = schnorr.sign(sec, pre_hash, ndata)
         assert schnorr.verify(pubkey, sig, pre_hash)  # verify what we just signed
         return sig
 
 
-    def sign(self, keypairs, *, use_cache=False):
+    def sign(self, keypairs, *, use_cache=False, ndata=b''):
         for i, txin in enumerate(self.inputs()):
             pubkeys, x_pubkeys = self.get_sorted_pubkeys(txin)
             for j, (pubkey, x_pubkey) in enumerate(zip(pubkeys, x_pubkeys)):
@@ -933,18 +963,18 @@ class Transaction:
                     continue
                 print_error(f"adding signature for input#{i} sig#{j}; {kname}: {_pubkey} schnorr: {self._sign_schnorr}")
                 sec, compressed = keypairs.get(_pubkey)
-                self._sign_txin(i, j, sec, compressed, use_cache=use_cache)
+                self._sign_txin(i, j, sec, compressed, use_cache=use_cache, ndata=ndata)
         print_error("is_complete", self.is_complete())
         self.raw = self.serialize()
 
-    def _sign_txin(self, i, j, sec, compressed, *, use_cache=False):
+    def _sign_txin(self, i, j, sec, compressed, *, use_cache=False, ndata=b''):
         '''Note: precondition is self._inputs is valid (ie: tx is already deserialized)'''
         pubkey = public_key_from_private_key(sec, compressed)
         # add signature
         nHashType = 0x00000041 # hardcoded, perhaps should be taken from unsigned input dict
         pre_hash = Hash(bfh(self.serialize_preimage(i, nHashType, use_cache=use_cache)))
         if self._sign_schnorr:
-            sig = self._schnorr_sign(pubkey, sec, pre_hash)
+            sig = self._schnorr_sign(pubkey, sec, pre_hash, ndata)
         else:
             sig = self._ecdsa_sign(sec, pre_hash)
         reason = []


### PR DESCRIPTION
This implements RPA Re-usable payment address (AKA Paycodes) with a CLI.

Note this only implements the basic functions of generating a paycode, a transaction, and extracting private key.  Other functions such as storing the key in the keystore will be implemented in the next stages.