### PR TITLE
Add electrs.electroncash.de

### DIFF
--- a/electroncash/servers.json
+++ b/electroncash/servers.json
@@ -116,6 +116,11 @@
         "t": "50001",
         "version": "1.4"
     },
+    "electrs.electroncash.de": {
+        "pruning": "-",
+	"s": "40002",
+	"version": "1.4"
+    },
     "jktsologn7uprtwn7gsgmwuddj6rxsqmwc2vaug7jwcwzm2bxqnfpwad.onion": {
         "pruning": "-",
         "s": "50002",

--- a/electroncash/servers.json
+++ b/electroncash/servers.json
@@ -118,8 +118,8 @@
     },
     "electrs.electroncash.de": {
         "pruning": "-",
-	"s": "40002",
-	"version": "1.4"
+        "s": "40002",
+        "version": "1.4"
     },
     "jktsologn7uprtwn7gsgmwuddj6rxsqmwc2vaug7jwcwzm2bxqnfpwad.onion": {
         "pruning": "-",

--- a/electroncash/servers_testnet.json
+++ b/electroncash/servers_testnet.json
@@ -24,6 +24,9 @@
         "s": "50004",
         "t": "50003"
     },
+    "electrs.electroncash.de": {
+        "s": "60002"
+    },
     "tbch.loping.net": {
         "s": "60002",
         "t": "60001"


### PR DESCRIPTION
electrs.electroncash.de is running stable for a while now and can be added to the default list