### PR TITLE
[iOS] Support OP_RETURN tansaction outputs

### DIFF
--- a/ios/CustomCode/ViewsForIB.h
+++ b/ios/CustomCode/ViewsForIB.h
@@ -88,6 +88,7 @@
 @property (nonatomic, weak) IBOutlet UIBarButtonItem *clearBut;
 @property (nonatomic, weak) IBOutlet UIBarButtonItem *previewBut;
 @property (nonatomic, weak) IBOutlet UIButton *sendBut; // actually a subview of a UIBarButtonItem
+@property (nonatomic, weak) IBOutlet UIButton *opReturnToggle;
 @property (nonatomic, weak) IBOutlet UILabel *message;
 @property (nonatomic, weak) IBOutlet NSLayoutConstraint *csFeeTop, *csTvHeight, *csPayToTop, *csContentHeight;
 @property (nonatomic, weak) IBOutlet UITableView *tv;
@@ -97,6 +98,7 @@
 @end
 
 @interface SendVC : SendBase
+-(IBAction)onToggleRawOpReturn; // implemented in python send.py
 -(IBAction)onQRBut:(id)sender; // implemented in python send.py
 -(IBAction)onContactBut:(id)sender; // implemented in python send.py
 -(IBAction)clear; // implemented in python send.py

--- a/ios/CustomCode/ViewsForIB.h
+++ b/ios/CustomCode/ViewsForIB.h
@@ -76,6 +76,7 @@
 @property (nonatomic, weak) IBOutlet UIButton *contactBut;
 @property (nonatomic, weak) IBOutlet UILabel *descTit;
 @property (nonatomic, weak) IBOutlet UITextView *desc;
+@property (nonatomic, weak) IBOutlet UITextView *opReturn;
 @property (nonatomic, weak) IBOutlet UILabel *amtTit;
 @property (nonatomic, weak) IBOutlet BTCAmountEdit *amt;
 @property (nonatomic, weak) IBOutlet UIButton *maxBut;
@@ -92,6 +93,7 @@
 @property (nonatomic, weak) IBOutlet UITableView *tv;
 @property (nonatomic, weak) IBOutlet UIView *bottomView, *messageView;
 @property (nonatomic, strong) IBOutlet ECTextViewDelegate *descDel;
+@property (nonatomic, strong) IBOutlet ECTextViewDelegate *opReturnDel;
 @end
 
 @interface SendVC : SendBase

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -1160,7 +1160,7 @@ class ElectrumGui(PrintError):
             self.sendVC.setPayToGreen()
         else:
             self.sendVC.setPayToExpired()
-        self.sendVC.onPayTo_message_amount_(None, None, None, None, None) # special usage of function will pick up fields from pr
+        self.sendVC.onPayTo_message_amount_opReturn_isRaw_(None, None, None, None, False) # special usage of function will pick up fields from pr
         # need to update fee
         self.sendVC.updateFee()
 
@@ -1240,9 +1240,13 @@ class ElectrumGui(PrintError):
             message = out.get('message')
             op_return = out.get('op_return')
             op_return_raw = out.get('op_return_raw')
+            op_return_is_raw = False
+            if op_return_raw is not None:
+                op_return_is_raw = True
+                op_return = op_return_raw
             # use label as description (not BIP21 compliant)
             if self.sendVC:
-                self.sendVC.onPayTo_message_amount_(address,message,amount,op_return,op_return_raw)
+                self.sendVC.onPayTo_message_amount_opReturn_isRaw_(address,message,amount,op_return,op_return_is_raw)
                 return True
             else:
                 self.show_error("Oops! Something went wrong! Email the developers!")

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -1160,7 +1160,7 @@ class ElectrumGui(PrintError):
             self.sendVC.setPayToGreen()
         else:
             self.sendVC.setPayToExpired()
