### PR TITLE
Add feerate argument to payto/paytomany

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -33,7 +33,7 @@ import sys
 import time
 
 from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
-from functools import wraps, partial
+from functools import wraps
 
 from . import bitcoin
 from . import util
@@ -539,7 +539,7 @@ class Commands:
         coins = self.wallet.get_spendable_coins(domain, self.config)
         if feerate is not None:
             fee_per_kb = 1000 * PyDecimal(feerate)
-            fee_estimator = partial(SimpleConfig.estimate_fee_for_feerate, fee_per_kb)
+            fee_estimator = lambda size: SimpleConfig.estimate_fee_for_feerate(fee_per_kb, size)
         else:
             fee_estimator = fee
         tx = self.wallet.make_unsigned_transaction(coins, final_outputs, self.config, fee_estimator, change_addr)

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -33,7 +33,7 @@ import sys
 import time
 
 from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
-from functools import wraps
+from functools import wraps, partial
 
 from . import bitcoin
 from . import util
@@ -45,6 +45,7 @@ from .wallet import create_new_wallet, restore_wallet_from_text
 from .transaction import Transaction, multisig_script, OPReturn
 from .util import bfh, bh2u, format_satoshis, json_decode, print_error, to_bytes
 from .paymentrequest import PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
+from .simple_config import SimpleConfig
 
 known_commands = {}
 
@@ -509,8 +510,10 @@ class Commands:
         message = util.to_bytes(message)
         return bitcoin.verify_message(address, sig, message)
 
