### PR TITLE
[fusion] require fast schnorr for server

### DIFF
--- a/electroncash_plugins/fusion/server.py
+++ b/electroncash_plugins/fusion/server.py
@@ -227,6 +227,8 @@ class FusionServer(GenericServer):
     def __init__(self, config, network, bindhost, port, upnp = None, announcehost = None, donation_address = None):
         assert network
         assert isinstance(donation_address, (Address, type(None)))
+        if not schnorr.has_fast_sign() or not schnorr.has_fast_verify():
+            raise RuntimeError("Fusion requires libsecp256k1")
         super().__init__(bindhost, port, ClientThread, upnp = upnp)
         self.config = config
         self.network = network


### PR DESCRIPTION
If we use a pure-python schnorr verifier, we will be way too slow to
verify the hundreds of signatures that fly at us during covert
submissions. (Each verify does two elliptic curve multiplies!
Every covert component has one verification for the blind sig,
and every input additionally has one verification for the tx
sig. So easily a few hundred schnorr verifies.)