### PR TITLE
AppImage: Update OpenSSL to version 1.1.1-1ubuntu2.1~18.04.9

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -21,7 +21,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
         libncurses5-dev=6.1-1ubuntu1.18.04 \
         libsqlite3-dev=3.22.0-1ubuntu0.4 \
         libusb-1.0-0-dev=2:1.0.21-2 \
-        libudev-dev=237-3ubuntu10.44 \
+        libudev-dev=237-3ubuntu10.45 \
         gettext=0.19.8.1-6ubuntu0.3 \
         pkg-config=0.29.1-0ubuntu2 \
         libdbus-1-3=1.12.2-1ubuntu1.2 \
@@ -34,7 +34,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
         zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
         libfreetype6=2.8.1-2ubuntu2.1 \
         libfontconfig1=2.12.6-0ubuntu2 \
-        libssl-dev=1.1.1-1ubuntu2.1~18.04.8 \
+        libssl-dev=1.1.1-1ubuntu2.1~18.04.9 \
         rustc=1.47.0+dfsg1+llvm-1ubuntu1~18.04.1 \
         && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
This has some important fixes:

* SECURITY UPDATE: NULL pointer deref in signature_algorithms processing
  - debian/patches/CVE-2021-3449-1.patch: fix NULL pointer dereference in
    ssl/statem/extensions.c.
  - debian/patches/CVE-2021-3449-2.patch: teach TLSProxy how to encrypt
    <= TLSv1.2 ETM records in util/perl/TLSProxy/Message.pm.
  - debian/patches/CVE-2021-3449-3.patch: add a test to
    test/recipes/70-test_renegotiation.t.
  - debian/patches/CVE-2021-3449-4.patch: ensure buffer/length pairs are
    always in sync in ssl/s3_lib.c, ssl/ssl_lib.c,
    ssl/statem/extensions.c, ssl/statem/extensions_clnt.c,
    ssl/statem/statem_clnt.c, ssl/statem/statem_srvr.c.
  - CVE-2021-3449

This also updates libudev-dev to version 237-3ubuntu10.45, the old version is not available anymore.

I tested the AppImage.

https://ec.loping.net/4.2.4-50-gfea82b9b2/