### PR TITLE
Make make_locale check exit status of gettext commands

### DIFF
--- a/contrib/make_locale
+++ b/contrib/make_locale
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
+
+import glob
+import io
+import itertools
 import os
 from os.path import isdir, join
-import sys
-import io
-import zipfile
-import requests
-import glob
-import itertools
 from pathlib import Path
+import requests
+import shlex
+from subprocess import check_call
+import sys
+import zipfile
 
 assert len(sys.argv) < 3
+
+def run(cmd):
+    check_call(shlex.split(cmd))
 
 original_dir = os.getcwd()
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
@@ -45,7 +51,7 @@ if not os.path.exists('electroncash/locale'):
     os.mkdir('electroncash/locale')
 cmd = 'xgettext -s --from-code UTF-8 --language Python --no-wrap -f app.fil --keyword=pgettext:1c,2 --keyword=npgettext:1c,2,3 -c --output=electroncash/locale/messages.pot'
 print('Generate template')
-os.system(cmd)
+run(cmd)
 
 os.chdir('electroncash')
 
@@ -102,4 +108,4 @@ for lang in os.listdir('locale'):
         os.mkdir(msg_dir)
     cmd = 'msgfmt --output-file="{0}/electron-cash.mo" "{0}/electron-cash.po"'.format(msg_dir)
     print('Installing', lang)
-    os.system(cmd)
+    run(cmd)


### PR DESCRIPTION
Previously it just continued running even if the commands failed, which would lead to confusing errors later in the build process.

I've tested both success and failure on both Windows and Linux.