### PR TITLE
Add option to force CashAddress prefix

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -106,6 +106,7 @@ from electroncash import daemon
 from electroncash import keystore
 from electroncash.mnemonic import Mnemonic, Mnemonic_Electrum
 from electroncash.winconsole import create_or_attach_console  # Import ok on other platforms, won't be called.
+from electroncash.address import Address
 import electroncash_plugins
 import electroncash.web as web
 
@@ -551,6 +552,11 @@ def main():
 
     # todo: defer this to gui
     config = SimpleConfig(config_options)
+
+    # These options apply to both GUI and daemon
+    Address.show_cashaddr(config.get("show_cashaddr", True))
+    Address.force_cashaddr_prefix(config.get("force_cashaddr_prefix", False))
+
     cmdname = config.get('cmd')
 
     # run non-RPC commands separately

--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -350,6 +350,9 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
     # Default to CashAddr
     FMT_UI = FMT_CASHADDR
 
+    # Defults to skip CashAddr prefixes (i.e. 'bitcoincash:' or 'bchtest:')
+    FMT_FORCE_PREFIX = False
+
     def __new__(cls, hash160, kind):
         assert kind in (cls.ADDR_P2PKH, cls.ADDR_P2SH)
         hash160 = to_bytes(hash160)
@@ -361,6 +364,10 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
     @classmethod
     def show_cashaddr(cls, on):
         cls.FMT_UI = cls.FMT_CASHADDR if on else cls.FMT_LEGACY
+
+    @classmethod
+    def force_cashaddr_prefix(cls, on):
+        cls.FMT_FORCE_PREFIX = on
 
     @classmethod
     def from_cashaddr_string(cls, string, *, net=None):
@@ -534,6 +541,8 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
 
     def to_ui_string(self, *, net=None):
         '''Convert to text in the current UI format choice.'''
+        if self.FMT_FORCE_PREFIX:
+            return self.to_full_ui_string(net=net)
         if net is None: net = networks.net
         return self.to_string(self.FMT_UI, net=net)
 

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -82,7 +82,7 @@ from .update_checker import UpdateChecker
 class ElectrumGui(QObject, PrintError):
     new_window_signal = pyqtSignal(str, object)
     update_available_signal = pyqtSignal(bool)
-    cashaddr_toggled_signal = pyqtSignal()  # app-wide signal for when cashaddr format is toggled. This used to live in each ElectrumWindow instance but it was recently refactored to here.
+    cashaddr_format_changed_signal = pyqtSignal()  # app-wide signal for when cashaddr format is toggled. This used to live in each ElectrumWindow instance but it was recently refactored to here.
     cashaddr_status_button_hidden_signal = pyqtSignal(bool)  # app-wide signal for when cashaddr toggle button is hidden from the status bar
     shutdown_signal = pyqtSignal()  # signal for requesting an app-wide full shutdown
     do_in_main_thread_signal = pyqtSignal(object, object, object)
@@ -127,7 +127,6 @@ class ElectrumGui(QObject, PrintError):
         self.gc_timer = QTimer(self); self.gc_timer.setSingleShot(True); self.gc_timer.timeout.connect(ElectrumGui.gc); self.gc_timer.setInterval(500) #msec
         self.nd = None
         self._last_active_window = None  # we remember the last activated ElectrumWindow as a Weak.ref
-        Address.show_cashaddr(self.is_cashaddr())
         # Dark Theme -- ideally set this before any widgets are created.
         self.set_dark_theme_if_needed()
         # /
@@ -927,7 +926,7 @@ class ElectrumGui(QObject, PrintError):
         self.config.set_key('show_cashaddr', on)
         Address.show_cashaddr(on)
         if was != on:
-            self.cashaddr_toggled_signal.emit()
+            self.cashaddr_format_changed_signal.emit()
 
     def is_cashaddr_status_button_hidden(self):
         return bool(self.config.get('hide_cashaddr_button', False))
@@ -938,6 +937,14 @@ class ElectrumGui(QObject, PrintError):
         if was != b:
             self.config.set_key('hide_cashaddr_button', bool(b))
             self.cashaddr_status_button_hidden_signal.emit(b)
+
+    def force_cashaddr_prefix_button(self, b):
+        b = bool(b)
+        was = self.config.get('force_cashaddr_prefix', False)
+        Address.force_cashaddr_prefix(b)
+        if was != b:
+            self.config.set_key('force_cashaddr_prefix', b)
+            self.cashaddr_format_changed_signal.emit()
 
     @property
     def windows_qt_use_freetype(self):

--- a/electroncash_gui/qt/address_dialog.py
+++ b/electroncash_gui/qt/address_dialog.py
@@ -125,7 +125,7 @@ class AddressDialog(PrintError, WindowModalDialog):
 
     def connect_signals(self):
         # connect slots so the embedded history list gets updated whenever the history changes
-        self.parent.gui_object.cashaddr_toggled_signal.connect(self.update_addr)
+        self.parent.gui_object.cashaddr_format_changed_signal.connect(self.update_addr)
         self.parent.history_updated_signal.connect(self.hw.update)
         self.parent.labels_updated_signal.connect(self.hw.update_labels)
         self.parent.network_signal.connect(self.got_verified_tx)
@@ -136,7 +136,7 @@ class AddressDialog(PrintError, WindowModalDialog):
         except TypeError: pass
         try: self.parent.network_signal.disconnect(self.got_verified_tx)
         except TypeError: pass
