### PR TITLE
Allow setting custom user directory with OS environment variable

### DIFF
--- a/electroncash/util.py
+++ b/electroncash/util.py
@@ -468,7 +468,9 @@ def bh2u(x):
 
 
 def user_dir(prefer_local=False):
-    if 'ANDROID_DATA' in os.environ:
+    if "ELECTRONCASHDIR" in os.environ:
+        return os.environ["ELECTRONCASHDIR"]
+    elif 'ANDROID_DATA' in os.environ:
         return android_data_dir()
     elif os.name == 'posix' and "HOME" in os.environ:
         return os.path.join(os.environ["HOME"], ".electron-cash" )


### PR DESCRIPTION
Users who like their home directory be free of any clutter will appreciate being able to set a custom user directory for Electron-cash.

With this change setting the environment variable `ELECTRONCASHDIR` to a path will make Electron-cash use that path instead of the default in the home directory.

Please tell me if and where I should add this option to the docs should this be pulled.