### PR TITLE
Enable coverage HTML report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ lib/*.so.0
 # tox files
 .cache/
 .coverage
+htmlcov
 
 # MacOSX
 .DS_Store/

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps=
 commands=
 	coverage run --source=lib,plugins -m py.test -v {posargs}
 	coverage report
+	coverage html
 
 [pytest]
 norecursedirs=contrib ios android


### PR DESCRIPTION
Generate a HTML report for coverage when running tox.
Also add the report .gitignore