### PR TITLE
daemonize Tor subprocess

### DIFF
--- a/electroncash/tor/controller.py
+++ b/electroncash/tor/controller.py
@@ -162,6 +162,7 @@ class TorController(PrintError):
                 kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
             else:
                 kwargs['creationflags'] = 0x08000000 # CREATE_NO_WINDOW, for < Python 3.7
+        kwargs['start_new_session'] = True
         return TorController._orig_subprocess_popen(*args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
This prevents Ctrl-C from hitting the tor child process.

Note that since Tor gets started with `__OwningControllerProcess <electron_cash_pid>`,
it will always die even if we kill -9 the parent.