### PR TITLE
NSIS: Wait for the uninstaller to finish

### DIFF
--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -114,7 +114,10 @@ Function .onInit
   ReadRegStr $R1 ${INSTDIR_REG_ROOT} "${INSTDIR_REG_KEY}" DisplayName
   ${If} $R0 != ""
   ${AndIf} ${Cmd} ${|} MessageBox MB_YESNO|MB_ICONEXCLAMATION "$R1 has already been installed. $\nDo you want to remove the previous version before installing $(^Name)?" /SD IDNO IDYES ${|}
-    ExecWait $R0
+    GetFullPathName $R1 "$R0\.."
+    ExecWait '$R0 _?=$R1'
+    IfErrors 0 +2
+      Abort
   ${EndIf}
 
   ; Check for administrator rights


### PR DESCRIPTION
When there is an existing installation and the user chose to uninstall, wait for the uninstaller to finish. Normal `ExecWait` doesn't work because by default the uninstaller spawns a new process. This also exits the installation if the uninstall fails.