### PR TITLE
fusion: Add depth checks

### DIFF
--- a/electroncash_plugins/fusion/conf.py
+++ b/electroncash_plugins/fusion/conf.py
@@ -46,6 +46,7 @@ class Conf:
         CoinbaseSeenLatch = False
         FusionMode = 'normal'
         QueudAutofuse = 4
+        FuseDepth = 0 # Fuse forever by default
         Selector = ('fraction', 0.1)  # coin selector options
         SelfFusePlayers = 1 # self-fusing control (1 = just self, more than 1 = self fuse up to N times)
         SpendOnlyFusedCoins = False  # spendable_coin_filter @hook
@@ -113,6 +114,16 @@ class Conf:
             assert i >= 1
             i = int(i)
         self.wallet.storage.put('cashfusion_queued_autofuse', i)
+
+    @property
+    def fuse_depth(self) -> int:
+        return int(self.wallet.storage.get('cashfusion_fuse_depth', self.Defaults.FuseDepth))
+    @fuse_depth.setter
+    def fuse_depth(self, i : Optional[int]):
+        if i is not None:
+            assert i >= 0
+            i = int(i)
+        self.wallet.storage.put('cashfusion_fuse_depth', i)
 
     @property
     def selector(self) -> Tuple[str, Union[int,float]]:

--- a/electroncash_plugins/fusion/conf.py
+++ b/electroncash_plugins/fusion/conf.py
@@ -46,7 +46,7 @@ class Conf:
         CoinbaseSeenLatch = False
         FusionMode = 'normal'
         QueudAutofuse = 4
-        FuseDepth = 0 # Fuse forever by default
+        FuseDepth = 0  # Fuse forever by default
         Selector = ('fraction', 0.1)  # coin selector options
         SelfFusePlayers = 1 # self-fusing control (1 = just self, more than 1 = self fuse up to N times)
         SpendOnlyFusedCoins = False  # spendable_coin_filter @hook

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -743,7 +743,7 @@ class FusionPlugin(BasePlugin):
         return answer
 
     @classmethod
-    def is_fuz_address(cls, wallet, address, fuz_parents = 0):
+    def is_fuz_address(cls, wallet, address, fuz_parents=0):
         """ Returns True if address contains any fused UTXOs.
             If you want thread safety, caller must hold wallet locks. """
         assert isinstance(address, Address)

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -676,7 +676,7 @@ class FusionPlugin(BasePlugin):
         return can_fuse_from(wallet) and can_fuse_to(wallet)
 
     @staticmethod
-    def is_fuz_coin(wallet, coin, fuz_parents = 0) -> Optional[bool]:
+    def is_fuz_coin(wallet, coin, fuz_parents=0) -> Optional[bool]:
         """ Returns True if the coin in question is definitely a CashFusion coin (uses heuristic matching),
         or False if the coin in question is not from a CashFusion tx. Returns None if the tx for the coin
         is not (yet) known to the wallet (None == inconclusive answer, caller may wish to try again later).

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -73,6 +73,9 @@ MAX_AUTOFUSIONS_PER_WALLET = 10
 
 CONSOLIDATE_MAX_OUTPUTS = MIN_TX_COMPONENTS // 3
 
+# Threshold for the amount (sats) for a wallet to be fully fused. This is to avoid refuse when dusted.
+FUSE_DEPTH_THRESHOLD = 0.95
+
 pnp = None
 def get_upnp():
     """ return an initialized UPnP singleton """
@@ -598,6 +601,21 @@ class FusionPlugin(BasePlugin):
                     for f in list(wallet._fusions_auto):
                         f.stop('Wallet has unconfirmed coins... waiting.', not_if_running = True)
                     continue
+
+                fuse_depth = Conf(wallet).fuse_depth
+                if fuse_depth > 0:
+                    sum_eligible_values = 0
+                    sum_fuz_values = 0
+                    for (eaddr, ecoins) in eligible:
+                        ecoins_value = 0
+                        for ecoin in ecoins:
+                            ecoins_value += ecoin['value']
+                        sum_eligible_values += ecoins_value
+                        if self.is_fuz_address(wallet, eaddr, fuse_depth - 1):
+                            sum_fuz_values += ecoins_value
+                    if sum_eligible_values != 0 and float(sum_fuz_values / sum_eligible_values) >= FUSE_DEPTH_THRESHOLD:
+                        continue
+
                 if not dont_start_fusions and num_auto < min(target_num_auto, MAX_AUTOFUSIONS_PER_WALLET):
                     # we don't have enough auto-fusions running, so start one
                     fraction = get_target_params_2(wallet_conf, sum_value)
@@ -660,10 +678,11 @@ class FusionPlugin(BasePlugin):
         return can_fuse_from(wallet) and can_fuse_to(wallet)
 
     @staticmethod
-    def is_fuz_coin(wallet, coin) -> Optional[bool]:
+    def is_fuz_coin(wallet, coin, fuz_parents = 0) -> Optional[bool]:
         """ Returns True if the coin in question is definitely a CashFusion coin (uses heuristic matching),
         or False if the coin in question is not from a CashFusion tx. Returns None if the tx for the coin
