### PR TITLE
Removed unreachable line of code

### DIFF
--- a/electroncash/rsakey.py
+++ b/electroncash/rsakey.py
@@ -125,7 +125,7 @@ def numBits(n):
      '8':4, '9':4, 'a':4, 'b':4,
      'c':4, 'd':4, 'e':4, 'f':4,
      }[s[0]]
-    return int(math.floor(math.log(n, 2))+1)
+
 
 def numBytes(n):
     if n==0:


### PR DESCRIPTION
This line was introduced in the original implementation of the function
back in 2015, and never cleaned up: e8d30129eae10b5efeaa9e95a900576e41dd2bf1

Related issue: https://github.com/Electron-Cash/Electron-Cash/issues/2213

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/electron-cash/electron-cash/2224)
<!-- Reviewable:end -->