-        self.sendVC.onPayTo_message_amount_(None, None, None) # special usage of function will pick up fields from pr
+        self.sendVC.onPayTo_message_amount_(None, None, None, None, None) # special usage of function will pick up fields from pr
         # need to update fee
         self.sendVC.updateFee()
 
@@ -1238,9 +1238,11 @@ class ElectrumGui(PrintError):
             amount = out.get('amount')
             label = out.get('label')
             message = out.get('message')
+            op_return = out.get('op_return')
+            op_return_raw = out.get('op_return_raw')
             # use label as description (not BIP21 compliant)
             if self.sendVC:
-                self.sendVC.onPayTo_message_amount_(address,message,amount)
+                self.sendVC.onPayTo_message_amount_(address,message,amount,op_return,op_return_raw)
                 return True
             else:
                 self.show_error("Oops! Something went wrong! Email the developers!")

--- a/ios/ElectronCash/electroncash_gui/ios_native/send.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/send.py
@@ -270,7 +270,7 @@ class SendVC(SendBase):
             try:
                 qpt = list(self.queuedPayTo)
                 self.queuedPayTo = None
-                self.onPayTo_message_amount_(qpt[0],qpt[1],qpt[2], None, None)
+                self.onPayTo_message_amount_opReturn_isRaw_(qpt[0],qpt[1],qpt[2], None, False)
             except:
                 utils.NSLog("queuedPayTo.. failed with exception: %s",str(sys.exc_info()[1]))
 
@@ -412,7 +412,7 @@ class SendVC(SendBase):
         return True
 
     @objc_method
-    def onPayTo_message_amount_(self, address, message, amount, op_return, op_return_raw) -> None:
+    def onPayTo_message_amount_opReturn_isRaw_(self, address, message, amount, op_return, op_return_is_raw) -> None:
         # address
         if not self.viewIfLoaded:
             self.queuedPayTo = [address, message, amount]
@@ -444,19 +444,14 @@ class SendVC(SendBase):
         utils.uitf_redo_attrs(tf)
         utils.uitf_redo_attrs(self.fiat)
         # op_return
-        if op_return is not None:
-            self.opReturnDel.text = str(op_return)
-            self.opReturn.resignFirstResponder()
-        # op_return_raw
-        if op_return_raw is not None:
-            self.opReturnIsRaw = True
-            self.opReturnToggle.setSelected_(self.opReturnIsRaw)
-            self.opReturnDel.text = str(op_return_raw)
-            self.opReturn.resignFirstResponder()
+        self.opReturnDel.text = str(op_return) if op_return is not None else ""
+        self.opReturnIsRaw = bool(op_return_is_raw)
+        self.opReturnToggle.setSelected_(self.opReturnIsRaw)
+        self.opReturn.resignFirstResponder()
 
         self.qrScanErr = False
         self.chkOk()
-        utils.NSLog("OnPayTo %s %s %s %s %s",str(address), str(message), str(amount), str(op_return), str(op_return_raw))
+        utils.NSLog("OnPayTo %s %s %s %s %s",str(address), str(message), str(amount), str(op_return), str(op_return_is_raw))
 
     @objc_method
     def chkOk(self) -> bool:
@@ -654,8 +649,8 @@ class SendVC(SendBase):
                 #print("LOCK AMOUNT = False")
 
                 try:
-                    #self.onPayTo_message_amount_(payto_address[1].to_ui_string(), None, None)
-                    self.onPayTo_message_amount_(data, None, None, None, None)
+                    #self.onPayTo_message_amount_opReturn_isRaw_(payto_address[1].to_ui_string(), None, None)
+                    self.onPayTo_message_amount_opReturn_isRaw_(data, None, None, None, False)
                     return
                 except Exception as e:
                     utils.NSLog("EXCEPTION -- %s",str(e))
@@ -692,7 +687,7 @@ class SendVC(SendBase):
         else:
             #print("onCheckPayToText.. last clause")
             self.isMax = is_max