-    def _mktx(self, outputs, fee=None, change_addr=None, domain=None, nocheck=False,
+    def _mktx(self, outputs, fee=None, feerate=None, change_addr=None, domain=None, nocheck=False,
               unsigned=False, password=None, locktime=None, op_return=None, op_return_raw=None, addtransaction=False):
+        if fee is not None and feerate is not None:
+            raise ValueError("Cannot specify both 'fee' and 'feerate' at the same time!")
         if op_return and op_return_raw:
             raise ValueError('Both op_return and op_return_raw cannot be specified together!')
         self.nocheck = nocheck
@@ -534,7 +537,12 @@ class Commands:
             final_outputs.append((TYPE_ADDRESS, address, amount))
 
         coins = self.wallet.get_spendable_coins(domain, self.config)
-        tx = self.wallet.make_unsigned_transaction(coins, final_outputs, self.config, fee, change_addr)
+        if feerate is not None:
+            fee_per_kb = 1000 * PyDecimal(feerate)
+            fee_estimator = partial(SimpleConfig.estimate_fee_for_feerate, fee_per_kb)
+        else:
+            fee_estimator = fee
+        tx = self.wallet.make_unsigned_transaction(coins, final_outputs, self.config, fee_estimator, change_addr)
         if locktime != None:
             tx.locktime = locktime
         if not unsigned:
@@ -547,20 +555,20 @@ class Commands:
         return tx
 
     @command('wp')
-    def payto(self, destination, amount, fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None,
+    def payto(self, destination, amount, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None,
               op_return=None, op_return_raw=None, addtransaction=False):
         """Create a transaction. """
         tx_fee = satoshis(fee)
         domain = from_addr.split(',') if from_addr else None
-        tx = self._mktx([(destination, amount)], tx_fee, change_addr, domain, nocheck, unsigned, password, locktime, op_return, op_return_raw, addtransaction=addtransaction)
+        tx = self._mktx([(destination, amount)], tx_fee, feerate, change_addr, domain, nocheck, unsigned, password, locktime, op_return, op_return_raw, addtransaction=addtransaction)
         return tx.as_dict()
 
     @command('wp')
-    def paytomany(self, outputs, fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None, addtransaction=False):
+    def paytomany(self, outputs, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None, addtransaction=False):
         """Create a multi-output transaction. """
         tx_fee = satoshis(fee)
         domain = from_addr.split(',') if from_addr else None
-        tx = self._mktx(outputs, tx_fee, change_addr, domain, nocheck, unsigned, password, locktime, addtransaction=addtransaction)
+        tx = self._mktx(outputs, tx_fee, feerate, change_addr, domain, nocheck, unsigned, password, locktime, addtransaction=addtransaction)
         return tx.as_dict()
 
     @command('w')
@@ -857,7 +865,8 @@ command_options = {
     'entropy':     (None, "Custom entropy"),
     'expiration':  (None, "Time in seconds"),
     'expired':     (None, "Show only expired requests."),
-    'fee':         ("-f", "Transaction fee (in BCH)"),
+    'fee':         ("-f", "Transaction fee (absolute, in BCH)"),
+    'feerate':     (None, "Transaction fee rate (in sat/byte)"),
     'force':       (None, "Create new address beyond gap limit, if no more addresses are available."),
     'from_addr':   ("-F", "Source address (must be a wallet address; use sweep to spend from non-wallet address)."),
     'frozen':      (None, "Show only frozen addresses"),

--- a/electroncash/simple_config.py
+++ b/electroncash/simple_config.py
@@ -4,6 +4,7 @@ import threading
 import time
 import os
 import stat
+from decimal import Decimal as PyDecimal
 
 from . import util
 from copy import deepcopy
@@ -351,7 +352,11 @@ class SimpleConfig(PrintError):
         return i >= 0
 
     def estimate_fee(self, size):
-        return int(self.fee_per_kb() * size / 1000.)
+        return self.estimate_fee_for_feerate(self.fee_per_kb(), size)
+
+    @classmethod
+    def estimate_fee_for_feerate(cls, fee_per_kb, size):
+        return int(PyDecimal(fee_per_kb) * PyDecimal(size) / 1000)
 
     def update_fee_estimates(self, key, value):
         self.fee_estimates[key] = value

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -1874,7 +1874,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 result.extend(new_addrs)
             return result
 
-    def make_unsigned_transaction(self, inputs, outputs, config, fee=None, change_addr=None, sign_schnorr=None):
+    def make_unsigned_transaction(self, inputs, outputs, config, fixed_fee=None, change_addr=None, sign_schnorr=None):
         ''' sign_schnorr flag controls whether to mark the tx as signing with
         schnorr or not. Specify either a bool, or set the flag to 'None' to use
         whatever the wallet is configured to use from the GUI '''
@@ -1892,17 +1892,17 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         if not inputs:
             raise NotEnoughFunds()
 
-        if fee is None and config.fee_per_kb() is None:
+        if fixed_fee is None and config.fee_per_kb() is None:
             raise BaseException('Dynamic fee estimates not available')
 
         for item in inputs:
             self.add_input_info(item)
 
         # Fee estimator
-        if fee is None:
+        if fixed_fee is None:
             fee_estimator = config.estimate_fee
-        elif callable(fee):
-            fee_estimator = fee
+        elif callable(fixed_fee):
+            fee_estimator = fixed_fee
         else:
             fee_estimator = lambda size: fee
 

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -1904,7 +1904,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         elif callable(fixed_fee):
             fee_estimator = fixed_fee
         else:
-            fee_estimator = lambda size: fee
+            fee_estimator = lambda size: fixed_fee
 
         if i_max is None:
             # Let the coin chooser select the coins to spend

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -1874,7 +1874,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 result.extend(new_addrs)
             return result
 
-    def make_unsigned_transaction(self, inputs, outputs, config, fixed_fee=None, change_addr=None, sign_schnorr=None):
+    def make_unsigned_transaction(self, inputs, outputs, config, fee=None, change_addr=None, sign_schnorr=None):
         ''' sign_schnorr flag controls whether to mark the tx as signing with
         schnorr or not. Specify either a bool, or set the flag to 'None' to use
         whatever the wallet is configured to use from the GUI '''
@@ -1892,17 +1892,19 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         if not inputs:
             raise NotEnoughFunds()
 
-        if fixed_fee is None and config.fee_per_kb() is None:
+        if fee is None and config.fee_per_kb() is None:
             raise BaseException('Dynamic fee estimates not available')
 
         for item in inputs:
             self.add_input_info(item)
 
         # Fee estimator
-        if fixed_fee is None:
+        if fee is None:
             fee_estimator = config.estimate_fee
+        elif callable(fee):
+            fee_estimator = fee
         else:
-            fee_estimator = lambda size: fixed_fee
+            fee_estimator = lambda size: fee
 
         if i_max is None:
             # Let the coin chooser select the coins to spend


### PR DESCRIPTION
This pull request adds `feerate` parameter to CLI functions `payto` and `paytomany`. It allows setting feerate for a transaction without for example calling payto once, getting tx size (via a function that is not exposed by default commands.py) and then calling payto once again with calculated fee.