### PR TITLE
Support disabling JSON-RPC server in Daemon

### DIFF
--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -138,7 +138,7 @@ def get_rpc_credentials(config):
 
 class Daemon(DaemonThread):
 
-    def __init__(self, config, fd, is_gui, plugins):
+    def __init__(self, config, fd, is_gui, plugins, listen_jsonrpc=True):
         DaemonThread.__init__(self)
         self.plugins = plugins
         self.config = config
@@ -156,8 +156,9 @@ class Daemon(DaemonThread):
             self.network.add_jobs([self.fx])
         self.gui = None
         self.wallets = {}
-        # Setup JSONRPC server
-        self.init_server(config, fd, is_gui)
+        if listen_jsonrpc:
+            # Setup JSONRPC server
+            self.init_server(config, fd, is_gui)
 
     def init_server(self, config, fd, is_gui):
         host = config.get('rpchost', '127.0.0.1')

--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -138,7 +138,7 @@ def get_rpc_credentials(config):
 
 class Daemon(DaemonThread):
 
-    def __init__(self, config, fd, is_gui, plugins, listen_jsonrpc=True):
+    def __init__(self, config, fd, is_gui, plugins, *, listen_jsonrpc=True):
         DaemonThread.__init__(self)
         self.plugins = plugins
         self.config = config


### PR DESCRIPTION
This pull request allows to disable JSON-RPC server (and therefore it's file lock) setup.

It is useful in cases of using Daemon for only some of it's functionality (properly starting network, fx thread, handling wallets), and using custom JSON-RPC solution (i.e. BitcartCC) instead of default server. This allows starting both custom daemon object and electron cash gui at the same time. As the param is appended with a default value, no behaviour should be changed by default.