### PR TITLE
Fix daemon running in non-jsonrpc mode

### DIFF
--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -142,6 +142,7 @@ class Daemon(DaemonThread):
         DaemonThread.__init__(self)
         self.plugins = plugins
         self.config = config
+        self.listen_jsonrpc = listen_jsonrpc
         if config.get('offline'):
             self.network = None
         else:
@@ -155,6 +156,7 @@ class Daemon(DaemonThread):
             # On the testnets we don't offer exchange rate/fiat display (is_supported() == False).
             self.network.add_jobs([self.fx])
         self.gui = None
+        self.server = None
         self.wallets = {}
         if listen_jsonrpc:
             # Setup JSONRPC server
@@ -170,7 +172,6 @@ class Daemon(DaemonThread):
                                             rpc_user=rpc_user, rpc_password=rpc_password)
         except Exception as e:
             self.print_error('Warning: cannot initialize RPC server on host', host, e)
-            self.server = None
             os.close(fd)
             return
         os.write(fd, bytes(repr((server.socket.getsockname(), time.time())), 'utf8'))
@@ -339,8 +340,9 @@ class Daemon(DaemonThread):
         self.on_stop()
 
     def stop(self):
-        self.print_error("stopping, removing lockfile")
-        remove_lockfile(get_lockfile(self.config))
+        if self.listen_jsonrpc:
+            self.print_error("stopping, removing lockfile")
+            remove_lockfile(get_lockfile(self.config))
         super().stop()
 
 


### PR DESCRIPTION
This pull request finalizes PR #2305 and fixes some issues related to using it. Sorry, before I introduced it as a way to avoid creating file lock, got to proper shutdown only now (: If actually starting the daemon thread with listen_jsonrpc=False (required for proper shutdown later), it would show `AttributeError: server is not defined` because `init_server` wasn't called, so creating it a bit earlier. Another fix is to not cleanup lockfile if listen_jsonrpc is False, because it is unused anyway (see spesmilo/electrum#7396)