### PR TITLE
appimage build: build was failing on some host systems

### DIFF
--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -206,8 +206,11 @@ find -exec touch -h -d '2000-11-11T11:11:11+00:00' {} +
 info "Creating the AppImage"
 (
     cd "$BUILDDIR"
-    chmod +x "$CACHEDIR/appimagetool"
-    "$CACHEDIR/appimagetool" --appimage-extract
+    cp "$CACHEDIR/appimagetool" "$CACHEDIR/appimagetool_copy"
+    # zero out "appimage" magic bytes, as on some systems they confuse the linker
+    sed -i 's|AI\x02|\x00\x00\x00|' "$CACHEDIR/appimagetool_copy"
+    chmod +x "$CACHEDIR/appimagetool_copy"
+    "$CACHEDIR/appimagetool_copy" --appimage-extract
     # We build a small wrapper for mksquashfs that removes the -mkfs-fixed-time option
     # that mksquashfs from squashfskit does not support. It is not needed for squashfskit.
     cat > ./squashfs-root/usr/lib/appimagekit/mksquashfs << EOF


### PR DESCRIPTION
On Ubuntu host, build succeeded; but e.g. on Manjaro host, it failed with:
```
./build.sh: line 233: /opt/electrum/contrib/build-linux/appimage/../../../contrib/build-linux/appimage/.cache/appimage/appimagetool: No such file or directory
```

This seems to be caused by applications like `AppImageLauncher` registering the AppImage magic bytes with `binfmt_misc` leaking into the Docker container.

See also: https://github.com/AppImage/pkg2appimage/issues/373