### PR TITLE
AppImage: Include libxcb into the image

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -28,6 +28,8 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
         libpcsclite-dev=1.8.23-1 \
         swig=3.0.12-1 \
         libxkbcommon-x11-0=0.8.2-1~ubuntu18.04.1 \
+        libxcb-util1=0.4.0-0ubuntu3 \
+        libxcb-xinerama0=1.13-2~ubuntu18.04 \
         autopoint=0.19.8.1-6ubuntu0.3 \
         zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
         libfreetype6=2.8.1-2ubuntu2.1 \

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -153,6 +153,9 @@ cp -fp /usr/lib/x86_64-linux-gnu/libusb-1.0.so "$APPDIR"/usr/lib/x86_64-linux-gn
 # some distros lack libxkbcommon-x11
 cp -f /usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so.0 "$APPDIR"/usr/lib/x86_64-linux-gnu || fail "Could not copy libxkbcommon-x11"
 
+# some distros lack some libxcb libraries (see #2189, #2196)
+cp -f /usr/lib/x86_64-linux-gnu/libxcb-* "$APPDIR"/usr/lib/x86_64-linux-gnu || fail "Could not copy libxkcb"
+
 info "Stripping binaries of debug symbols"
 # "-R .note.gnu.build-id" also strips the build id
 # "-R .comment" also strips the GCC version information


### PR DESCRIPTION
Ubuntu 20.04 needs `libxcb-xinerama.so.0` and Debian 10 needs `libxcb-util.so.1` for the Qt `xcb` plugin.

See #2189
Closes #2196