### PR TITLE
Add ability to forget config on exit

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -998,6 +998,7 @@ def add_global_options(parser):
     group.add_argument("-P", "--portable", action="store_true", dest="portable", default=False, help="Use local 'electron_cash_data' directory")
     group.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path")
     group.add_argument("-wp", "--walletpassword", dest="wallet_password", default=None, help="Supply wallet password")
+    group.add_argument("--forgetconfig", action="store_true", dest="forget_config", default=False, help="Forget config on exit")
     group.add_argument("--testnet", action="store_true", dest="testnet", default=False, help="Use Testnet")
     group.add_argument("--testnet4", action="store_true", dest="testnet4", default=False, help="Use Testnet4")
     group.add_argument("--scalenet", action="store_true", dest="scalenet", default=False, help="Use Scalenet")

--- a/electroncash/simple_config.py
+++ b/electroncash/simple_config.py
@@ -225,6 +225,8 @@ class SimpleConfig(PrintError):
         return key not in self.cmdline_options
 
     def save_user_config(self):
+        if self.get('forget_config'):
+            return
         if not self.path:
             return
         path = os.path.join(self.path, "config")


### PR DESCRIPTION
This is useful to not store some confidential info like opened wallets. It is also useful if an app needs to set some variables for it's running time but doesn't need to interfere with gui
Also see spesmilo/electrum#5898