### PR TITLE
Update(s) to cashfusion qt for py310 removal of coercion 

### DIFF
--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -1429,7 +1429,7 @@ class WalletSettingsDialog(WindowModalDialog):
                 else:
                     self.conf.selector = None
                     return self.refresh()
-                sel_count = COIN_FRACTION_FUDGE_FACTOR / max(sel_fraction, 0.001)
+                sel_count = round(COIN_FRACTION_FUDGE_FACTOR / max(sel_fraction, 0.001))
                 self.amt_selector_size.setAmount(round(sel_size))
                 self.sb_selector_fraction.setValue(max(min(sel_fraction, 1.0), 0.001) * 100.0)
                 self.sb_selector_count.setValue(sel_count)


### PR DESCRIPTION
1. I confirmed that all `setValue` calls have correct typing after this fix.
2. I assume that the original behavior would have used implicit `int()` truncation, but given the usage and scale (large number) of the value `sel_count`, I chose to use `round()` as the conversion.

There may be other values in fusion requiring updates. I didn't immediately see any. Leaving the PR open to edits from maintainers.

Intended as starting point for solution to #2393 