-        is not (yet) known to the wallet (None == inconclusive answer, caller may wish to try again later). """
+        is not (yet) known to the wallet (None == inconclusive answer, caller may wish to try again later).
+        Optionally check recursively if the depth of fused coins is sufficient. """
         cache = getattr(wallet, "_cashfusion_is_fuz_coin_cache", None)
         if cache is None:
             cache = wallet._cashfusion_is_fuz_coin_cache = dict()
@@ -688,10 +707,18 @@ class FusionPlugin(BasePlugin):
                     # Nope, lokad prefix not found
                     return False
                 # Step 2 - are at least 1 of the inputs from me? (DoS prevention measure)
+                fuz_input_found = False
                 for inp in inputs:
                     inp_addr = inp.get('address', None)
                     if inp_addr is not None and wallet.is_mine(inp_addr):
-                        return True  # Success! This tx matches our heuristics
+                        fuz_input_found = True
+                        if fuz_parents <= 0:
+                            return True # This transaction is a CashFusion tx
+                        # [Optional] Step 3 - Check if all inputs from the wallet are also fusions
+                        if not FusionPlugin.is_fuz_coin(wallet, inp, fuz_parents - 1):
+                            return False # Not all parents were CashFusion transactions
+                if fuz_input_found:
+                    return True # All parents where CashFusion transactions with sufficient depth
                 # Failure -- this tx has the lokad but no inputs are "from me".
                 print_error(f"CashFusion: txid \"{tx_id}\" has a CashFusion-style OP_RETURN but none of the "
                             "inputs are from this wallet. This is UNEXPECTED!")
@@ -716,7 +743,7 @@ class FusionPlugin(BasePlugin):
         return answer
 
     @classmethod
-    def is_fuz_address(cls, wallet, address):
+    def is_fuz_address(cls, wallet, address, fuz_parents = 0):
         """ Returns True if address contains any fused UTXOs.
             If you want thread safety, caller must hold wallet locks. """
         assert isinstance(address, Address)
@@ -728,7 +755,7 @@ class FusionPlugin(BasePlugin):
             return True
         utxos = wallet.get_addr_utxo(address)
         for coin in utxos.values():
-            if cls.is_fuz_coin(wallet, coin):
+            if cls.is_fuz_coin(wallet, coin, fuz_parents):
                 cache.add(address)
                 return True
         return False

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -606,7 +606,7 @@ class FusionPlugin(BasePlugin):
                 if fuse_depth > 0:
                     sum_eligible_values = 0
                     sum_fuz_values = 0
-                    for (eaddr, ecoins) in eligible:
+                    for eaddr, ecoins in eligible:
                         ecoins_value = sum(ecoin['value'] for ecoin in ecoins)
                         sum_eligible_values += ecoins_value
                         if self.is_fuz_address(wallet, eaddr, fuse_depth - 1):

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -1351,7 +1351,7 @@ class WalletSettingsDialog(WindowModalDialog):
         numstop = self.sb_fuse_depth.value()
         self.conf.fuse_depth = numstop
         with self.wallet.lock:
