### PR TITLE
Build: Use git version with patch for CVE-2021-21300

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -10,7 +10,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
     echo deb ${UBUNTU_MIRROR} bionic-security main restricted universe multiverse >> /etc/apt/sources.list && \
     apt-get update -q && \
     apt-get install -qy \
-        git=1:2.17.1-1ubuntu0.7 \
+        git=1:2.17.1-1ubuntu0.8 \
         wget=1.19.4-1ubuntu2.2 \
         make=4.1-9.1ubuntu1 \
         autotools-dev=20180224.1 \

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
     apt-get update -q && \
     apt-get install -qy \
         wget=1.19.4-1ubuntu2.2 \
-        git=1:2.17.1-1ubuntu0.7 \
+        git=1:2.17.1-1ubuntu0.8 \
         p7zip-full=16.02+dfsg-6 \
         make=4.1-9.1ubuntu1 \
         autotools-dev=20180224.1 \


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-21300

https://launchpad.net/ubuntu/+source/git/1:2.17.1-1ubuntu0.8