### PR TITLE
Implement unconfirmed invoices status

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -44,7 +44,7 @@ from .plugins import run_hook
 from .wallet import create_new_wallet, restore_wallet_from_text
 from .transaction import Transaction, multisig_script, OPReturn
 from .util import bfh, bh2u, format_satoshis, json_decode, print_error, to_bytes
-from .paymentrequest import PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
+from .paymentrequest import PR_PAID, PR_UNCONFIRMED, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
 from .simple_config import SimpleConfig
 
 known_commands = {}
@@ -710,6 +710,7 @@ class Commands:
             PR_UNPAID: 'Pending',
             PR_PAID: 'Paid',
             PR_EXPIRED: 'Expired',
+            PR_UNCONFIRMED: 'Unconfirmed'
         }
         out['address'] = out.get('address').to_ui_string()
         out['amount (BCH)'] = format_satoshis(out.get('amount'))

--- a/electroncash/paymentrequest.py
+++ b/electroncash/paymentrequest.py
@@ -60,12 +60,14 @@ PR_UNPAID  = 0
 PR_EXPIRED = 1
 PR_UNKNOWN = 2     # sent but not propagated
 PR_PAID    = 3     # send and propagated
+PR_UNCONFIRMED = 7
 
 pr_tooltips = {
     PR_UNPAID:_('Pending'),
     PR_UNKNOWN:_('Unknown'),
     PR_PAID:_('Paid'),
-    PR_EXPIRED:_('Expired')
+    PR_EXPIRED:_('Expired'),
+    PR_UNCONFIRMED: _('Unconfirmed')
 }
 
 del _

--- a/electroncash/paymentrequest.py
+++ b/electroncash/paymentrequest.py
@@ -60,7 +60,7 @@ PR_UNPAID  = 0
 PR_EXPIRED = 1
 PR_UNKNOWN = 2     # sent but not propagated
 PR_PAID    = 3     # send and propagated
-PR_UNCONFIRMED = 7
+PR_UNCONFIRMED = 7 # paid and confirmations = 0 (7 used to match Electrum)
 
 pr_tooltips = {
     PR_UNPAID:_('Pending'),

--- a/electroncash_gui/qt/util.py
+++ b/electroncash_gui/qt/util.py
@@ -27,12 +27,13 @@ else:
 
 dialogs = []
 
-from electroncash.paymentrequest import PR_UNPAID, PR_PAID, PR_EXPIRED
+from electroncash.paymentrequest import PR_UNCONFIRMED, PR_UNPAID, PR_PAID, PR_EXPIRED
 
 pr_icons = {
     PR_UNPAID:":icons/unpaid.svg",
     PR_PAID:":icons/confirmed.svg",
-    PR_EXPIRED:":icons/expired.svg"
+    PR_EXPIRED:":icons/expired.svg",
+    PR_UNCONFIRMED: ":icons/unconfirmed.svg"
 }
 
 def _(message): return message

--- a/ios/ElectronCash/electroncash_gui/ios_native/receive.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/receive.py
@@ -12,7 +12,7 @@ from electroncash import WalletStorage, Wallet
 from electroncash.util import timestamp_to_datetime, format_time
 from electroncash.i18n import _, language
 from electroncash.address import Address, ScriptOutput
-from electroncash.paymentrequest import PR_UNPAID, PR_EXPIRED, PR_UNKNOWN, PR_PAID
+from electroncash.paymentrequest import PR_UNCONFIRMED, PR_UNPAID, PR_EXPIRED, PR_UNKNOWN, PR_PAID
 from electroncash import bitcoin
 import electroncash.web as web
 import sys, traceback, time
@@ -25,13 +25,15 @@ from collections import namedtuple
 pr_icons = {
     PR_UNPAID:"unpaid.png",
     PR_PAID:"confirmed.png",
-    PR_EXPIRED:"expired.png"
+    PR_EXPIRED:"expired.png",
+    PR_UNCONFIRMED:"unconfirmed.png",
 }
 
 pr_tooltips = {
     PR_UNPAID:'Pending',
     PR_PAID:'Paid',
-    PR_EXPIRED:'Expired'
+    PR_EXPIRED:'Expired',
+    PR_UNCONFIRMED:'Unconfirmed',
 }
 
 ReqItem = namedtuple("ReqItem", "dateStr addrStr signedBy message amountStr statusStr addr iconSign iconStatus fiatStr timestamp expiration expirationStr amount fiat")


### PR DESCRIPTION
This pull request implements unconfirmed status for invoices. If invoice is unconfirmed it indeed can't be fully considered paid (though as far as I know double-spends are very rare on bch). Also it fixes confirmations calculation bug (classic off-by-one (: )

Marking this PR as draft because it needs some review comments before I can proceed. 
Applied similar fix to spesmilo/electrum@d94d443082a6f71b651625e13318ad6b05b11318
This PR is similar to spesmilo/electrum@90abfda12bf78ce13332ab0474dcade418a211b1

The main question so far is: are you ok with making unconfirmed status number code equal to 7 and not 4 to match electrum's (they also have some lightning statuses which aren't needed here). If not, what about changing getrequest output format everywhere to provide two fields like electrum does: `status`, which is an integer code of that request, and `status_str`, which is the str version of it got from corresponding mapping?