### PR TITLE
Build: Add git_describe_filtered helper

### DIFF
--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -172,6 +172,15 @@ function verlt()
     [ "$1" = "$2" ] && return 1 || verlte $1 $2
 }
 
+function git_describe_filtered()
+{
+    if [ ! -z ${1+x} ] ; then
+        git describe --tags --match "$1" --dirty --always
+    else
+        git describe --tags --exclude 'android-*' --exclude 'ios_*' --dirty --always
+    fi
+}
+
 if [ -n "$_BASE_SH_SOURCED" ] ; then
     # Base.sh has been sourced already, no need to source it again
     return 0

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -20,7 +20,7 @@ SQUASHFSKIT_COMMIT="ae0d656efa2d0df2fcac795b6823b44462f19386"
 PKG2APPIMAGE_COMMIT="eb8f3acdd9f11ab19b78f5cb15daa772367daf15"
 
 
-VERSION=`git describe --tags --dirty --always`
+VERSION=`git_describe_filtered`
 APPIMAGE="$DISTDIR/Electron-Cash-$VERSION-x86_64.AppImage"
 
 rm -rf "$BUILDDIR"

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -31,6 +31,7 @@ set -e
 git checkout "$to_build" || fail "Could not branch or tag $to_build"
 
 GIT_COMMIT_HASH=$(git rev-parse HEAD)
+VERSION=`git_describe_filtered`
 
 info "Clearing $here/build and $here/dist..."
 rm "$here"/build/* -fr
@@ -221,7 +222,6 @@ build_the_app() {
         pushd "$here"/../..  # go to top level
 
 
-        VERSION=`git describe --tags`
         info "Version to release: $VERSION"
         info "Fudging timestamps on all files for determinism ..."
         find -exec touch -d '2000-11-11T11:11:11+00:00' {} +

--- a/contrib/make_linux_sdist
+++ b/contrib/make_linux_sdist
@@ -13,7 +13,7 @@ pushd "$contrib"/..
 
 # EC_PACKAGE_VERSION and EC_PACKAGE_NAME are used by setup.py to specify
 # generated filename with a version from git tag. Otherwise defaults are used.
-EC_PACKAGE_VERSION=`git describe --tags` || fail "Could not get determine git tag version"
+EC_PACKAGE_VERSION=`git_describe_filtered` || fail "Could not get determine git tag version"
 EC_PACKAGE_NAME="${PACKAGE}"
 export EC_PACKAGE_VERSION EC_PACKAGE_NAME
 

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -51,7 +51,7 @@ function DoCodeSignMaybe { # ARGS: infoName fileOrDirName codesignIdentity
 
 cd $build_dir/../..
 
-VERSION=`git describe --tags`
+VERSION=`git_describe_filtered`
 
 # Paramterize
 BUILDDIR=/tmp/electron-cash-build


### PR DESCRIPTION
This filters out the `android-*` and `ios_*` tags by default but can also be used to select specific tag prefixes.