-            self.wallet._cashfusion_address_cache = set() # The cache is calculated with old depth
+            self.wallet._cashfusion_address_cache = set()  # The cache is calculated with old depth
             self.wallet._cashfusion_is_fuz_coin_cache = dict()
         if prevval == 0 or (prevval > numstop and numstop != 0):
             for f in list(self.wallet._fusions_auto):

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -248,11 +248,12 @@ class Plugin(FusionPlugin, QObject):
                 # completely bypass this filter for external keypair dict
                 # which is only used for sweep dialog in send tab
                 continue
-            is_fuz_adr = self.is_fuz_address(wallet, coin['address'])
+            fuse_depth = Conf(wallet).fuse_depth
+            is_fuz_adr = self.is_fuz_address(wallet, coin['address'], fuse_depth - 1)
             if is_fuz_adr:
                 fuz_adrs_seen.add(coin['address'])
             # we allow coins sitting on a fused address to be "spent as fused"
-            if not self.is_fuz_coin(wallet, coin) and not is_fuz_adr:
+            if not self.is_fuz_coin(wallet, coin, fuse_depth - 1) and not is_fuz_adr:
                 coins.remove(coin)
             else:
                 fuz_coins_seen.add(get_coin_name(coin))
@@ -1037,6 +1038,15 @@ class WalletSettingsDialog(WindowModalDialog):
 
         main_layout.addLayout(hbox)
 
+        hbox = QHBoxLayout()
+        hbox.addWidget(QLabel(_("Minimum fuse depth (0 = infinite fusing)")))
+        self.sb_fuse_depth = QSpinBox()
+        self.sb_fuse_depth.setRange(0, 10)
+        self.sb_fuse_depth.setMinimumWidth(50)
+        hbox.addWidget(self.sb_fuse_depth)
+        self.sb_fuse_depth.valueChanged.connect(self.edited_fuse_depth)
+        main_layout.addLayout(hbox)
+
         self.gb_coinbase = gb = QGroupBox(_("Coinbase Coins"))
         vbox = QVBoxLayout(gb)
         self.cb_coinbase = QCheckBox(_('Auto-fuse coinbase coins (if mature)'))
@@ -1272,6 +1282,8 @@ class WalletSettingsDialog(WindowModalDialog):
             self.combo_self_fuse.setCurrentIndex(idx)
             del idx
 
+            self.sb_fuse_depth.setValue(self.conf.fuse_depth)
+
             if is_custom_page:
                 self.amt_selector_size.setEnabled(select_type == 'size')
                 self.sb_selector_count.setEnabled(select_type == 'count')
@@ -1332,6 +1344,18 @@ class WalletSettingsDialog(WindowModalDialog):
         if prevval > numfuse:
             for f in list(self.wallet._fusions_auto):
                 f.stop('User decreased queued-fuse limit', not_if_running = True)
+        self.refresh()
+
+    def edited_fuse_depth(self,):
+        prevval = self.conf.fuse_depth
+        numstop = self.sb_fuse_depth.value()
+        self.conf.fuse_depth = numstop
+        with self.wallet.lock:
+            self.wallet._cashfusion_address_cache = set() # The cache is calculated with old depth
+            self.wallet._cashfusion_is_fuz_coin_cache = dict()
+        if prevval == 0 or (prevval > numstop and numstop != 0):
+            for f in list(self.wallet._fusions_auto):
+                f.stop('User decreased fuse depth limit', not_if_running = False)
         self.refresh()
 
     def clicked_confirmed_only(self, checked):


### PR DESCRIPTION
Introduce the notion of 'depth' in fusion transactions.
The user can set a preferred depth that will cause further fusions to
halt once a threshold of all sats (currently hardcoded to 95%) has this
depth.
Only spend coins that satisfies this depth.

By default the depth is set to 0 which means that the fusing will
continue forever (same as current behaviour).