### PR TITLE
Tor: Fix proxy bypass for stem version 1.8.0

### DIFF
--- a/electroncash/tor/__init__.py
+++ b/electroncash/tor/__init__.py
@@ -1,5 +1,5 @@
 # Electron Cash - lightweight Bitcoin client
-# Copyright (C) 2019 Axel Gembe <derago@gmail.com>
+# Copyright (C) 2019, 2020 Axel Gembe <derago@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -21,4 +21,4 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .controller import TorController
+from .controller import TorController, check_proxy_bypass_tor_control


### PR DESCRIPTION
Stem release 1.8.0 moved to using `asyncio`, breaking our method of preventing the Tor control connection going through Tor itself.

To fix this we introduce a new general proxy bypass mechanism that checks the list `network.bypass_proxy_filters`, calling each function in it. If any of the functions returns true, a normal socket instead of a proxied socket will be returned.

The Tor controller provides such a filter that is installed by default and returns True when called from `stem.socket.ControlPort`.