### PR TITLE
Remove greedyhog server

### DIFF
--- a/electroncash/servers.json
+++ b/electroncash/servers.json
@@ -87,12 +87,6 @@
         "t": "50001",
         "version": "1.4.2"
     },
-    "greedyhog.mooo.com": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.4.1"
-    },
     "7nshufncf3nmp7pa42oqhnj6whsjgo2eok4jveex62tczuhvqur5ciad.onion": {
         "pruning": "-",
         "t": "50001",


### PR DESCRIPTION
They run ABC 0.22 servers which may cause problems post-upgrade. Tried to contact them through op_return on their donation address but didn't get any reply or action.