-            self.onPayTo_message_amount_(outputs[0][1].to_ui_string(),"",outputs[0][2], None, None)
+            self.onPayTo_message_amount_opReturn_isRaw_(outputs[0][1].to_ui_string(),"",outputs[0][2], None, False)
             self.updateFee()  #schedule a fee update later
         utils.NSLog("onCheckPayToText_ result: is_max=%s outputs=%s total=%s errors=%s",str(is_max),str(outputs),str(total),str(errors))
 

--- a/ios/ElectronCash/electroncash_gui/ios_native/send.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/send.py
@@ -270,7 +270,7 @@ class SendVC(SendBase):
             try:
                 qpt = list(self.queuedPayTo)
                 self.queuedPayTo = None
-                self.onPayTo_message_amount_(qpt[0],qpt[1],qpt[2])
+                self.onPayTo_message_amount_(qpt[0],qpt[1],qpt[2], None, None)
             except:
                 utils.NSLog("queuedPayTo.. failed with exception: %s",str(sys.exc_info()[1]))
 
@@ -412,7 +412,7 @@ class SendVC(SendBase):
         return True
 
     @objc_method
-    def onPayTo_message_amount_(self, address, message, amount) -> None:
+    def onPayTo_message_amount_(self, address, message, amount, op_return, op_return_raw) -> None:
         # address
         if not self.viewIfLoaded:
             self.queuedPayTo = [address, message, amount]
@@ -443,10 +443,20 @@ class SendVC(SendBase):
         tf.resignFirstResponder()
         utils.uitf_redo_attrs(tf)
         utils.uitf_redo_attrs(self.fiat)
+        # op_return
+        if op_return is not None:
+            self.opReturnDel.text = str(op_return)
+            self.opReturn.resignFirstResponder()
+        # op_return_raw
+        if op_return_raw is not None:
+            self.opReturnIsRaw = True
+            self.opReturnToggle.setSelected_(self.opReturnIsRaw)
+            self.opReturnDel.text = str(op_return_raw)
+            self.opReturn.resignFirstResponder()
 
         self.qrScanErr = False
         self.chkOk()
-        utils.NSLog("OnPayTo %s %s %s",str(address), str(message), str(amount))
+        utils.NSLog("OnPayTo %s %s %s %s %s",str(address), str(message), str(amount), str(op_return), str(op_return_raw))
 
     @objc_method
     def chkOk(self) -> bool:
@@ -645,7 +655,7 @@ class SendVC(SendBase):
 
                 try:
                     #self.onPayTo_message_amount_(payto_address[1].to_ui_string(), None, None)
-                    self.onPayTo_message_amount_(data, None, None)
+                    self.onPayTo_message_amount_(data, None, None, None, None)
                     return
                 except Exception as e:
                     utils.NSLog("EXCEPTION -- %s",str(e))
@@ -682,7 +692,7 @@ class SendVC(SendBase):
         else:
             #print("onCheckPayToText.. last clause")
             self.isMax = is_max
-            self.onPayTo_message_amount_(outputs[0][1].to_ui_string(),"",outputs[0][2])
+            self.onPayTo_message_amount_(outputs[0][1].to_ui_string(),"",outputs[0][2], None, None)
             self.updateFee()  #schedule a fee update later
         utils.NSLog("onCheckPayToText_ result: is_max=%s outputs=%s total=%s errors=%s",str(is_max),str(outputs),str(total),str(errors))
 

--- a/ios/ElectronCash/electroncash_gui/ios_native/send.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/send.py
@@ -18,6 +18,7 @@ from .uikit_bindings import *
 from electroncash import networks
 from electroncash.address import Address, ScriptOutput
 from electroncash.paymentrequest import PaymentRequest
+from electroncash.transaction import OPReturn
 from electroncash import bitcoin
 from .feeslider import FeeSlider
 from .amountedit import BTCAmountEdit
