### PR TITLE
[fusion] better detect protobuf incompatibility

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -2,7 +2,7 @@ pyaes>=0.1a1
 ecdsa>=0.9
 requests
 qrcode
-protobuf
+protobuf>=3.7.1
 dnspython[DNSSEC]
 jsonrpclib-pelix
 PySocks>=1.6.6

--- a/electroncash_plugins/fusion/compatibility.py
+++ b/electroncash_plugins/fusion/compatibility.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+#
+# Electron Cash - a lightweight Bitcoin Cash client
+# CashFusion - an advanced coin anonymizer
+#
+# Copyright (C) 2020 Mark B. Lundeberg
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Compatibility checking.
+"""
+
+# Please avoid introducing local imports here, as in future it would be
+# nice if plugins could check compatibility in the plugins enable/disable menu
+# (i.e. in the __init__.py)
+from electroncash import schnorr
+
+def check():
+    # Pure-python schnorr should't be used since fusion requires so many
+    # curve ops, so that CPU usage can be quite high and can cause rounds to
+    # fail due to slowed responses. This applies on both on server and client
+    # side.
+    if not schnorr.has_fast_sign() or not schnorr.has_fast_verify():
+        raise RuntimeError("Fusion requires libsecp256k1")

--- a/electroncash_plugins/fusion/fusion.py
+++ b/electroncash_plugins/fusion/fusion.py
@@ -40,6 +40,7 @@ from . import encrypt
 from . import fusion_pb2 as pb
 from . import pedersen
 from .comms import send_pb, recv_pb, get_current_genesis_hash
+from . import compatibility
 from .connection import open_connection
 from .conf import Conf
 from .covert import CovertSubmitter, is_tor_port
@@ -411,8 +412,10 @@ class Fusion(threading.Thread, PrintError):
     def run(self):
         server_connected_and_greeted = False
         try:
-            if not schnorr.has_fast_sign() or not schnorr.has_fast_verify():
-                raise FusionError("Fusion requires libsecp256k1")
+            try:
+                compatibility.check()
+            except RuntimeError as e:
+                raise FusionError("Incompatible: " + str(e))
             if (self.tor_host is not None and self.tor_port is not None
                     and not is_tor_port(self.tor_host, self.tor_port)):
                 raise FusionError(f"Can't connect to Tor proxy at {self.tor_host}:{self.tor_port}")

--- a/electroncash_plugins/fusion/server.py
+++ b/electroncash_plugins/fusion/server.py
@@ -41,6 +41,7 @@ import electroncash.schnorr as schnorr
 from electroncash.address import Address
 from electroncash.util import PrintError, ServerError, TimeoutException
 from . import fusion_pb2 as pb
+from . import compatibility
 from .comms import send_pb, recv_pb, ClientHandlerThread, GenericServer, get_current_genesis_hash
 from .protocol import Protocol
 from .util import (FusionError, sha256, calc_initial_hash, calc_round_hash, gen_keypair, tx_from_components,
@@ -227,8 +228,7 @@ class FusionServer(GenericServer):
     def __init__(self, config, network, bindhost, port, upnp = None, announcehost = None, donation_address = None):
         assert network
         assert isinstance(donation_address, (Address, type(None)))
-        if not schnorr.has_fast_sign() or not schnorr.has_fast_verify():
-            raise RuntimeError("Fusion requires libsecp256k1")
+        compatibility.check()
         super().__init__(bindhost, port, ClientThread, upnp = upnp)
         self.config = config
         self.network = network


### PR DESCRIPTION
Ubuntu 20.04 ships python3-protobuf 3.6.1 which, when running from source, causes fusions to fail with mysterious errors like "decode error".
    
Also, one of our requirements.txt was not being strict enough.
