### PR TITLE
Added electrum.bitcoinverde.org to server list.

### DIFF
--- a/electroncash/servers.json
+++ b/electroncash/servers.json
@@ -160,5 +160,11 @@
         "s": "50002",
         "t": "50001",
         "version": "1.4.4"
+    },
+    "electrum.bitcoinverde.org": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.4.4"
     }
 }


### PR DESCRIPTION
The electrum.bitcoinverde.org electrum server is written, hosted, and maintained by the Bitcoin Verde team.  The server is open source, written from scratch, and is bundled with the Bitcoin Verde node.

It is a new server implementation and may have bugs, but it has been tested against the current version of Electron Cash (v4.2.5) and I have not experienced any issues.  If any incompatibilities are found, please respond and I'll fix them.