### PR TITLE
[Fusion] Various fixes to starting and stopping behaviour

### DIFF
--- a/electroncash_plugins/fusion/fusion.py
+++ b/electroncash_plugins/fusion/fusion.py
@@ -416,6 +416,7 @@ class Fusion(threading.Thread, PrintError):
                     and not is_tor_port(self.tor_host, self.tor_port)):
                 raise FusionError(f"Can't connect to Tor proxy at {self.tor_host}:{self.tor_port}")
 
+            self.check_stop(running = False)
             self.check_coins()
 
             # Connect to the server
@@ -486,11 +487,17 @@ class Fusion(threading.Thread, PrintError):
                     self.notify_server_status(False, self.status)
 
     def stop(self, reason = 'stopped', not_if_running = False):
-        self.stop_reason = reason
+        if self.stopping:
+            return
         if not_if_running:
+            if self.stopping_if_not_running:
+                return
+            self.stop_reason = reason
             self.stopping_if_not_running = True
         else:
+            self.stop_reason = reason
             self.stopping = True
+        # note the reason is only overwritten if we were not already stopping this way.
 
     def check_stop(self, running=True):
         """ Gets called occasionally from fusion thread to allow a stop point. """

--- a/electroncash_plugins/fusion/fusion.py
+++ b/electroncash_plugins/fusion/fusion.py
@@ -459,11 +459,16 @@ class Fusion(threading.Thread, PrintError):
 
             self.status = ('complete', 'time_wait')
 
-            # wait up to a minute before unfreezing coins
+            # The server has told us the fusion is complete but we might not
+            # have seen the tx show up in our wallets. So we can't unfreeze
+            # coins or unreserve addresses yet, else they might be used in
+            # another fusion. Wait up to a minute for this to happen.
+            wallets = set(self.source_wallet_info.keys())
+            wallets.add(self.target_wallet)
             for _ in range(60):
                 if self.stopping:
                     break # not an error
-                for w in self.source_wallet_info:
+                for w in wallets:
                     if self.txid not in w.transactions:
                         break
                 else:

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -396,11 +396,7 @@ class FusionPlugin(BasePlugin):
         already 'running' in order to allow for the new change to take effect
         immediately. """
         self.remote_donation_address = ''
-        with self.lock:
-            wallets = list(self.autofusing_wallets.keys())
-        for wallet in wallets:
-            self._stop_fusions(wallet, 'Server changed', which='all')
-            # FIXME here: restart non-auto fusions on the new server!
+        self.stop_all_fusions('Server changed', not_if_running=True)
 
     def get_all_fusions(self, ):
         """ Return all still-live fusion objects that have been created using .start_fusion(),
@@ -409,6 +405,11 @@ class FusionPlugin(BasePlugin):
             fusions_and_times = list(self.fusions.items())
         fusions_and_times.sort(key=lambda x:x[1])
         return [f for f,t in fusions_and_times]
+
+    def stop_all_fusions(self, reason, *, not_if_running=True):
+        with self.lock:
+            for f in list(self.fusions):
+                f.stop(reason, not_if_running = not_if_running)
 
     def _stop_fusions(self, wallet, reason, *, not_if_running=True, which='auto'):
         # which may be 'all' or 'auto'

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -212,6 +212,8 @@ class Plugin(FusionPlugin, QObject):
 
         # Soft-stop background fuse if running.
         # We avoid doing a hard disconnect in the middle of a fusion round.
+        # TODO: only do a gentler 'stop-if-waiting' and have a "STOP SOONER"
+        # button on the waiting dialog for the less patient users.
         def task():
             for f in fusions:
                 f.join()

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -137,8 +137,7 @@ class Plugin(FusionPlugin, QObject):
                     with wallet.lock:
                         if not hasattr(wallet, '_fusions'):
                             return
-                        fusion = self.create_fusion(wallet, password, coins)
-                        fusion.start()
+                        self.start_fusion(wallet, password, coins)
                 except RuntimeError as e:
                     window.show_error(_('CashFusion failed: {error_message}').format(error_message=str(e)))
                     return


### PR DESCRIPTION
This is a package of a variety of related tweaks. See individual commits for each separate idea.

Primarily this is to fix a known issue that is likely causing #2010 : we should not be starting autofusions when network is down or wallet is not up to date. To make this even stronger, we will stop existing waiting autofusions if the network is down for an extended time.

Some related / needed changes as well:
- Misc refactorings.
- Also stop manual fusions when switching servers.
- Race fix.
- Better handling on 'confirmed-only' case.