@@ -209,10 +210,16 @@ class SendVC(SendBase):
         # Error Label
         self.message.text = ""
 
+        self.opReturnDel.placeholderFont = UIFont.italicSystemFontOfSize_(14.0)
+        self.opReturnDel.tv = self.opReturn
+        self.opReturnDel.text = ""
+        self.opReturnDel.placeholderText = _("OP_RETURN data (optional).")
+
         self.descDel.placeholderFont = UIFont.italicSystemFontOfSize_(14.0)
         self.descDel.tv = self.desc
         self.descDel.text = ""
         self.descDel.placeholderText = _("Description of the transaction (not mandatory).")
+        
 
         feelbl = self.feeLbl
         slider = self.feeSlider
@@ -453,7 +460,7 @@ class SendVC(SendBase):
             self.csPayToTop.constant = 0
 
         f = self.desc.frame
-        self.csContentHeight.constant = f.origin.y + f.size.height + 125
+        self.csContentHeight.constant = f.origin.y + f.size.height + 250
 
         retVal = False
         errLbl = self.message
@@ -527,6 +534,7 @@ class SendVC(SendBase):
         tf = self.fiat
         # label
         self.descDel.text = ""
+        self.opReturnDel.text = ""
         # slider
         slider = self.feeSlider
         slider.setValue_animated_(slider.minimumValue,True)
@@ -1020,6 +1028,21 @@ def read_send_form(send : ObjCInstance) -> tuple:
         #    msg += _('Do you wish to continue?')
         #    if not self.question(msg):
         #        return
+
+    try:
+        # handle op_return if specified and enabled
+        opreturn_message = send.opReturnDel.text
+        if opreturn_message:
+            #if self.opreturn_rawhex_cb.isChecked():
+            #        outputs.append(OPReturn.output_for_rawhex(opreturn_message))
+            #    else:
+            outputs.append(OPReturn.output_for_stringdata(opreturn_message))
+    except OPReturn.TooLarge as e:
+        utils.show_alert(send, _("Error"), str(e))
+        return None
+    except OPReturn.Error as e:
+        utils.show_alert(send, _("Error"), str(e))
+        return None
 
     if not outputs:
         utils.show_alert(send, _("Error"), _('No outputs'))

--- a/ios/Resources/Send.xib
+++ b/ios/Resources/Send.xib
@@ -33,6 +33,8 @@
                 <outlet property="maxBut" destination="4WI-jF-M4c" id="ZtC-tc-geb"/>
                 <outlet property="message" destination="6v5-8x-8pg" id="eMc-fZ-6XP"/>
                 <outlet property="messageView" destination="Peb-cL-o1H" id="bzQ-OU-2WZ"/>
+                <outlet property="opReturn" destination="vxm-In-q91" id="MN5-o8-523"/>
+                <outlet property="opReturnDel" destination="23d-e6-zWu" id="915-o8-523"/>
                 <outlet property="payTo" destination="bHD-2d-cy9" id="iWA-As-zDV"/>
                 <outlet property="payToTit" destination="owK-sH-4sK" id="9iC-QM-yMP"/>
                 <outlet property="previewBut" destination="NcO-3J-2Ud" id="6v4-mZ-fgt"/>
@@ -61,7 +63,7 @@
                     <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                     <subviews>
                         <view tag="100" contentMode="TopLeft" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="b2F-qP-ezb" userLabel="Content View">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="900"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="1500"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" tag="110" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pay to" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" preferredMaxLayoutWidth="310" translatesAutoresizingMaskIntoConstraints="NO" id="owK-sH-4sK">
                                     <rect key="frame" x="15" y="186" width="257" height="18"/>
@@ -222,6 +224,34 @@
                                         </userDefinedRuntimeAttribute>
                                     </userDefinedRuntimeAttributes>
                                 </textView>
