### PR TITLE
Ledger: Update USB ids for app-bitcoin version >= 1.5.1

### DIFF
--- a/electroncash_plugins/ledger/ledger.py
+++ b/electroncash_plugins/ledger/ledger.py
@@ -566,8 +566,14 @@ class LedgerPlugin(HW_PluginBase):
                    (0x2581, 0x3b7c), # HW.1 ledger production
                    (0x2581, 0x4b7c), # HW.1 ledger test
                    (0x2c97, 0x0000), # Blue
+                   (0x2c97, 0x0011), # Blue app-bitcoin >= 1.5.1
+                   (0x2c97, 0x0015), # Blue app-bitcoin >= 1.5.1
                    (0x2c97, 0x0001), # Nano-S
-                   (0x2c97, 0x0004)  # Nano-X
+                   (0x2c97, 0x1011), # Nano-S app-bitcoin >= 1.5.1
+                   (0x2c97, 0x1015), # Nano-S app-bitcoin >= 1.5.1
+                   (0x2c97, 0x0004), # Nano-X
+                   (0x2c97, 0x4011), # Nano-X app-bitcoin >= 1.5.1
+                   (0x2c97, 0x4015), # Nano-X app-bitcoin >= 1.5.1
                  ]
 
     def __init__(self, parent, config, name):


### PR DESCRIPTION
Ledger announced changes to the USB ids here:

https://www.ledger.com/windows-10-update-sunsetting-u2f-tunnel-transport-for-ledger-devices/

This patch adds the new USB ids.

closes #2054 