### PR TITLE
Tests: Fix missing dnspython dependency causing DNSSEC tests to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.6
     - 3.7
     - 3.8
+    - 3.9
 install:
   - pip install -r contrib/requirements/requirements-travis.txt
 cache:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps=
 	pytest
 	coverage
 	pycryptodomex<3.7
+	dnspython[DNSSEC]
 commands=
 	coverage run --source=electroncash,electroncash_plugins -m py.test -v {posargs}
 	coverage report


### PR DESCRIPTION
The tests were broken by #2156 because they do not pull in the `cryptography` package anymore:

https://travis-ci.org/github/Electron-Cash/Electron-Cash/jobs/757923867

This adds the dependency and also adds a Travis build for Python 3.9.