### PR TITLE
[fusion] better handling on interactions with electrumx server

### DIFF
--- a/electroncash_plugins/fusion/fusion.py
+++ b/electroncash_plugins/fusion/fusion.py
@@ -33,7 +33,7 @@ This module has no GUI dependency.
 from electroncash import schnorr
 from electroncash.bitcoin import public_key_from_private_key
 from electroncash.i18n import _, ngettext, pgettext
-from electroncash.util import format_satoshis, do_in_main_thread, PrintError, ServerError, TxHashMismatch
+from electroncash.util import format_satoshis, do_in_main_thread, PrintError, ServerError, TxHashMismatch, TimeoutException
 from electroncash.wallet import Standard_Wallet, Multisig_Wallet
 
 from . import encrypt
@@ -1030,7 +1030,9 @@ class Fusion(threading.Thread, PrintError):
                     if not any(s in server_msg for s in acceptable_substrings):
                         server_msg = server_msg.replace(txhex, "<...tx hex...>")
                         self.print_error("tx broadcast failed:", repr(server_msg))
-                        raise FusionError(f"could not broadcast the transaction! {nice_msg}") from e
+                        raise FusionError(f"could not broadcast the transaction: {nice_msg}") from e
+                except TimeoutException:
+                    raise FusionError("could not broadcast the transaction due to timeout")
 
                 self.print_error(f"successful broadcast of {txid}")
                 return True
@@ -1084,6 +1086,7 @@ class Fusion(threading.Thread, PrintError):
         self.print_error("receiving proofs")
         msg = self.recv('theirproofslist', timeout = 2 * Protocol.STANDARD_TIMEOUT)
         blames = []
+        count_inputs = 0
         for i, rp in enumerate(msg.proofs):
             try:
                 privkey = privkeys[rp.dst_key_idx]
@@ -1108,21 +1111,17 @@ class Fusion(threading.Thread, PrintError):
                 blames.append(pb.Blames.BlameProof(which_proof = i, session_key = skey, blame_reason = e.args[0]))
                 continue
 
-            if inpcomp is None:
-                self.print_error("verified an output / blank")
-            else:
+            if inpcomp is not None:
+                count_inputs += 1
                 try:
-                    res = check_input_electrumx(self.network, inpcomp)
+                    check_input_electrumx(self.network, inpcomp)
                 except ValidationError as e:
                     self.print_error(f"found a bad input [{rp.src_commitment_idx}]: {e.args[0]} ({inpcomp.prev_txid[::-1].hex()}:{inpcomp.prev_index})")
                     blames.append(pb.Blames.BlameProof(which_proof = i, session_key = skey, blame_reason = 'input does not match blockchain: ' + e.args[0],
                                                        need_lookup_blockchain = True))
-
-                    continue
-                if res:
-                    self.print_error("verified an input fully")
-                else:
-                    self.print_error("verified an input internally, but was unable to check it against blockchain!")
+                except Exception as e:
+                    self.print_error(f"verified an input internally, but was unable to check it against blockchain: {repr(e)}")
+        self.print_error(f"checked {len(msg.proofs)} proofs, {count_inputs} of them inputs")
 
         self.print_error("sending blames")
         self.send(pb.Blames(blames = blames))

--- a/electroncash_plugins/fusion/validation.py
+++ b/electroncash_plugins/fusion/validation.py
@@ -230,7 +230,12 @@ def validate_blame(blame, encproof, src_commit_blob, dest_commit_blob, all_compo
 
 def check_input_electrumx(network, inpcomp):
     """ Check an InputComponent against electrumx service. This can be a bit slow
-    since it gets all utxos on that address. """
+    since it gets all utxos on that address.
+
+    Returns normally if the check passed. Raises ValidationError if the input is not
+    consistent with blockchain (according to server), and raises other exceptions if
+    the server times out or gives an unexpected kind of response.
+    """
     address = Address.from_pubkey(inpcomp.pubkey)
     prevhash = inpcomp.prev_txid[::-1].hex()
     prevn = inpcomp.prev_index
@@ -247,4 +252,3 @@ def check_input_electrumx(network, inpcomp):
     # Not checked: is it a coinbase? is it matured?
     # A feasible strategy to identify unmatured coinbase is to cache the results
     # of blockchain.transaction.id_from_pos(height, 0) from the last 100 blocks.
-    return True


### PR DESCRIPTION
- catch timeouts when trying to broadcast (TimeoutException is not subclass of ServerError)
- add some error catching around check_input_electrumx()
- less noisy logs during blame