### PR TITLE
trezor: use `init_device` instead of `ping` to check connection

### DIFF
--- a/electroncash_plugins/trezor/clientbase.py
+++ b/electroncash_plugins/trezor/clientbase.py
@@ -125,8 +125,7 @@ class TrezorClientBase(PrintError):
             return True
 
         try:
-            res = self.client.ping("electrum pinging device")
-            assert res == "electrum pinging device"
+            self.client.init_device()
         except BaseException:
             return False
         return True


### PR DESCRIPTION
Backport https://github.com/spesmilo/electrum/pull/6471 from Electrum, that fixes [Trezor with autolock error](https://github.com/spesmilo/electrum/issues/6457).

I cannot test this because I don't have a Trezor.