### PR TITLE
Add "spend only fused coins" to Send tab

### DIFF
--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -1630,9 +1630,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.max_button.setFixedWidth(140)
         self.max_button.setCheckable(True)
         grid.addWidget(self.max_button, 5, 3)
-        hbox = QHBoxLayout()
+        hbox = self.send_tab_extra_plugin_controls_hbox = QHBoxLayout()
         hbox.addStretch(1)
-        grid.addLayout(hbox, 5, 4)
+        grid.addLayout(hbox, 5, 4, 1, -1)
 
         msg = _('Bitcoin Cash transactions are in general not free. A transaction fee is paid by the sender of the funds.') + '\n\n'\
               + _('The amount of fee can be decided freely by the sender. However, transactions with low fees take more time to be processed.') + '\n\n'\

--- a/electroncash_plugins/fusion/conf.py
+++ b/electroncash_plugins/fusion/conf.py
@@ -48,6 +48,7 @@ class Conf:
         QueudAutofuse = 4
         Selector = ('fraction', 0.1)  # coin selector options
         SelfFusePlayers = 1 # self-fusing control (1 = just self, more than 1 = self fuse up to N times)
+        SpendOnlyFusedCoins = False  # spendable_coin_filter @hook
 
 
     def __init__(self, wallet):
@@ -131,6 +132,13 @@ class Conf:
             assert i >= 1
             i = int(i)
         return self.wallet.storage.put('cashfusion_self_fuse_players', i)
+
+    @property
+    def spend_only_fused_coins(self) -> bool:
+        return bool(self.wallet.storage.get('cashfusion_spend_only_fused_coins', self.Defaults.SpendOnlyFusedCoins))
+    @spend_only_fused_coins.setter
+    def spend_only_fused_coins(self, b: bool):
+        return self.wallet.storage.put('cashfusion_spend_only_fused_coins', bool(b))
 
 
 CashFusionServer = namedtuple("CashFusionServer", ('hostname', 'port', 'ssl'))

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -663,7 +663,7 @@ class FusionPlugin(BasePlugin):
     def is_fuz_coin(cls, wallet, coin) -> Optional[bool]:
         """ Returns True if the coin in question is definitely a CashFusion coin (uses heuristic matching),
         or False if the coin in question is not from a CashFusion tx. Returns None if the tx for the coin
-        is not (yet) known to the wallet (None == inconclusive answer, called may wish to try again later). """
+        is not (yet) known to the wallet (None == inconclusive answer, caller may wish to try again later). """
         cache = getattr(wallet, "_cashfusion_is_fuz_coin_cache", None)
         if cache is None:
             cache = wallet._cashfusion_is_fuz_coin_cache = dict()

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -678,7 +678,8 @@ class FusionPlugin(BasePlugin):
             if tx is not None:
                 inputs = tx.inputs()
                 outputs = tx.outputs()
-                fuz_prefix = bytes((OpCodes.OP_RETURN, 4)) + Protocol.FUSE_ID  # OP_RETURN (4) FUZ\x00
+                # We expect: OP_RETURN (4) FUZ\x00
+                fuz_prefix = bytes((OpCodes.OP_RETURN, len(Protocol.FUSE_ID))) + Protocol.FUSE_ID
                 # Step 1 - does it have the proper OP_RETURN lokad prefix?
                 for typ, dest, amt in outputs:
                     if amt == 0 and typ == TYPE_SCRIPT and dest.script.startswith(fuz_prefix):

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -265,7 +265,8 @@ class Plugin(FusionPlugin, QObject):
             for name, adr_coin in adr_coins.items():
                 if (name not in fuz_coins_seen
                         and not adr_coin['is_frozen_coin']
-                        and adr_coin.get('slp_token') is None):
+                        and adr_coin.get('slp_token') is None
+                        and not adr_coin.get('coinbase')):
                     coins.append(adr_coin)
                     fuz_coins_seen.add(name)
 

--- a/electroncash_plugins/fusion/util.py
+++ b/electroncash_plugins/fusion/util.py
@@ -36,6 +36,7 @@ from .protocol import Protocol
 
 import hashlib
 import ecdsa
+from typing import Union, Tuple
 
 # Internally used exceptions, shouldn't leak out of this plugin.
 class FusionError(Exception):
@@ -165,3 +166,11 @@ def rand_position(seed, num_positions, counter):
     """
     int64 = int.from_bytes(sha256(seed + counter.to_bytes(4, 'big'))[:8], 'big')
     return (int64 * num_positions) >> 64
+
+
+def get_coin_name(coin: dict, also_return_txid_n=False) -> Union[str, Tuple[str, str, int]]:
+    tx_id, n = coin['prevout_hash'], coin['prevout_n']
+    name = "{}:{}".format(tx_id, n)
+    if not also_return_txid_n:
+        return name
+    return name, tx_id, n


### PR DESCRIPTION
**Merge instructions**: Please squash

---

We add a new checkbox to the send tab, "Spend only fused coins", which
only appears if CashFusion is loaded and if the wallet in question can
fuse.

If checked, we do something similar to the CashShuffle plugin -- we
refuse to spend coins that aren't yet fused. We also try to "force-add"
coins that live on the same address as fused coins, regardless of fused
status.

The checkbox's state is per-wallet and is persisted across restarts.

The determination of whether a coin is a fusion coin uses some
heuristics -- it looks for whether the special "cashfusion" lokad id 
is present in the txn, and also if at least 1 input is signed by us.


![photo_2021-07-16 00 59 00](https://user-images.githubusercontent.com/266627/125863236-a89661f7-658c-4f88-a4d0-f9653b4562e7.jpeg)

If the user gets a "not enough funds" error in the send tab, additional
text will be printed at the bottom if there are some coins that are unfused
and the checkbox is checked (so that the user understands why they
got the error, if some coins are locked because they are unfused).

![photo_2021-07-16 00 59 03](https://user-images.githubusercontent.com/266627/125863250-a04e3e96-6458-4096-b2aa-b98781a702b1.jpeg)
