### PR TITLE
fusion: Filter labels based on tx heuristics

### DIFF
--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -618,8 +618,8 @@ class Plugin(FusionPlugin, QObject):
     @hook
     def history_list_filter(self, history_list, h_item, label):
         # NB: 'h_item' might be None due to performance reasons
-        if self._hide_history_txs:
-            return bool(label.startswith("CashFusion "))  # this string is not translated for performance reasons
+        if self._hide_history_txs and h_item is not None:
+            return FusionPlugin.check_is_fuz_tx(history_list.wallet, h_item.tx_hash)
         return None
 
     @hook


### PR DESCRIPTION
Instead of parsing the label text use the heuristics for history
filtering. This way fused transactions could be filtered from recovered
wallets without the need for LabelSyncing.