### PR TITLE
Remove expensive json.dumps calls in storage.put

### DIFF
--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -161,12 +161,6 @@ class WalletStorage(PrintError):
         return v
 
     def put(self, key, value):
-        try:
-            json.dumps(key)
-            json.dumps(value)
-        except:
-            self.print_error("json error: cannot save", key)
-            return
         with self.lock:
             if value is not None:
                 if self.data.get(key) != value:


### PR DESCRIPTION
The vast majority of the time taken by `save_transactions(write=True)` is in `json.dumps`.
```
>>> s.print_stats()
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.004    0.004    3.905    3.905 electroncash/wallet.py:416(save_transactions)
       17    0.002    0.000    3.746    0.220 stdlib/json/__init__.py:183(dumps)
       17    0.300    0.018    3.744    0.220 stdlib/json/encoder.py:182(encode)
     8886    0.582    0.000    3.439    0.000 stdlib/json/encoder.py:413(_iterencode)
18271/8884    1.381    0.000    2.855    0.000 stdlib/json/encoder.py:333(_iterencode_dict)
        1    0.000    0.000    2.234    2.234 electroncash/storage.py:176(write)
        1    0.001    0.001    2.234    2.234 electroncash/storage.py:183(_write)
        8    0.001    0.000    1.596    0.200 electroncash/storage.py:160(put)
```
Of the 3.7 seconds taken by `json.dumps`, 1.6 are from the `storage.put` calls in `save_transactions`.
```
>>> s.print_callers("dumps")
                                        ncalls  tottime  cumtime
stdlib/json/__init__.py:183(dumps)  <-      16    0.001    1.595  electroncash/storage.py:160(put)
                                             1    0.001    2.151  electroncash/storage.py:183(_write)
```
Protecting against a rare programming error isn't worth the cost of almost doubling the wallet save time. If somehow a non-dumpable object gets passed to `storage.put`, it will soon cause a crash in `storage.write`, which should be good enough to identify the cause.
