### PR TITLE
Make OpenAlias accept 'bitcoincash:' prefix

### DIFF
--- a/electroncash/contacts.py
+++ b/electroncash/contacts.py
@@ -263,7 +263,7 @@ class Contacts(util.PrintError):
         for record in records:
             string = record.strings[0].decode('utf-8')
             if string.startswith('oa1:' + prefix):
-                address = cls.find_regex(string, r'recipient_address=([A-Za-z0-9]+)')
+                address = cls.find_regex(string, r'recipient_address=([A-Za-z0-9:]+)')
                 name = cls.find_regex(string, r'recipient_name=([^;]+)')
                 if not name:
                     name = address


### PR DESCRIPTION
The OpenAlias regex rejected the address containing bitcoincash: prefix. I think it should be accepted both with and without the cashaddr prefix.