### PR TITLE
Windows: Use PyInstaller version 4.2

### DIFF
--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -61,7 +61,7 @@ prepare_wine() {
         LIBUSB_COMMIT=c6a35c56016ea2ab2f19115d2ea1e85e0edae155 # Version 1.0.24
 
         PYINSTALLER_REPO='https://github.com/EchterAgo/pyinstaller.git'
-        PYINSTALLER_COMMIT=1a8b2d47c277c451f4e358d926a47c096a5615ec
+        PYINSTALLER_COMMIT=d6f3d02365ba68ffc84169c56c292701f346110e # Version 4.2 + a patch to drop an unused .rc file
 
         # Satochip pyscard
         PYSCARD_FILENAME=pyscard-1.9.9-cp36-cp36m-win32.whl  # python 3.6, 32-bit

--- a/contrib/build-wine/requirements-wine-build.txt
+++ b/contrib/build-wine/requirements-wine-build.txt
@@ -17,3 +17,6 @@ setuptools==41.0.1 \
 wheel==0.33.4 \
     --hash=sha256:5e79117472686ac0c4aef5bad5172ea73a1c2d1646b808c35926bd26bdfb0c08 \
     --hash=sha256:62fcfa03d45b5b722539ccbc07b190e4bfff4bb9e3a4d470dd9f6a0981002565
+pyinstaller-hooks-contrib==2020.11 \
+    --hash=sha256:fa8280b79d8a2b267a2e43ff44f73b3e4a68fc8d205b8d34e8e06c960f7c2fcf \
+    --hash=sha256:fc3290a2ca337d1d58c579c223201360bfe74caed6454eaf5a2550b77dbda45c

--- a/contrib/requirements/requirements-wine-build.txt
+++ b/contrib/requirements/requirements-wine-build.txt
@@ -5,3 +5,4 @@ altgraph>=0.15
 future
 pefile>=2017.8.1
 pywin32-ctypes>=0.2.0
+pyinstaller-hooks-contrib>=2020.6


### PR DESCRIPTION
PyInstaller 3.6 fixed the MinGW build issue we used a patch for:

https://github.com/pyinstaller/pyinstaller/commit/6df55e45876968537585c197f2b86f67d0242305

but version 4.2 broke the MinGW build again:

https://github.com/pyinstaller/pyinstaller/commit/99db9ab98d63b028724d38f241424d21df44afcf

this fails with `windres: no resources` because the preprocessed RC file is essentially empty. Windows RC seems to ignore this. To fix it we add a patch that just removes the RC file build:

https://github.com/EchterAgo/pyinstaller/commit/d6f3d02365ba68ffc84169c56c292701f346110e