+                                <label opaque="NO" userInteractionEnabled="NO" tag="224" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OP_RETURN" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" preferredMaxLayoutWidth="310" translatesAutoresizingMaskIntoConstraints="NO" id="N2l-Eb-723">
+                                    <rect key="frame" x="15" y="561" width="345" height="18"/>
+                                    <rect key="contentStretch" x="1" y="0.0" width="1" height="1"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="18" id="O0G-5T-o24"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                    <color key="textColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="deviceRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="vxm-In-q91">
+                                    <rect key="frame" x="15" y="584" width="345" height="76"/>
+                                    <color key="backgroundColor" red="0.96470588239999999" green="0.96470588239999999" blue="0.96470588239999999" alpha="1" colorSpace="deviceRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="76" id="Y9D-x9-Z91"/>
+                                    </constraints>
+                                    <color key="textColor" red="0.25490196079999999" green="0.25490196079999999" blue="0.25490196079999999" alpha="1" colorSpace="deviceRGB"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="4"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <outlet property="delegate" destination="23d-e6-zWu" id="Czb-er-L23"/>
+                                    </connections>
+                                </textView>
                                 <label opaque="NO" userInteractionEnabled="NO" tag="110" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Amount" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" preferredMaxLayoutWidth="310" translatesAutoresizingMaskIntoConstraints="NO" id="aof-Nz-C3S">
                                     <rect key="frame" x="15" y="272" width="285" height="18"/>
                                     <rect key="contentStretch" x="1" y="0.0" width="1" height="1"/>
@@ -270,6 +300,7 @@
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="xtv-AQ-swS" secondAttribute="trailing" constant="15" id="03B-rK-uzX"/>
+                                <constraint firstAttribute="trailing" secondItem="vxm-In-q91" secondAttribute="trailing" constant="15" id="3be-Ni-Q91"/>
                                 <constraint firstAttribute="trailing" secondItem="vxm-In-qQU" secondAttribute="trailing" constant="15" id="3be-Ni-QZE"/>
                                 <constraint firstItem="bHD-2d-cy9" firstAttribute="top" secondItem="owK-sH-4sK" secondAttribute="bottom" constant="5" id="3j2-Do-3zf"/>
                                 <constraint firstItem="heV-Gd-Pf3" firstAttribute="top" secondItem="x1H-SG-11E" secondAttribute="bottom" constant="9" id="69P-s2-0j8"/>
@@ -292,6 +323,7 @@
                                 <constraint firstItem="uVz-6s-k9O" firstAttribute="top" secondItem="b2F-qP-ezb" secondAttribute="top" constant="25" id="UL3-AL-DhS"/>
                                 <constraint firstItem="fan-4K-Ndv" firstAttribute="top" secondItem="39E-Af-C6m" secondAttribute="bottom" constant="5" id="WPL-LP-bgT"/>
                                 <constraint firstAttribute="height" constant="900" id="X72-wH-lvd"/>
+                                <constraint firstItem="N2l-Eb-723" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="Xuy-2c-s23"/>
                                 <constraint firstItem="N2l-Eb-7Ts" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="Xuy-2c-sCY"/>
                                 <constraint firstItem="bHD-2d-cy9" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="ZRG-YT-ji9"/>
                                 <constraint firstItem="qTe-7D-gzO" firstAttribute="leading" secondItem="owK-sH-4sK" secondAttribute="trailing" constant="25" id="a9X-ef-vMr"/>
@@ -299,15 +331,19 @@
                                 <constraint firstItem="xtv-AQ-swS" firstAttribute="top" secondItem="aof-Nz-C3S" secondAttribute="bottom" constant="5" id="bsU-Bo-sKw"/>
                                 <constraint firstAttribute="trailing" secondItem="iuD-jH-Nyq" secondAttribute="trailing" constant="15" id="bxu-8k-hqp"/>
                                 <constraint firstItem="4WI-jF-M4c" firstAttribute="leading" secondItem="aof-Nz-C3S" secondAttribute="trailing" id="c2V-EP-AUp"/>
