### PR TITLE
easy fix to allow fusions to continue while keeping dust protection

### DIFF
--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -73,8 +73,8 @@ MAX_AUTOFUSIONS_PER_WALLET = 10
 
 CONSOLIDATE_MAX_OUTPUTS = MIN_TX_COMPONENTS // 3
 
-# Threshold for the amount (sats) for a wallet to be fully fused. This is to avoid refuse when dusted.
-FUSE_DEPTH_THRESHOLD = 0.95
+# Threshold for proportion of total wallet value fused before stopping fusion. This avoids re-fusion due to dust.
+FUSE_DEPTH_THRESHOLD = 0.999
 
 # We don't allow a fuse depth beyond this in the wallet UI
 MAX_LIMIT_FUSE_DEPTH = 10
@@ -629,7 +629,7 @@ class FusionPlugin(BasePlugin):
                         sum_eligible_values += ecoins_value
                         if self.is_fuz_address(wallet, eaddr, require_depth=fuse_depth-1):
                             sum_fuz_values += ecoins_value
-                    if sum_eligible_values != 0 and sum_fuz_values / sum_eligible_values >= FUSE_DEPTH_THRESHOLD:
+                    if (sum_eligible_values != 0) and (sum_fuz_values / sum_eligible_values >= FUSE_DEPTH_THRESHOLD):
                         continue
 
                 if not dont_start_fusions and num_auto < min(target_num_auto, MAX_AUTOFUSIONS_PER_WALLET):


### PR DESCRIPTION
A better solution is probably to just have a certain number of dusts that we protect against, but for now, this is just a number change that requires no logic change.

This is the proposal implemented:

| Wallet Total Value | Required to Start Fusion @95%           | Note                   | Required to Start Fusion @99.9%      | Note                |
|--------------------|-----------------------------------------|------------------------|--------------------------------------|---------------------|
| 100 BCH ($50,000)  | 5.00000 BCH ($2500.000) (915,751 dusts) | Too high before fusion | 0.10000 BCH ($50.000) (18,315 dusts) | Fine                |
| 10 BCH ($5,000)    | 0.50000 BCH ($250.000) (91,575 dusts)   | Too high before fusion | 0.01000 BCH ($5.000) (1,832 dusts)   | Fine                |
| 1 BCH ($500)       | 0.05000 BCH ($25.000) (9,158 dusts)     | Too high before fusion | 0.00100 BCH ($0.500) (183 dusts)     | Fine                |
| 0.1 BCH ($50)      | 0.00500 BCH ($2.500) (916 dusts)        | Probably fine          | 0.00010 BCH ($0.050) (18 dusts)      | Fine                |
| 0.01 BCH ($5)      | 0.00050 BCH ($0.250) (92 dusts)         | Hard to fuse anyway    | 0.00001 BCH ($0.005) (2 dusts)       | Hard to fuse anyway |