### PR TITLE
Warn if a legacy addres is used

### DIFF
--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -601,6 +601,28 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         if net is None: net = networks.net
         return [addr.to_string(fmt, net=net) for addr in addrs]
 
+    @staticmethod
+    def is_legacy(address: str, net=None) -> bool:
+        """Find if the string of the address is in legacy format"""
+        if net is None:
+            net = networks.net
+        try:
+            raw = Base58.decode_check(address)
+        except Base58Error:
+            return False
+
+        if len(raw) != 21:
+            return False
+
+        verbyte = raw[0]
+        legacy_formats = (
+            net.ADDRTYPE_P2PKH,
+            net.ADDRTYPE_P2PKH_BITPAY,
+            net.ADDRTYPE_P2SH,
+            net.ADDRTYPE_P2SH_BITPAY,
+        )
+        return verbyte in legacy_formats
+
     def to_cashaddr(self, *, net=None):
         if net is None: net = networks.net
         if self.kind == self.ADDR_P2PKH:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2070,7 +2070,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             return False
         return True
 
-    def _chk_no_legacy_address(self):
+    def _warn_if_legacy_address(self):
         """Show a warning if self.payto_e has legacy addresses, since the user
         might be trying to send BTC instead of BCH."""
         warn_legacy_address = bool(self.config.get("warn_legacy_address", True))
@@ -2114,6 +2114,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 )
                 if res[1]:  # Never ask if checked
                     self.config.set_key("warn_legacy_address", False)
+                break
 
     def do_preview(self):
         self.do_send(preview = True)
@@ -2129,7 +2130,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if not self._chk_no_segwit_suspects():
             return
 
-        self._chk_no_legacy_address()
+        self._warn_if_legacy_address()
 
         r = self.read_send_tab()
         if not r:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2070,6 +2070,51 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             return False
         return True
 
+    def _chk_no_legacy_address(self):
+        """Show a warning if self.payto_e has legacy addresses, since the user
+        might be trying to send BTC instead of BCH."""
+        warn_legacy_address = bool(self.config.get("warn_legacy_address", True))
+        if not warn_legacy_address:
+            return
+        for line in self.payto_e.lines():
+            line = line.strip()
+            if line.lower().startswith(networks.net.CASHADDR_PREFIX + ":"):
+                line = line.split(":", 1)[1]  # strip "bitcoincash:" prefix
+            if "," in line:
+                # if address, amount line, strip address out and ignore rest
+                line = line.split(",", 1)[0]
+            line = line.strip()
+            if Address.is_legacy(line):
+                msg1 = (
+                    _("You are about to send BCH to a legacy address.")
+                    + "<br><br>"
+                    + _(
+                        "Legacy addresses are deprecated for Bitcoin Cash "
+                        "(BCH), and used by Bitcoin (BTC)."
+                    )
+                )
+                msg2 = _(
+                    "Proceed if what you are intending to do is sending BCH."
+                )
+                msg3 = _(
+                    "If you are intending to send BTC, close the "
+                    "application and use a BTC wallet instead.  Electron "
+                    "Cash is a BCH wallet, not a BTC wallet."
+                )
+                res = self.msg_box(
+                    parent=self,
+                    icon=QMessageBox.Warning,
+                    title=_("You are sending to a legacy address"),
+                    rich_text=True,
+                    text=msg1,
+                    informative_text=msg2,
+                    detail_text=msg3,
+                    checkbox_text=_("Never show this again"),
+                    checkbox_ischecked=False,
+                )
+                if res[1]:  # Never ask if checked
+                    self.config.set_key("warn_legacy_address", False)
+
     def do_preview(self):
         self.do_send(preview = True)
 
@@ -2083,6 +2128,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         if not self._chk_no_segwit_suspects():
             return
+
+        self._chk_no_legacy_address()
 
         r = self.read_send_tab()
         if not r:


### PR DESCRIPTION
Legacy addresses are the source of confusion for many BCH users.

See [Why you should never send your BCH to BTC address](https://blog.cex.io/news/why-you-should-never-send-bch-to-btc-address-21346).

This changeset creates a popup warning window when the user tries to
send BCH to a legacy address.  The window has a "Never show this again"
checkbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/electron-cash/electron-cash/2129)
<!-- Reviewable:end -->