+                                <constraint firstItem="vxm-In-q91" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="cA7-s3-w91"/>
                                 <constraint firstItem="vxm-In-qQU" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="cA7-s3-wFq"/>
+                                <constraint firstAttribute="trailing" secondItem="N2l-Eb-723" secondAttribute="trailing" constant="15" id="dXR-N2-X23"/>
                                 <constraint firstAttribute="trailing" secondItem="N2l-Eb-7Ts" secondAttribute="trailing" constant="15" id="dXR-N2-XQ1"/>
                                 <constraint firstItem="owK-sH-4sK" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="euJ-eI-WFb"/>
                                 <constraint firstAttribute="trailing" secondItem="4WI-jF-M4c" secondAttribute="trailing" constant="15" id="gVq-eW-wNb"/>
+                                <constraint firstItem="vxm-In-q91" firstAttribute="top" secondItem="N2l-Eb-723" secondAttribute="bottom" constant="5" id="gnW-A8-r91"/>
                                 <constraint firstItem="vxm-In-qQU" firstAttribute="top" secondItem="N2l-Eb-7Ts" secondAttribute="bottom" constant="5" id="gnW-A8-ro9"/>
                                 <constraint firstAttribute="trailing" secondItem="bHD-2d-cy9" secondAttribute="trailing" constant="15" id="hFy-os-Nyb"/>
                                 <constraint firstAttribute="trailing" secondItem="x1H-SG-11E" secondAttribute="trailing" constant="15" id="haD-l2-EQg"/>
                                 <constraint firstItem="J75-d7-Cck" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="kxr-Mi-ZUG"/>
                                 <constraint firstItem="ILr-El-MVG" firstAttribute="top" secondItem="xtv-AQ-swS" secondAttribute="bottom" constant="5" id="oxG-Va-Xs5"/>
+                                <constraint firstItem="N2l-Eb-723" firstAttribute="top" secondItem="vxm-In-qQU" secondAttribute="bottom" constant="25" id="p7w-8V-n23"/>
                                 <constraint firstItem="N2l-Eb-7Ts" firstAttribute="top" secondItem="heV-Gd-Pf3" secondAttribute="bottom" constant="25" id="p7w-8V-nBz"/>
                                 <constraint firstItem="x1H-SG-11E" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="rEv-Mf-GgW"/>
                                 <constraint firstAttribute="trailing" secondItem="fan-4K-Ndv" secondAttribute="trailing" constant="15" id="tyS-RC-utI"/>
@@ -437,6 +473,20 @@
             </userDefinedRuntimeAttributes>
             <connections>
                 <outlet property="tv" destination="vxm-In-qQU" id="qEr-zv-OVX"/>
+            </connections>
+        </customObject>
+        <customObject id="23d-e6-zWu" customClass="ECTextViewDelegate">
+            <userDefinedRuntimeAttributes>
+                <userDefinedRuntimeAttribute type="color" keyPath="placeholderColor">
+                    <color key="value" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="deviceRGB"/>
+                </userDefinedRuntimeAttribute>
+                <userDefinedRuntimeAttribute type="color" keyPath="color">
+                    <color key="value" red="0.25490196079999999" green="0.25490196079999999" blue="0.25490196079999999" alpha="1" colorSpace="deviceRGB"/>
+                </userDefinedRuntimeAttribute>
+                <userDefinedRuntimeAttribute type="boolean" keyPath="centerPlaceholder" value="NO"/>
+            </userDefinedRuntimeAttributes>
+            <connections>
+                <outlet property="tv" destination="vxm-In-q91" id="qEr-zv-O91"/>
             </connections>
         </customObject>
     </objects>