-        try: self.parent.gui_object.cashaddr_toggled_signal.disconnect(self.update_addr)
+        try: self.parent.gui_object.cashaddr_format_changed_signal.disconnect(self.update_addr)
         except TypeError: pass
         try: self.parent.labels_updated_signal.disconnect(self.hw.update_labels)
         except TypeError: pass

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -69,7 +69,7 @@ class AddressList(MyTreeWidget):
         self._ca_cb_registered = False
         self._ca_minimal_chash_updated_signal.connect(self._ca_update_chash)
 
-        self.parent.gui_object.cashaddr_toggled_signal.connect(self.update)
+        self.parent.gui_object.cashaddr_format_changed_signal.connect(self.update)
         self.parent.ca_address_default_changed_signal.connect(self._ca_on_address_default_change)
 
         if not __class__._cashacct_icon:
@@ -82,7 +82,7 @@ class AddressList(MyTreeWidget):
             self.wallet.network.unregister_callback(self._ca_updated_minimal_chash_callback)
             self._ca_cb_registered = False
         # paranoia -- we have seen Qt not clean up the signal before the object is destroyed on Python 3.7.3 PyQt 5.12.3, see #1531
-        try: self.parent.gui_object.cashaddr_toggled_signal.disconnect(self.update)
+        try: self.parent.gui_object.cashaddr_format_changed_signal.disconnect(self.update)
         except TypeError: pass
         try: self.parent.ca_address_default_changed_signal.disconnect(self._ca_on_address_default_change)
         except TypeError: pass

--- a/electroncash_gui/qt/contact_list.py
+++ b/electroncash_gui/qt/contact_list.py
@@ -76,7 +76,7 @@ class ContactList(PrintError, MyTreeWidget):
         if self.wallet.network:
             self.wallet.network.register_callback(self._ca_callback, ['ca_verified_tx', 'ca_updated_minimal_chash'] )
         self._ca_minimal_chash_updated_signal.connect(self._ca_update_chash)
-        self.parent.gui_object.cashaddr_toggled_signal.connect(self.update)
+        self.parent.gui_object.cashaddr_format_changed_signal.connect(self.update)
 
 
     def clean_up(self):
@@ -85,7 +85,7 @@ class ContactList(PrintError, MyTreeWidget):
         except TypeError: pass
         try: self.do_update_signal.disconnect(self.update)
         except TypeError: pass
-        try: self.parent.gui_object.cashaddr_toggled_signal.disconnect(self.update)
+        try: self.parent.gui_object.cashaddr_format_changed_signal.disconnect(self.update)
         except TypeError: pass
         if self.wallet.network:
             self.wallet.network.unregister_callback(self._ca_callback)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -4664,7 +4664,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def clean_up_connections(self):
         def disconnect_signals():
-            del self.cashaddr_format_changed_signal  # delete alias so it doesn interfere with below
+            del self.cashaddr_toggled_signal  # delete alias so it doesn interfere with below
             for attr_name in dir(self):
                 if attr_name.endswith("_signal"):
                     sig = getattr(self, attr_name)

--- a/electroncash_gui/qt/transaction_dialog.py
+++ b/electroncash_gui/qt/transaction_dialog.py
@@ -323,7 +323,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
                 try: parent.labels_updated_signal.disconnect(self.update_tx_if_in_wallet)
                 except TypeError: pass
                 for slot in self.cashaddr_signal_slots:
-                    try: parent.gui_object.cashaddr_toggled_signal.disconnect(slot)
+                    try: parent.gui_object.cashaddr_format_changed_signal.disconnect(slot)
                     except TypeError: pass
                 self.cashaddr_signal_slots = []
 
@@ -606,7 +606,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         o_text.setTextInteractionFlags(o_text.textInteractionFlags() | Qt.LinksAccessibleByMouse | Qt.LinksAccessibleByKeyboard)
         vbox.addWidget(o_text)
         self.cashaddr_signal_slots.append(self.update_io)
-        self.main_window.gui_object.cashaddr_toggled_signal.connect(self.update_io)
+        self.main_window.gui_object.cashaddr_format_changed_signal.connect(self.update_io)
         self.update_io()
 
     def update_io(self):
@@ -727,6 +727,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
             # /CashAccounts support
             # Mark B. Lundeberg's patented output formatter logic™
             if v is not None:
+                # 42 is the length of a Cash Address without prefix
                 if len(addrstr) > 42: # for long outputs, make a linebreak.
                     cursor.insertBlock()
                     addrstr = '\u21b3'

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -63,7 +63,7 @@ class UTXOList(MyTreeWidget):
         self.setSortingEnabled(True)
         self.wallet = self.parent.wallet
         self.parent.ca_address_default_changed_signal.connect(self._ca_on_address_default_change)
-        self.parent.gui_object.cashaddr_toggled_signal.connect(self.update)
+        self.parent.gui_object.cashaddr_format_changed_signal.connect(self.update)
         self.utxos = list()
         # cache some values to avoid constructing Qt objects for every pass through self.on_update (this is important for large wallets)
         self.monospaceFont = QFont(MONOSPACE_FONT)
@@ -80,7 +80,7 @@ class UTXOList(MyTreeWidget):
         self.cleaned_up = True
         try: self.parent.ca_address_default_changed_signal.disconnect(self._ca_on_address_default_change)
         except TypeError: pass
-        try: self.parent.gui_object.cashaddr_toggled_signal.disconnect(self.update)
+        try: self.parent.gui_object.cashaddr_format_changed_signal.disconnect(self.update)
         except TypeError: pass
 
     def if_not_dead(func):


### PR DESCRIPTION
Rename cashaddr_toggled_signal -> cashaddr_format_changed_signal and use
it for both legacy/cashaddr toggle and prefix toggle.
The prefix will be shown in both the qt gui and the RPC responses.