--- a/ios/Resources/Send.xib
+++ b/ios/Resources/Send.xib
@@ -35,6 +35,7 @@
                 <outlet property="messageView" destination="Peb-cL-o1H" id="bzQ-OU-2WZ"/>
                 <outlet property="opReturn" destination="vxm-In-q91" id="MN5-o8-523"/>
                 <outlet property="opReturnDel" destination="23d-e6-zWu" id="915-o8-523"/>
+                <outlet property="opReturnToggle" destination="23t-AW-hwQ" id="23T-UC-aXc"/>
                 <outlet property="payTo" destination="bHD-2d-cy9" id="iWA-As-zDV"/>
                 <outlet property="payToTit" destination="owK-sH-4sK" id="9iC-QM-yMP"/>
                 <outlet property="previewBut" destination="NcO-3J-2Ud" id="6v4-mZ-fgt"/>
@@ -252,6 +253,17 @@
                                         <outlet property="delegate" destination="23d-e6-zWu" id="Czb-er-L23"/>
                                     </connections>
                                 </textView>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="23t-AW-hwQ">
+                                    <rect key="frame" x="224" y="374" width="131" height="24"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                    <state key="normal" title="  Raw Hex" image="Rect_For_Chk_18px.png">
+                                        <color key="titleColor" red="0.25490196079999999" green="0.25490196079999999" blue="0.25490196079999999" alpha="1" colorSpace="deviceRGB"/>
+                                    </state>
+                                    <state key="selected" image="Rect_For_Chk_Chkd_18px.png"/>
+                                    <connections>
+                                        <action selector="onToggleRawOpReturn" destination="-1" eventType="primaryActionTriggered" id="wXr-rW-SPo"/>
+                                    </connections>
+                                </button>
                                 <label opaque="NO" userInteractionEnabled="NO" tag="110" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Amount" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" preferredMaxLayoutWidth="310" translatesAutoresizingMaskIntoConstraints="NO" id="aof-Nz-C3S">
                                     <rect key="frame" x="15" y="272" width="285" height="18"/>
                                     <rect key="contentStretch" x="1" y="0.0" width="1" height="1"/>
@@ -350,6 +362,8 @@
                                 <constraint firstItem="uVz-6s-k9O" firstAttribute="leading" secondItem="b2F-qP-ezb" secondAttribute="leading" constant="15" id="vfR-TN-c1f"/>
                                 <constraint firstItem="iuD-jH-Nyq" firstAttribute="leading" secondItem="qTe-7D-gzO" secondAttribute="trailing" constant="15" id="zNb-GK-BcP"/>
                                 <constraint firstItem="39E-Af-C6m" firstAttribute="top" secondItem="ILr-El-MVG" secondAttribute="bottom" constant="25" id="zXY-SD-Riz"/>
+                                <constraint firstItem="23t-AW-hwQ" firstAttribute="trailing" secondItem="b2F-qP-ezb" secondAttribute="trailing" constant="-25" id="91y-2c-s23"/>
+                                <constraint firstItem="23t-AW-hwQ" firstAttribute="top" secondItem="vxm-In-q91" secondAttribute="bottom" constant="8" id="23W-A8-r91"/>
                             </constraints>
                         </view>
                     </subviews>
@@ -498,5 +512,7 @@
         <image name="qrcode_new_framed_hi.png" width="23" height="23"/>
         <image name="tab_contacts_new.png" width="18" height="25"/>
         <image name="tab_contacts_new_hi.png" width="18" height="25"/>
+        <image name="Rect_For_Chk_18px.png" width="18" height="18"/>
+        <image name="Rect_For_Chk_Chkd_18px.png" width="18" height="18"/>
     </resources>
 </document>


### PR DESCRIPTION
This pull request concerns the iOS version only. The aim is to bring op_return support to the mobile wallet [#1378]. The desktop version already has op_return support.

I open it as a WIP for discussion and feedback.

The goals are the following:

- [x] Support op_return text message outputs
- [x] Support op_return raw hex outputs
- [x] Support reading QR codes with op_return params

If anything is missing please let me know.
