### PR TITLE
Add new option: "Retire unused change addresses" 

### DIFF
--- a/electroncash/network.py
+++ b/electroncash/network.py
@@ -34,7 +34,7 @@ from collections import defaultdict
 import threading
 import socket
 import json
-from typing import Dict
+from typing import Dict, Iterable, Tuple
 
 import socks
 from . import util
@@ -254,7 +254,7 @@ class Network(util.DaemonThread):
         self.tor_controller.active_port_changed.append(self.on_tor_port_changed)
         self.tor_controller.start()
 
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
         # locks: if you need to take multiple ones, acquire them in the order they are defined here!
         self.interface_lock = threading.RLock()            # <- re-entrant
         self.pending_sends_lock = threading.Lock()
@@ -492,7 +492,7 @@ class Network(util.DaemonThread):
         old_reqs = self.unanswered_requests
         self.unanswered_requests = {}
         for m_id, request in old_reqs.items():
-            message_id = self.queue_request(request[0], request[1], callback = request[2])
+            message_id = self.queue_request(request[0], request[1], callback=request[2])
             assert message_id is not None
         self.queue_request('server.banner', [])
         self.queue_request('server.donation_address', [])
@@ -857,7 +857,8 @@ class Network(util.DaemonThread):
         for callback in callbacks:
             callback(response)
 
-    def get_index(self, method, params):
+    @staticmethod
+    def get_index(method, params):
         """ hashable index for subscriptions and cache"""
         return str(method) + (':' + str(params[0]) if params else '')
 
@@ -915,13 +916,47 @@ class Network(util.DaemonThread):
                 for sh in scripthashes]
         self.send(msgs, callback)
 
+    def unsubscribe_from_scripthashes(self, scripthashes: Iterable[str], callback):
+        method_sub = 'blockchain.scripthash.subscribe'
+        msgs = []
+        for sh in scripthashes:
+            params = [sh]
+            k = self.get_index(method_sub, params)
+            with self.lock:
+                # Clear any potential previously-queued subscription request
+                self.cancel_requests(callback, method=method_sub, params=params)
+                # See if this would have been the last callback
+                callbacks = self.subscriptions.get(k, None)
+                if isinstance(callbacks, (list, set)):
+                    # "refct" of the subscription is now 0
+                    try:
+                        callbacks.remove(callback)
+                    except (ValueError, KeyError):
+                        pass
+                if not callbacks:
+                    msgs.append(('blockchain.scripthash.unsubscribe', params))
+                    self.subscriptions.pop(k, None)
+                    self.subscribed_addresses.discard(sh)
+                    with self.interface_lock:
+                        self.sub_cache.pop(k, None)
+        if msgs:
+            def unsub_callback(response):
+                method = response.get('method')
+                result = response.get('result')
+                sh = response.get('params', [None])[0]
+                self.print_error(f"Got {method} response for {sh}: {result}")
+            self.print_error(f"Sending unsub for {len(msgs)} scripthash(es) ...")
+            self.send(msgs, unsub_callback)
+
     def request_scripthash_history(self, sh, callback):
         self.send([('blockchain.scripthash.get_history', [sh])], callback)
 
     def send(self, messages, callback):
         """Messages is a list of (method, params) tuples"""
         messages = list(messages)
-        if messages: # Guard against empty message-list which is a no-op and just wastes CPU to enque/dequeue (not even callback is called). I've seen the code send empty message lists before in synchronizer.py
+        # Guard against empty message-list which is a no-op and just wastes CPU to enqueue/dequeue (not even callback is
+        # called). I've seen the code send empty message lists before in synchronizer.py
+        if messages:
             with self.pending_sends_lock:
                 self.pending_sends.append((messages, callback))
 
@@ -941,7 +976,7 @@ class Network(util.DaemonThread):
                 if method.endswith('.subscribe'):
                     k = self.get_index(method, params)
                     # add callback to list
-                    l = self.subscriptions[k] # <-- it's a defaultdict(list)
+                    l = self.subscriptions[k]  # <-- it's a defaultdict(list)
                     if callback not in l:
                         l.append(callback)
                     # check cached response for subscriptions
@@ -950,22 +985,43 @@ class Network(util.DaemonThread):
                     util.print_error("cache hit", k)
                     callback(r)
                 else:
-                    self.queue_request(method, params, callback = callback)
+                    self.queue_request(method, params, callback=callback)
 
-    def _cancel_pending_sends(self, callback):
+    def _cancel_pending_sends(self, callback, *, method=None, params=None) -> Tuple[int, int]:
         ct = 0
+        nmsgs = 0
         with self.pending_sends_lock:
+            idx = 0
             for item in self.pending_sends.copy():
+                do_delete = False
                 messages, _callback = item
                 if callback == _callback:
-                    self.pending_sends.remove(item)
+                    if method is None and params is None:
+                        do_delete = True
+                        nmsgs += len(messages)
+                    else:
+                        # Clean out pending sends that match "method" and/or "params"
+                        idx2 = 0
+                        for _method, _params in messages.copy():
+                            if (method is None or _method == method) and (params is None or _params == params):
+                                del messages[idx2]
+                                nmsgs += 1
+                            else:
+                                idx2 += 1
+                        if not messages:
+                            # Set of messages is empty, delete the entire blob
+                            do_delete = True
+                if do_delete:
+                    del self.pending_sends[idx]
                     ct += 1
-        return ct
+                else:
+                    idx += 1
+        return ct, nmsgs
 
     def unsubscribe(self, callback):
-        '''Unsubscribe a callback to free object references to enable GC.
+        """Unsubscribe a callback to free object references to enable GC.
         It is advised that this function only be called from the network thread
-        to avoid race conditions.'''
+        to avoid race conditions."""
         # Note: we can't unsubscribe from the server, so if we receive
         # subsequent notifications, they will be safely ignored as
         # no callbacks will exist to process them. For subscriptions we will
@@ -980,27 +1036,34 @@ class Network(util.DaemonThread):
                         # remove empty list
                         self.subscriptions.pop(k, None)
                     ct += 1
-        ct2 = self._cancel_pending_sends(callback)
-        if ct or ct2:
+        ct2, ct3 = self._cancel_pending_sends(callback)
+        if ct or ct2 or ct3:
             qname = getattr(callback, '__qualname__', '<unknown>')
-            self.print_error("Removed {} subscription callbacks and {} pending sends for callback: {}".format(ct, ct2, qname))
+            self.print_error(f"Removed {ct} subscription callbacks and {ct2} pending sends (nmsgs={ct3}) for"
+                             f" callback: {qname}")
 
-    def cancel_requests(self, callback):
-        '''Remove a callback to free object references to enable GC.
+    def cancel_requests(self, callback, *, method=None, params=None):
+        """Remove a callback to free object references to enable GC.
         It is advised that this function only be called from the network thread
-        to avoid race conditions.'''
+        to avoid race conditions."""
         # If the interface ends up answering these requests, they will just
         # be safely ignored. This is better than the alternative which is to
         # keep references to an object that declared itself defunct.
         ct = 0
         for message_id, client_req in self.unanswered_requests.copy().items():
-            if callback == client_req[2]:
-                self.unanswered_requests.pop(message_id, None) # guard against race conditions here. Note: this usually is called from the network thread but who knows what future programmers may do. :)
-                ct += 1
-        ct2 = self._cancel_pending_sends(callback)
-        if ct or ct2:
+            _method, _params, _callback = client_req
+            if callback == _callback:
+                do_delete = (method is None or _method == method) and (params is None or _params == params)
+                if do_delete:
+                    # guard against race conditions here. Note: this usually is called from the network thread but who
+                    # knows what future programmers may do. :)
+                    self.unanswered_requests.pop(message_id, None)
+                    ct += 1
+        ct2, ct3 = self._cancel_pending_sends(callback, method=method, params=params)
+        if ct or ct2 or ct3:
             qname = getattr(callback, '__qualname__', repr(callback))
-            self.print_error("Removed {} unanswered client requests and {} pending sends for callback: {}".format(ct, ct2, qname))
+            self.print_error(f"Removed {ct} unanswered client requests and {ct2} pending sends (nmsgs={ct3}) for"
+                             f" callback: {qname}")
 
     def connection_down(self, server, blacklist=False):
         '''A connection to server either went down, or was never made.

--- a/electroncash/network.py
+++ b/electroncash/network.py
@@ -911,7 +911,7 @@ class Network(util.DaemonThread):
             # Response is now in canonical form
             self.process_response(interface, request, response, callbacks)
 
-    def subscribe_to_scripthashes(self, scripthashes, callback):
+    def subscribe_to_scripthashes(self, scripthashes: Iterable[str], callback):
         msgs = [('blockchain.scripthash.subscribe', [sh])
                 for sh in scripthashes]
         self.send(msgs, callback)

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -26,8 +26,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from collections import defaultdict
 from threading import Lock
-from typing import Dict, Iterable, Set, Tuple
+from typing import DefaultDict, Dict, Iterable, Optional, Set, Tuple
 import hashlib
 import sys
 import traceback
@@ -35,7 +36,7 @@ import warnings
 
 from .address import Address
 from .transaction import Transaction
-from .util import ThreadJob, bh2u
+from .util import ThreadJob, bh2u, Monotonic
 from . import networks
 from .bitcoin import InvalidXKeyFormat
 
@@ -50,7 +51,7 @@ class Synchronizer(ThreadJob):
 
     External interface: __init__() and add() member functions."""
 
-    def __init__(self, wallet, network):
+    def __init__(self, wallet, network, *, limit_change_subs=0):
         self.wallet = wallet
         self.network = network
         self.cleaned_up = False
@@ -62,12 +63,24 @@ class Synchronizer(ThreadJob):
             # This is because we require ordered dictionaries.
             warnings.warn("CPython 3.6+ or Python 3.7+ is required for class Synchronizer to operate correctly."
                           " Please switch Python versions!", RuntimeWarning, stacklevel=2)
-        self.new_addresses_for_change: Dict[Address, type(None)] = dict()  # Basically, an ordered set of Addresses
-        # Entries are (tx_hash, tx_height) tuples
-        self.requested_tx = {}
+        # Basically, an ordered set of Addresses
+        self.new_addresses_for_change: Dict[Address, None] = dict()
+        # Mapping of tx_hash -> tx_height
+        self.requested_tx: Dict[str, int] = dict()
+        # Mapping of scripthash -> set of requested tx_hashes
+        self.requested_tx_by_sh: DefaultDict[str, Set[str]] = defaultdict(set)
         self.requested_histories = {}
         self.requested_hashes = set()
-        self.h2addr = {}
+        self.change_sh_ctr = Monotonic(locking=True)
+        # all known change address scripthashes -> their order seen
+        self.change_scripthashes: DefaultDict[str, int] = defaultdict(self.change_sh_ctr)
+        # set of all change address scripthashes that we are currently subscribed to
+        self.change_subs = set()
+        # set of all "used", 0 balance change sh's
+        self.change_subs_expiry_candidates: Set[str] = set()
+        # mapping of scripthash -> Address
+        self.h2addr: Dict[str, Address] = {}
+        self.limit_change_subs = limit_change_subs
         self.lock = Lock()
         self._tick_ct = 0
         self.initialize()
@@ -86,8 +99,7 @@ class Synchronizer(ThreadJob):
                 self.print_error("response error:", response)
 
     def is_up_to_date(self):
-        return (not self.requested_tx and not self.requested_histories
-                and not self.requested_hashes)
+        return not self.requested_tx and not self.requested_histories and not self.requested_hashes
 
     def _release(self):
         """ Called from the Network (DaemonThread) -- to prevent race conditions
@@ -117,10 +129,19 @@ class Synchronizer(ThreadJob):
 
     def subscribe_to_addresses(self, addresses: Iterable[Address], *, for_change=False):
         hashes2addr = {addr.to_scripthash_hex(): addr for addr in addresses}
+        if not hashes2addr:
+            return  # Nothing to do!
         # Keep a hash -> address mapping
         self.h2addr.update(hashes2addr)
+        hashes_set = set(hashes2addr.keys())
+        self.requested_hashes |= hashes_set
+        if for_change and self.limit_change_subs:
+            for sh in hashes2addr.keys():  # Iterate in order (dicts are ordered)
+                # This is a defaultdict, accessing it will add a counted item if not there
+                self.change_scripthashes[sh]
+            self.change_subs |= hashes_set
+        # Nit: we use hashes2addr.keys() here to preserve order
         self.network.subscribe_to_scripthashes(hashes2addr.keys(), self.on_address_status)
-        self.requested_hashes |= set(hashes2addr.keys())
 
     @staticmethod
     def get_status(hist: Iterable[Tuple[str, int]]):
@@ -130,6 +151,30 @@ class Synchronizer(ThreadJob):
         for tx_hash, height in hist:
             status.extend(f"{tx_hash}:{height:d}:".encode('ascii'))
         return bh2u(hashlib.sha256(status).digest())
+
+    def check_change_sh(self, sh: str):
+        if not self.limit_change_subs:
+            # If not limiting change subs, this subsystem is not used so no need to maintain data structures below...
+            return
+        if (not sh or sh not in self.change_scripthashes or sh in self.requested_tx_by_sh
+                or sh in self.requested_histories or sh not in (self.change_subs - self.requested_hashes)):
+            # this scripthash is either not change or is not subbed or is not yet "stable", discard and abort early
+            self.change_subs_expiry_candidates.discard(sh)
+            return
+        addr = self.h2addr.get(sh)
+        if not addr:
+            return
+        hlen = len(self.wallet.get_address_history(addr))  # O(1) lookup into a dict
+        if hlen == 2:  # Only "expire" old change address with precisely 1 input tx and 1 spending tx
+            bal = self.wallet.get_addr_balance(addr)  # Potentially fast lookup since addr_balance gets cached
+        else:
+            bal = None
+        if bal is not None and not any(bal):
+            # Candidate for expiry: has history of size 2 and also 0 balance
+            self.change_subs_expiry_candidates.add(sh)
+        else:
+            # Not a candidate for expiry
+            self.change_subs_expiry_candidates.discard(sh)
 
     def on_address_status(self, response):
         if self.cleaned_up:
@@ -149,10 +194,11 @@ class Synchronizer(ThreadJob):
         if self.get_status(history) != result:
             if self.requested_histories.get(scripthash) is None:
                 self.requested_histories[scripthash] = result
-                self.network.request_scripthash_history(scripthash,
-                                                        self.on_address_history)
+                self.network.request_scripthash_history(scripthash, self.on_address_history)
         # remove addr from list only after it is added to requested_histories
         self.requested_hashes.discard(scripthash)  # Notifications won't be in
+        # See if now the change address needs to be recategorized
+        self.check_change_sh(scripthash)
 
     def on_address_history(self, response):
         if self.cleaned_up:
@@ -183,9 +229,11 @@ class Synchronizer(ThreadJob):
             # Store received history
             self.wallet.receive_history_callback(addr, hist, tx_fees)
             # Request transactions we don't have
-            self.request_missing_txs(hist)
+            self.request_missing_txs(hist, scripthash)
+        # Check that this scripthash is a candidate for purge
+        self.check_change_sh(scripthash)
 
-    def tx_response(self, response):
+    def tx_response(self, response, scripthash: Optional[str]):
         if self.cleaned_up:
             return
         params, result, error = self.parse_response(response)
@@ -194,37 +242,49 @@ class Synchronizer(ThreadJob):
         # on bad server reply or reorg.
         # see Electrum commit 7b8114f865f644c5611c3bb849c4f4fc6ce9e376 fix#5122
         tx_height = self.requested_tx.pop(tx_hash, 0)
-        if error:
-            # was some response error. note we popped the tx already
-            # we assume a blockchain reorg happened and tx disappeared.
-            self.print_error("error for tx_hash {}, skipping".format(tx_hash))
-            return
-        try:
-            tx = Transaction(result)
-            tx.deserialize()
-        except Exception:
-            traceback.print_exc()
-            self.print_msg("cannot deserialize transaction, skipping", tx_hash)
-            return
-        # Paranoia - in case server is malicious and serves bogus tx.
-        # We must do this because verifier verifies merkle_proof based on this
-        # tx_hash.
-        chk_txid = tx.txid_fast()
-        if tx_hash != chk_txid:
-            self.print_error("received tx does not match expected txid ({} != {}), skipping"
-                             .format(tx_hash, chk_txid))
-            return
-        del chk_txid
-        # /Paranoia
-        self.wallet.receive_tx_callback(tx_hash, tx, tx_height)
-        self.print_error("received tx %s height: %d bytes: %d" %
-                         (tx_hash, tx_height, len(tx.raw)))
-        # callbacks
-        self.network.trigger_callback('new_transaction', tx, self.wallet)
-        if not self.requested_tx:
-            self.network.trigger_callback('wallet_updated', self.wallet)
+        # Maintain the requested_tx_by_sh dict
+        if scripthash in self.requested_tx_by_sh:
+            self.requested_tx_by_sh[scripthash].discard(tx_hash)
+            if not self.requested_tx_by_sh[scripthash]:
+                del self.requested_tx_by_sh[scripthash]
 
-    def request_missing_txs(self, hist: Iterable[Tuple[str, int]]):
+        def process():
+            if error:
+                # was some response error. note we popped the tx already
+                # we assume a blockchain reorg happened and tx disappeared.
+                self.print_error("error for tx_hash {}, skipping".format(tx_hash))
+                return
+            try:
+                tx = Transaction(result)
+                tx.deserialize()
+            except Exception:
+                traceback.print_exc()
+                self.print_msg("cannot deserialize transaction, skipping", tx_hash)
+                return
+            # Paranoia - in case server is malicious and serves bogus tx.
+            # We must do this because verifier verifies merkle_proof based on this
+            # tx_hash.
+            chk_txid = tx.txid_fast()
+            if tx_hash != chk_txid:
+                self.print_error("received tx does not match expected txid ({} != {}), skipping"
+                                 .format(tx_hash, chk_txid))
+                return
+            del chk_txid
+            # /Paranoia
+            self.wallet.receive_tx_callback(tx_hash, tx, tx_height)
+            self.print_error("received tx %s height: %d bytes: %d" %
+                             (tx_hash, tx_height, len(tx.raw)))
+            # callbacks
+            self.network.trigger_callback('new_transaction', tx, self.wallet)
+            if not self.requested_tx:
+                self.network.trigger_callback('wallet_updated', self.wallet)
+
+        process()
+
+        # wallet balance updated for this sh, check if it is a candidate for purge
+        self.check_change_sh(scripthash)
+
+    def request_missing_txs(self, hist: Iterable[Tuple[str, int]], scripthash: Optional[str]) -> bool:
         # "hist" is a list of [tx_hash, tx_height] lists
         requests = []
         for tx_hash, tx_height in hist:
@@ -234,14 +294,24 @@ class Synchronizer(ThreadJob):
                 continue
             requests.append(('blockchain.transaction.get', [tx_hash]))
             self.requested_tx[tx_hash] = tx_height
-        self.network.send(requests, self.tx_response)
+            if self.limit_change_subs and scripthash is not None:
+                self.requested_tx_by_sh[scripthash].add(tx_hash)
+        if requests:
+            self.network.send(requests, lambda response: self.tx_response(response, scripthash))
+            return True
+        return False
 
     def initialize(self):
         """ Check the initial state of the wallet.  Subscribe to all its
         addresses, and request any transactions in its address history
         we don't have. """
-        for history in self.wallet.get_history_values():
-            self.request_missing_txs(history)
+        if self.limit_change_subs:
+            for addr, history in self.wallet.get_history_items():
+                self.request_missing_txs(history, addr.to_scripthash_hex())
+        else:
+            # If not using the limit_change_subs feature, save CPU cycles by not computing scripthashes
+            for history in self.wallet.get_history_values():
+                self.request_missing_txs(history, None)
 
         if self.requested_tx:
             self.print_error("missing tx", self.requested_tx)

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -79,17 +79,17 @@ class Synchronizer(ThreadJob):
         self.change_subs: Set[str] = set()
         # set of all "used", 0 balance change sh's
         self.change_subs_expiry_candidates: Set[str] = set()
+        # mapping of scripthash -> Address
+        self.h2addr: Dict[str, Address] = {}
+        self.lock = Lock()
+        self._tick_ct = 0
+        self.limit_change_subs = max(self.wallet.limit_change_addr_subs, 0)  # Disallow negatives; they create problems
         # set of all change address scripthashes that are retired and should be ignored
         if self.limit_change_subs:
             self.change_scripthashes_that_are_retired = set(self.wallet.storage.get(
                 'synchronizer_retired_change_scripthashes', []))
         else:
             self.change_scripthashes_that_are_retired = set()
-        # mapping of scripthash -> Address
-        self.h2addr: Dict[str, Address] = {}
-        self.lock = Lock()
-        self._tick_ct = 0
-        self.limit_change_subs = max(self.wallet.limit_change_addr_subs, 0)  # Disallow negatives; they create problems
         self._initialize()
 
     def clear_retired_change_addrs(self):

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -405,6 +405,11 @@ class Synchronizer(ThreadJob):
             if up_to_date != self.wallet.is_up_to_date():
                 self.wallet.set_up_to_date(up_to_date)
                 self.network.trigger_callback('wallet_updated', self.wallet)
+
+            # 4. Every 50 ticks (approx every 5 seconds), check that we are not over the change subs limit
+            if self.limit_change_subs and up_to_date and self._tick_ct % 50 == 0:
+                self._check_change_subs_limits()
+
         except InvalidXKeyFormat:
             # Workaround to buggy testnet wallets that had the wrong xpub..
             # This is here so that the network thread doesn't get blown up when

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -95,7 +95,7 @@ class Synchronizer(ThreadJob):
         unregister ourselves as a job from within the Network thread itself. """
         self._need_release = False
         self.cleaned_up = True
-        self.network.unsubscribe(self.on_address_status)
+        self.network.unsubscribe_from_scripthashes(self.h2addr.keys(), self.on_address_status)
         self.network.cancel_requests(self.on_address_status)
         self.network.cancel_requests(self.on_address_history)
         self.network.cancel_requests(self.tx_response)

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -3,6 +3,9 @@
 # Electrum - lightweight Bitcoin client
 # Copyright (C) 2014 Thomas Voegtlin
 #
+# Electron Cash - Bitcoin Cash thin client
+# Copyright (C) 2017-2022 The Electron Cash Developers
+#
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
 # (the "Software"), to deal in the Software without restriction,
@@ -24,6 +27,7 @@
 # SOFTWARE.
 
 from threading import Lock
+from typing import Iterable, Tuple
 import hashlib
 import traceback
 
@@ -34,15 +38,14 @@ from .bitcoin import InvalidXKeyFormat
 
 
 class Synchronizer(ThreadJob):
-    '''The synchronizer keeps the wallet up-to-date with its set of
+    """The synchronizer keeps the wallet up-to-date with its set of
     addresses and their transactions.  It subscribes over the network
     to wallet addresses, gets the wallet to generate new addresses
     when necessary, requests the transaction history of any addresses
     we don't have the full history of, and requests binary transaction
     data of any transactions the wallet doesn't have.
 
-    External interface: __init__() and add() member functions.
-    '''
+    External interface: __init__() and add() member functions."""
 
     def __init__(self, wallet, network):
         self.wallet = wallet
@@ -77,9 +80,9 @@ class Synchronizer(ThreadJob):
                 and not self.requested_hashes)
 
     def _release(self):
-        ''' Called from the Network (DaemonThread) -- to prevent race conditions
+        """ Called from the Network (DaemonThread) -- to prevent race conditions
         with network, we remove data structures related to the network and
-        unregister ourselves as a job from within the Network thread itself. '''
+        unregister ourselves as a job from within the Network thread itself. """
         self._need_release = False
         self.cleaned_up = True
         self.network.unsubscribe(self.on_address_status)
@@ -89,12 +92,12 @@ class Synchronizer(ThreadJob):
         self.network.remove_jobs([self])
 
     def release(self):
-        ''' Called from main thread, enqueues a 'release' to happen in the
-        Network thread. '''
+        """ Called from main thread, enqueues a 'release' to happen in the
+        Network thread. """
         self._need_release = True
 
     def add(self, address):
-        '''This can be called from the proxy or GUI threads.'''
+        """ This can be called from the proxy or GUI threads. """
         with self.lock:
             self.new_addresses.add(address)
 
@@ -105,13 +108,14 @@ class Synchronizer(ThreadJob):
         self.network.subscribe_to_scripthashes(hashes, self.on_address_status)
         self.requested_hashes |= set(hashes)
 
-    def get_status(self, h):
-        if not h:
+    @staticmethod
+    def get_status(hist: Iterable[Tuple[str, int]]):
+        if not hist:
             return None
-        status = ''
-        for tx_hash, height in h:
-            status += tx_hash + ':%d:' % height
-        return bh2u(hashlib.sha256(status.encode('ascii')).digest())
+        status = bytearray()
+        for tx_hash, height in hist:
+            status.extend(f"{tx_hash}:{height:d}:".encode('ascii'))
+        return bh2u(hashlib.sha256(status).digest())
 
     def on_address_status(self, response):
         if self.cleaned_up:
@@ -208,8 +212,7 @@ class Synchronizer(ThreadJob):
         if not self.requested_tx:
             self.network.trigger_callback('wallet_updated', self.wallet)
 
-
-    def request_missing_txs(self, hist):
+    def request_missing_txs(self, hist: Iterable[Tuple[str, int]]):
         # "hist" is a list of [tx_hash, tx_height] lists
         requests = []
         for tx_hash, tx_height in hist:
@@ -221,14 +224,11 @@ class Synchronizer(ThreadJob):
             self.requested_tx[tx_hash] = tx_height
         self.network.send(requests, self.tx_response)
 
-
     def initialize(self):
-        '''Check the initial state of the wallet.  Subscribe to all its
+        """ Check the initial state of the wallet.  Subscribe to all its
         addresses, and request any transactions in its address history
-        we don't have.
-        '''
-        # FIXME: encapsulation
-        for history in self.wallet._history.values():
+        we don't have. """
+        for history in self.wallet.get_history_values():
             self.request_missing_txs(history)
 
         if self.requested_tx:
@@ -236,7 +236,7 @@ class Synchronizer(ThreadJob):
         self.subscribe_to_addresses(self.wallet.get_addresses())
 
     def run(self):
-        '''Called from the network proxy thread main loop.'''
+        """ Called from the network proxy thread main loop. """
         if self._need_release:
             self._release()
         if self.cleaned_up:
@@ -268,7 +268,9 @@ class Synchronizer(ThreadJob):
             # encountering such wallets.
             # See #1164
             if networks.net.TESTNET:
-                self.print_stderr("*** ERROR *** Bad format testnet xkey detected. Synchronizer will no longer proceed to synchronize. Please regenerate this testnet wallet from seed to fix this error.")
+                self.print_stderr("*** ERROR *** Bad format testnet xkey detected. Synchronizer will no longer"
+                                  " proceed to synchronize. Please regenerate this testnet wallet from seed to"
+                                  " fix this error.")
                 self._release()
             else:
                 raise

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -112,14 +112,15 @@ class Synchronizer(ThreadJob):
             if not for_change:
                 self.new_addresses.add(address)
             else:
+                # we use a dict here to preserve order -- this is an "ordered set"
                 self.new_addresses_for_change[address] = None
 
     def subscribe_to_addresses(self, addresses: Iterable[Address], *, for_change=False):
-        hashes = [addr.to_scripthash_hex() for addr in addresses]
+        hashes2addr = {addr.to_scripthash_hex(): addr for addr in addresses}
         # Keep a hash -> address mapping
-        self.h2addr.update({hash: addr for hash, addr in zip(hashes, addresses)})
-        self.network.subscribe_to_scripthashes(hashes, self.on_address_status)
-        self.requested_hashes |= set(hashes)
+        self.h2addr.update(hashes2addr)
+        self.network.subscribe_to_scripthashes(hashes2addr.keys(), self.on_address_status)
+        self.requested_hashes |= set(hashes2addr.keys())
 
     @staticmethod
     def get_status(hist: Iterable[Tuple[str, int]]):

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -52,6 +52,7 @@ class Synchronizer(ThreadJob):
     External interface: __init__() and add() member functions."""
 
     def __init__(self, wallet, network, *, limit_change_subs=0):
+        assert limit_change_subs >= 0  # Disallow negative values here as they will create problems
         self.wallet = wallet
         self.network = network
         self.cleaned_up = False
@@ -75,7 +76,7 @@ class Synchronizer(ThreadJob):
         # all known change address scripthashes -> their order seen
         self.change_scripthashes: DefaultDict[str, int] = defaultdict(self.change_sh_ctr)
         # set of all change address scripthashes that we are currently subscribed to
-        self.change_subs = set()
+        self.change_subs: Set[str] = set()
         # set of all "used", 0 balance change sh's
         self.change_subs_expiry_candidates: Set[str] = set()
         # mapping of scripthash -> Address
@@ -127,6 +128,30 @@ class Synchronizer(ThreadJob):
                 # we use a dict here to preserve order -- this is an "ordered set"
                 self.new_addresses_for_change[address] = None
 
+    def check_change_subs_limits(self):
+        if not self.limit_change_subs:
+            return
+        active = self.change_subs_active
+        ctr = len(active) - self.limit_change_subs
+        if ctr <= 0:
+            return
+        candidates = sorted(self.change_subs_expiry_candidates, key=lambda x: self.change_scripthashes.get(x, 2**64))
+        unsubs = []
+        for scripthash in candidates:
+            if ctr <= 0:
+                break
+            if scripthash not in active:
+                continue
+            unsubs.append(scripthash)
+            self.change_subs_expiry_candidates.discard(scripthash)
+            self.change_subs.discard(scripthash)
+            ctr -= 1
+        if unsubs:
+            self.print_error(f"change_subs limit reached ({self.limit_change_subs}), unsubscribing from"
+                             f" {len(unsubs)} old change scripthashes,"
+                             f" change scripthash subs ct now: {len(self.change_subs)}")
+            self.network.unsubscribe_from_scripthashes(unsubs, self.on_address_status)
+
     def subscribe_to_addresses(self, addresses: Iterable[Address], *, for_change=False):
         hashes2addr = {addr.to_scripthash_hex(): addr for addr in addresses}
         if not hashes2addr:
@@ -142,6 +167,8 @@ class Synchronizer(ThreadJob):
             self.change_subs |= hashes_set
         # Nit: we use hashes2addr.keys() here to preserve order
         self.network.subscribe_to_scripthashes(hashes2addr.keys(), self.on_address_status)
+        if for_change:
+            self.check_change_subs_limits()
 
     @staticmethod
     def get_status(hist: Iterable[Tuple[str, int]]):
@@ -152,12 +179,16 @@ class Synchronizer(ThreadJob):
             status.extend(f"{tx_hash}:{height:d}:".encode('ascii'))
         return bh2u(hashlib.sha256(status).digest())
 
+    @property
+    def change_subs_active(self) -> Set[str]:
+        return self.change_subs - self.requested_hashes
+
     def check_change_sh(self, sh: str):
         if not self.limit_change_subs:
             # If not limiting change subs, this subsystem is not used so no need to maintain data structures below...
             return
         if (not sh or sh not in self.change_scripthashes or sh in self.requested_tx_by_sh
-                or sh in self.requested_histories or sh not in (self.change_subs - self.requested_hashes)):
+                or sh in self.requested_histories or sh not in self.change_subs_active):
             # this scripthash is either not change or is not subbed or is not yet "stable", discard and abort early
             self.change_subs_expiry_candidates.discard(sh)
             return
@@ -315,8 +346,38 @@ class Synchronizer(ThreadJob):
 
         if self.requested_tx:
             self.print_error("missing tx", self.requested_tx)
+
         self.subscribe_to_addresses(self.wallet.get_receiving_addresses())
-        self.subscribe_to_addresses(self.wallet.get_change_addresses(), for_change=True)
+        if not self.limit_change_subs:
+            self.subscribe_to_addresses(self.wallet.get_change_addresses(), for_change=True)
+        else:
+            # Subs limiting for change addrs in place, do it in the network thread next time we run, grabbing
+            # self.limit_change_subs addresses at a time
+            with self.lock:
+                self.new_addresses_for_change.update({addr: None for addr in self.wallet.get_change_addresses()})
+
+    def pop_new_addresses(self) -> Tuple[Set[Address], Iterable[Address]]:
+        with self.lock:
+            # Pop all queued receiving
+            addresses = self.new_addresses
+            self.new_addresses = set()
+            if not self.limit_change_subs:
+                # Pop all queued change addrs
+                addresses_for_change = self.new_addresses_for_change.keys()
+                self.new_addresses_for_change = dict()
+            else:
+                # Change address subs limiting in place, only grab first self.limit_change_subs new change addresses
+                addresses_for_change = list(self.new_addresses_for_change.keys())[:self.limit_change_subs]
+                # only grab change addresses if this set + queued subs requests are under the limit
+                if len(self.requested_hashes) < self.limit_change_subs:
+                    addresses_for_change = addresses_for_change[:self.limit_change_subs - len(self.requested_hashes)]
+                    for addr in addresses_for_change:
+                        # delete the keys we just grabbed
+                        self.new_addresses_for_change.pop(addr, None)
+                else:
+                    # Do nothing this time around
+                    addresses_for_change = []
+        return addresses, addresses_for_change
 
     def run(self):
         """ Called from the network proxy thread main loop. """
@@ -334,11 +395,7 @@ class Synchronizer(ThreadJob):
             self.wallet.synchronize()
 
             # 2. Subscribe to new addresses
-            with self.lock:
-                addresses = self.new_addresses
-                self.new_addresses = set()
-                addresses_for_change = list(self.new_addresses_for_change.keys())
-                self.new_addresses_for_change = dict()
+            addresses, addresses_for_change = self.pop_new_addresses()
             if addresses:
                 self.subscribe_to_addresses(addresses)
             if addresses_for_change:

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -172,10 +172,6 @@ class Synchronizer(ThreadJob):
         # tx_fees
         tx_fees = [(item['tx_hash'], item.get('fee')) for item in result]
         tx_fees = dict(filter(lambda x:x[1] is not None, tx_fees))
-        # Note if the server hasn't been patched to sort the items properly
-        if hist != sorted(hist, key=lambda x:x[1]):
-            which = self.network.interface or self
-            which.print_error("serving improperly sorted address histories")
         # Check that txids are unique
         if len(hashes) != len(result):
             self.print_error("error: server history has non-unique txids: {}"

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -54,6 +54,7 @@ class Synchronizer(ThreadJob):
     def __init__(self, wallet, network):
         self.wallet = wallet
         self.network = network
+        assert self.wallet and self.wallet.storage and self.network
         self.cleaned_up = False
         self._need_release = False
         self.new_addresses: Set[Address] = set()
@@ -78,12 +79,22 @@ class Synchronizer(ThreadJob):
         self.change_subs: Set[str] = set()
         # set of all "used", 0 balance change sh's
         self.change_subs_expiry_candidates: Set[str] = set()
+        # set of all change address scripthashes that are retired and should be ignored
+        self.change_scripthashes_that_are_retired = set(self.wallet.storage.get(
+            'synchronizer_retired_change_scripthashes', []))
         # mapping of scripthash -> Address
         self.h2addr: Dict[str, Address] = {}
         self.lock = Lock()
         self._tick_ct = 0
         self.limit_change_subs = max(self.wallet.limit_change_addr_subs, 0)  # Disallow negatives; they create problems
         self._initialize()
+
+    def clear_retired_change_addrs(self):
+        self.change_scripthashes_that_are_retired.clear()
+
+    def save(self):
+        self.wallet.storage.put('synchronizer_retired_change_scripthashes',
+                                list(self.change_scripthashes_that_are_retired))
 
     def diagnostic_name(self):
         return f"{__class__.__name__}/{self.wallet.diagnostic_name()}"
@@ -143,6 +154,7 @@ class Synchronizer(ThreadJob):
             if scripthash not in active:
                 continue
             unsubs.append(scripthash)
+            self.change_scripthashes_that_are_retired.add(scripthash)
             self.change_subs_expiry_candidates.discard(scripthash)
             self.change_subs.discard(scripthash)
             ctr -= 1
@@ -159,16 +171,25 @@ class Synchronizer(ThreadJob):
         # Keep a hash -> address mapping
         self.h2addr.update(hashes2addr)
         hashes_set = set(hashes2addr.keys())
-        self.requested_hashes |= hashes_set
+        skipped_ct = 0
         if for_change and self.limit_change_subs:
-            for sh in hashes2addr.keys():  # Iterate in order (dicts are ordered)
+            for sh in list(hashes2addr.keys()):  # Iterate in order (dicts are ordered)
                 # This is a defaultdict, accessing it will add a counted item if not there
                 self.change_scripthashes[sh]
+                if sh in self.change_scripthashes_that_are_retired:
+                    # this scripthash was "retired", do not subscribe to it
+                    hashes_set.discard(sh)
+                    hashes2addr.pop(sh, None)
+                    skipped_ct += 1
             self.change_subs |= hashes_set
+        self.requested_hashes |= hashes_set
         # Nit: we use hashes2addr.keys() here to preserve order
         self.network.subscribe_to_scripthashes(hashes2addr.keys(), self._on_address_status)
         if for_change:
             self._check_change_subs_limits()
+            if skipped_ct:
+                self.print_error(f"Skipped {skipped_ct} change address scripthashes because they are in the"
+                                 f" \"retired\" set (set size: {len(self.change_scripthashes_that_are_retired)})")
 
     @staticmethod
     def get_status(hist: Iterable[Tuple[str, int]]):

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -83,12 +83,12 @@ class Synchronizer(ThreadJob):
         self.lock = Lock()
         self._tick_ct = 0
         self.limit_change_subs = max(self.wallet.limit_change_addr_subs, 0)  # Disallow negatives; they create problems
-        self.initialize()
+        self._initialize()
 
     def diagnostic_name(self):
         return f"{__class__.__name__}/{self.wallet.diagnostic_name()}"
 
-    def parse_response(self, response):
+    def _parse_response(self, response):
         error = True
         try:
             if not response: return None, None, error
@@ -107,10 +107,10 @@ class Synchronizer(ThreadJob):
         unregister ourselves as a job from within the Network thread itself. """
         self._need_release = False
         self.cleaned_up = True
-        self.network.unsubscribe_from_scripthashes(self.h2addr.keys(), self.on_address_status)
-        self.network.cancel_requests(self.on_address_status)
-        self.network.cancel_requests(self.on_address_history)
-        self.network.cancel_requests(self.tx_response)
+        self.network.unsubscribe_from_scripthashes(self.h2addr.keys(), self._on_address_status)
+        self.network.cancel_requests(self._on_address_status)
+        self.network.cancel_requests(self._on_address_history)
+        self.network.cancel_requests(self._tx_response)
         self.network.remove_jobs([self])
 
     def release(self):
@@ -127,7 +127,7 @@ class Synchronizer(ThreadJob):
                 # we use a dict here to preserve order -- this is an "ordered set"
                 self.new_addresses_for_change[address] = None
 
-    def check_change_subs_limits(self):
+    def _check_change_subs_limits(self):
         if not self.limit_change_subs:
             return
         active = self.change_subs_active
@@ -149,9 +149,9 @@ class Synchronizer(ThreadJob):
             self.print_error(f"change_subs limit reached ({self.limit_change_subs}), unsubscribing from"
                              f" {len(unsubs)} old change scripthashes,"
                              f" change scripthash subs ct now: {len(self.change_subs)}")
-            self.network.unsubscribe_from_scripthashes(unsubs, self.on_address_status)
+            self.network.unsubscribe_from_scripthashes(unsubs, self._on_address_status)
 
-    def subscribe_to_addresses(self, addresses: Iterable[Address], *, for_change=False):
+    def _subscribe_to_addresses(self, addresses: Iterable[Address], *, for_change=False):
         hashes2addr = {addr.to_scripthash_hex(): addr for addr in addresses}
         if not hashes2addr:
             return  # Nothing to do!
@@ -165,9 +165,9 @@ class Synchronizer(ThreadJob):
                 self.change_scripthashes[sh]
             self.change_subs |= hashes_set
         # Nit: we use hashes2addr.keys() here to preserve order
-        self.network.subscribe_to_scripthashes(hashes2addr.keys(), self.on_address_status)
+        self.network.subscribe_to_scripthashes(hashes2addr.keys(), self._on_address_status)
         if for_change:
-            self.check_change_subs_limits()
+            self._check_change_subs_limits()
 
     @staticmethod
     def get_status(hist: Iterable[Tuple[str, int]]):
@@ -182,7 +182,7 @@ class Synchronizer(ThreadJob):
     def change_subs_active(self) -> Set[str]:
         return self.change_subs - self.requested_hashes
 
-    def check_change_sh(self, sh: str):
+    def _check_change_scripthash(self, sh: str):
         if not self.limit_change_subs:
             # If not limiting change subs, this subsystem is not used so no need to maintain data structures below...
             return
@@ -206,14 +206,14 @@ class Synchronizer(ThreadJob):
             # Not a candidate for expiry
             self.change_subs_expiry_candidates.discard(sh)
 
-    def on_address_status(self, response):
+    def _on_address_status(self, response):
         if self.cleaned_up:
             self.print_error("Already cleaned-up, ignoring stale reponse:", response)
             # defensive programming: make doubly sure we aren't registered to receive any callbacks from network class
             # and cancel subscriptions again.
             self._release()
             return
-        params, result, error = self.parse_response(response)
+        params, result, error = self._parse_response(response)
         if error:
             return
         scripthash = params[0]
@@ -224,16 +224,16 @@ class Synchronizer(ThreadJob):
         if self.get_status(history) != result:
             if self.requested_histories.get(scripthash) is None:
                 self.requested_histories[scripthash] = result
-                self.network.request_scripthash_history(scripthash, self.on_address_history)
+                self.network.request_scripthash_history(scripthash, self._on_address_history)
         # remove addr from list only after it is added to requested_histories
         self.requested_hashes.discard(scripthash)  # Notifications won't be in
         # See if now the change address needs to be recategorized
-        self.check_change_sh(scripthash)
+        self._check_change_scripthash(scripthash)
 
-    def on_address_history(self, response):
+    def _on_address_history(self, response):
         if self.cleaned_up:
             return
-        params, result, error = self.parse_response(response)
+        params, result, error = self._parse_response(response)
         if error:
             return
         scripthash = params[0]
@@ -259,14 +259,14 @@ class Synchronizer(ThreadJob):
             # Store received history
             self.wallet.receive_history_callback(addr, hist, tx_fees)
             # Request transactions we don't have
-            self.request_missing_txs(hist, scripthash)
+            self._request_missing_txs(hist, scripthash)
         # Check that this scripthash is a candidate for purge
-        self.check_change_sh(scripthash)
+        self._check_change_scripthash(scripthash)
 
-    def tx_response(self, response, scripthash: Optional[str]):
+    def _tx_response(self, response, scripthash: Optional[str]):
         if self.cleaned_up:
             return
-        params, result, error = self.parse_response(response)
+        params, result, error = self._parse_response(response)
         tx_hash = params[0] or ''
         # unconditionally pop. so we don't end up in a "not up to date" state
         # on bad server reply or reorg.
@@ -312,9 +312,9 @@ class Synchronizer(ThreadJob):
         process()
 
         # wallet balance updated for this sh, check if it is a candidate for purge
-        self.check_change_sh(scripthash)
+        self._check_change_scripthash(scripthash)
 
-    def request_missing_txs(self, hist: Iterable[Tuple[str, int]], scripthash: Optional[str]) -> bool:
+    def _request_missing_txs(self, hist: Iterable[Tuple[str, int]], scripthash: Optional[str]) -> bool:
         # "hist" is a list of [tx_hash, tx_height] lists
         requests = []
         for tx_hash, tx_height in hist:
@@ -327,35 +327,35 @@ class Synchronizer(ThreadJob):
             if self.limit_change_subs and scripthash is not None:
                 self.requested_tx_by_sh[scripthash].add(tx_hash)
         if requests:
-            self.network.send(requests, lambda response: self.tx_response(response, scripthash))
+            self.network.send(requests, lambda response: self._tx_response(response, scripthash))
             return True
         return False
 
-    def initialize(self):
+    def _initialize(self):
         """ Check the initial state of the wallet.  Subscribe to all its
         addresses, and request any transactions in its address history
         we don't have. """
         if self.limit_change_subs:
             for addr, history in self.wallet.get_history_items():
-                self.request_missing_txs(history, addr.to_scripthash_hex())
+                self._request_missing_txs(history, addr.to_scripthash_hex())
         else:
             # If not using the limit_change_subs feature, save CPU cycles by not computing scripthashes
             for history in self.wallet.get_history_values():
-                self.request_missing_txs(history, None)
+                self._request_missing_txs(history, None)
 
         if self.requested_tx:
             self.print_error("missing tx", self.requested_tx)
 
-        self.subscribe_to_addresses(self.wallet.get_receiving_addresses())
+        self._subscribe_to_addresses(self.wallet.get_receiving_addresses())
         if not self.limit_change_subs:
-            self.subscribe_to_addresses(self.wallet.get_change_addresses(), for_change=True)
+            self._subscribe_to_addresses(self.wallet.get_change_addresses(), for_change=True)
         else:
             # Subs limiting for change addrs in place, do it in the network thread next time we run, grabbing
             # self.limit_change_subs addresses at a time
             with self.lock:
                 self.new_addresses_for_change.update({addr: None for addr in self.wallet.get_change_addresses()})
 
-    def pop_new_addresses(self) -> Tuple[Set[Address], Iterable[Address]]:
+    def _pop_new_addresses(self) -> Tuple[Set[Address], Iterable[Address]]:
         with self.lock:
             # Pop all queued receiving
             addresses = self.new_addresses
@@ -394,11 +394,11 @@ class Synchronizer(ThreadJob):
             self.wallet.synchronize()
 
             # 2. Subscribe to new addresses
-            addresses, addresses_for_change = self.pop_new_addresses()
+            addresses, addresses_for_change = self._pop_new_addresses()
             if addresses:
-                self.subscribe_to_addresses(addresses)
+                self._subscribe_to_addresses(addresses)
             if addresses_for_change:
-                self.subscribe_to_addresses(addresses_for_change, for_change=True)
+                self._subscribe_to_addresses(addresses_for_change, for_change=True)
 
             # 3. Detect if situation has changed
             up_to_date = self.is_up_to_date()

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -51,8 +51,7 @@ class Synchronizer(ThreadJob):
 
     External interface: __init__() and add() member functions."""
 
-    def __init__(self, wallet, network, *, limit_change_subs=0):
-        assert limit_change_subs >= 0  # Disallow negative values here as they will create problems
+    def __init__(self, wallet, network):
         self.wallet = wallet
         self.network = network
         self.cleaned_up = False
@@ -81,9 +80,9 @@ class Synchronizer(ThreadJob):
         self.change_subs_expiry_candidates: Set[str] = set()
         # mapping of scripthash -> Address
         self.h2addr: Dict[str, Address] = {}
-        self.limit_change_subs = limit_change_subs
         self.lock = Lock()
         self._tick_ct = 0
+        self.limit_change_subs = max(self.wallet.limit_change_addr_subs, 0)  # Disallow negatives; they create problems
         self.initialize()
 
     def diagnostic_name(self):

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -134,7 +134,8 @@ class Synchronizer(ThreadJob):
         ctr = len(active) - self.limit_change_subs
         if ctr <= 0:
             return
-        candidates = sorted(self.change_subs_expiry_candidates, key=lambda x: self.change_scripthashes.get(x, 2**64))
+        huge_int = 2**64
+        candidates = sorted(self.change_subs_expiry_candidates, key=lambda x: self.change_scripthashes.get(x, huge_int))
         unsubs = []
         for scripthash in candidates:
             if ctr <= 0:

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -80,8 +80,11 @@ class Synchronizer(ThreadJob):
         # set of all "used", 0 balance change sh's
         self.change_subs_expiry_candidates: Set[str] = set()
         # set of all change address scripthashes that are retired and should be ignored
-        self.change_scripthashes_that_are_retired = set(self.wallet.storage.get(
-            'synchronizer_retired_change_scripthashes', []))
+        if self.limit_change_subs:
+            self.change_scripthashes_that_are_retired = set(self.wallet.storage.get(
+                'synchronizer_retired_change_scripthashes', []))
+        else:
+            self.change_scripthashes_that_are_retired = set()
         # mapping of scripthash -> Address
         self.h2addr: Dict[str, Address] = {}
         self.lock = Lock()

--- a/electroncash/synchronizer.py
+++ b/electroncash/synchronizer.py
@@ -133,7 +133,9 @@ class Synchronizer(ThreadJob):
     def on_address_status(self, response):
         if self.cleaned_up:
             self.print_error("Already cleaned-up, ignoring stale reponse:", response)
-            self._release()  # defensive programming: make doubly sure we aren't registered to receive any callbacks from netwok class and cancel subscriptions again.
+            # defensive programming: make doubly sure we aren't registered to receive any callbacks from network class
+            # and cancel subscriptions again.
+            self._release()
             return
         params, result, error = self.parse_response(response)
         if error:

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -1,6 +1,9 @@
 # Electrum - lightweight Bitcoin client
 # Copyright (C) 2015 Thomas Voegtlin
 #
+# Electron Cash - Bitcoin Cash thin client
+# Copyright (C) 2017-2022 The Electron Cash Developers
+#
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
 # (the "Software"), to deal in the Software without restriction,
@@ -40,7 +43,7 @@ import time
 from collections import defaultdict, namedtuple
 from enum import Enum, auto
 from functools import partial
-from typing import Set, Tuple, Union
+from typing import Set, Tuple, Union, ValuesView
 
 from .i18n import ngettext
 from .util import (NotEnoughFunds, ExcessiveFee, PrintError, UserCancelled, profiler, format_satoshis, format_time,
@@ -697,7 +700,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         if txs:
             self._addr_bal_cache = {}  # this is probably not necessary -- as the receive_history_callback will invalidate bad cache items -- but just to be paranoid we clear the whole balance cache on reorg anyway as a safety measure
         for tx_hash in txs:
-            self._update_request_statuses_touched_by_tx(tx_hash)    
+            self._update_request_statuses_touched_by_tx(tx_hash)
         return txs
 
     def get_local_height(self):
@@ -2700,6 +2703,10 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         # Note: we will have '1' at some point in the future which will mean:
         # 'ask me per tx', so for now True -> 2.
         self.storage.put('sign_schnorr', 2 if b else 0)
+
+    def get_history_values(self) -> ValuesView[Tuple[str, int]]:
+        """ Returns the an iterable (view) of all the List[tx_hash, height] pairs for each address in the wallet."""
+        return self._history.values()
 
 
 class Simple_Wallet(Abstract_Wallet):

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2592,14 +2592,16 @@ class Abstract_Wallet(PrintError, SPVDelegate):
     def is_hardware(self):
         return any([isinstance(k, Hardware_KeyStore) for k in self.get_keystores()])
 
-    def add_address(self, address):
+    def add_address(self, address, *, for_change=False):
         assert isinstance(address, Address)
-        self._addr_bal_cache.pop(address, None)  # paranoia, not really necessary -- just want to maintain the invariant that when we modify address history below we invalidate cache.
+        # paranoia, not really necessary -- just want to maintain the invariant that when we modify address history
+        # below we invalidate cache.
+        self._addr_bal_cache.pop(address, None)
         self.invalidate_address_set_cache()
         if address not in self._history:
             self._history[address] = []
         if self.synchronizer:
-            self.synchronizer.add(address)
+            self.synchronizer.add(address, for_change=for_change)
         self.cashacct.on_address_addition(address)
 
     def has_password(self):
@@ -3061,7 +3063,7 @@ class Deterministic_Wallet(Abstract_Wallet):
             addr_list.append(address)
             if save:
                 self.save_addresses()
-            self.add_address(address)
+            self.add_address(address, for_change=for_change)
             return address
 
     def synchronize_sequence(self, for_change):

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2143,6 +2143,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             # thread-safe fashion from within the thread where they normally
             # operate on their data structures.
             self.cashacct.stop()
+            self.synchronizer.save()
             self.synchronizer.release()
             self.verifier.release()
             self.synchronizer = None
@@ -2627,6 +2628,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         if not self.synchronizer or not self.verifier:
             raise RuntimeError('Refusing to rebuild a stopped wallet!')
         network = self.network
+        self.synchronizer.clear_retired_change_addrs()
         self.stop_threads()
         do_addr_save = False
         with self.lock:

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2729,6 +2729,15 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         val = max(val or 0, 0)  # Guard against bool, None, or negative
         self.storage.put('limit_change_addr_subs', int(val))
 
+    def is_retired_change_addr(self, addr: Address) -> bool:
+        """ Returns True if the address in question is in the "retired change address" set (set maintained by
+        the synchronizer).  If the network is not started (offline mode), will always return False. """
+        assert isinstance(addr, Address)
+        if not self.synchronizer:
+            return False
+        sh = addr.to_scripthash_hex()
+        return sh in self.synchronizer.change_scripthashes_that_are_retired
+
 
 class Simple_Wallet(Abstract_Wallet):
     # wallet with a single keystore

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2712,6 +2712,21 @@ class Abstract_Wallet(PrintError, SPVDelegate):
     def get_history_items(self) -> ItemsView[Address, List[Tuple[str, int]]]:
         return self._history.items()
 
+    DEFAULT_CHANGE_ADDR_SUBS_LIMIT = 1000
+
+    @property
+    def limit_change_addr_subs(self) -> int:
+        """Returns positive nonzero if old change subs limiting is set in wallet storage, otherwise returns 0"""
+        val = int(self.storage.get('limit_change_addr_subs', self.DEFAULT_CHANGE_ADDR_SUBS_LIMIT))
+        if val >= 0:
+            return val
+        return self.DEFAULT_CHANGE_ADDR_SUBS_LIMIT
+
+    @limit_change_addr_subs.setter
+    def limit_change_addr_subs(self, val: int):
+        val = max(val or 0, 0)  # Guard against bool, None, or negative
+        self.storage.put('limit_change_addr_subs', int(val))
+
 
 class Simple_Wallet(Abstract_Wallet):
     # wallet with a single keystore

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -26,7 +26,7 @@
 from functools import partial
 from collections import defaultdict
 
-from .util import MyTreeWidget, MONOSPACE_FONT, SortableTreeWidgetItem, rate_limited, webopen
+from .util import MyTreeWidget, MONOSPACE_FONT, SortableTreeWidgetItem, rate_limited, webopen, ColorScheme
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QFont, QColor, QKeySequence, QCursor, QIcon
 from PyQt5.QtWidgets import QTreeWidgetItem, QAbstractItemView, QMenu, QToolTip
@@ -236,9 +236,16 @@ class AddressList(MyTreeWidget):
                     address_item.setData(0, self.DataRoles.cash_accounts, ca_list)
 
                 if self.wallet.is_frozen(address):
-                    address_item.setBackground(0, QColor('lightblue'))
+                    address_item.setBackground(0, ColorScheme.BLUE.as_color(True))
+                    address_item.setToolTip(0, _("Address is frozen, right-click to unfreeze"))
                 if self.wallet.is_beyond_limit(address, is_change):
-                    address_item.setBackground(0, QColor('red'))
+                    address_item.setBackground(0, ColorScheme.RED.as_color(True))
+                if is_change and self.wallet.is_retired_change_addr(address):
+                    address_item.setForeground(0, ColorScheme.GRAY.as_color())
+                    old_tt = address_item.toolTip(0)
+                    if old_tt:
+                        old_tt += "\n"
+                    address_item.setToolTip(0, old_tt + _("Change address is retired"))
                 if is_hidden:
                     if not has_hidden:
                         seq_item.insertChild(0, hidden_item)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -4477,6 +4477,53 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             use_schnorr_cb.setToolTip(no_schnorr_reason[0])
         per_wallet_tx_widgets.append((use_schnorr_cb, None))
 
+        # Retire old change addresses
+        limit_change_w = QWidget()
+        vb = QVBoxLayout(limit_change_w)
+        vb.setContentsMargins(0, 0, 0, 0)
+        limit_change_chk = QCheckBox(_("Retire unnused change addresses"))
+        limit_change_chk.setChecked(self.wallet.limit_change_addr_subs > 0)
+        vb.addWidget(limit_change_chk)
+        limit_change_inner_w = QWidget()
+        hb = QHBoxLayout(limit_change_inner_w)
+        hb.addSpacing(24)
+        hb.setContentsMargins(0, 0, 0, 0)
+        limit_change_sb = QSpinBox()
+        limit_change_sb.setMinimum(0)
+        limit_change_sb.setMaximum(2**31 - 1)
+        limit_change_sb.setValue(self.wallet.limit_change_addr_subs or self.wallet.DEFAULT_CHANGE_ADDR_SUBS_LIMIT)
+        l1 = QLabel(_("Retire if older than:"))
+        f = l1.font()
+        f.setPointSize(f.pointSize() - 1)
+        l1.setFont(f)
+        hb.addWidget(l1)
+        hb.addWidget(limit_change_sb)
+        l2 = QLabel(_("from latest index"))
+        l2.setFont(f)
+        hb.addWidget(l2)
+        limit_change_sb.setFont(f)
+        orig_limit_change_subs = self.wallet.limit_change_addr_subs
+        def limit_change_subs_changed():
+            limit_change_inner_w.setEnabled(limit_change_chk.isChecked())
+            self.wallet.limit_change_addr_subs = limit_change_sb.value() if limit_change_chk.isChecked() else 0
+            if self.wallet.limit_change_addr_subs != orig_limit_change_subs:
+                self.need_restart = True
+        limit_change_inner_w.setEnabled(limit_change_chk.isChecked())
+        limit_change_sb.valueChanged.connect(limit_change_subs_changed)
+        limit_change_chk.stateChanged.connect(limit_change_subs_changed)
+        vb.addWidget(limit_change_inner_w)
+        vb.addStretch(1)
+        limit_change_w.setToolTip("<p>" + _("If checked, change addresses with no balance and trivial history which are"
+                                            " sufficeintly old will not be subscribed-to on the server, in order"
+                                            " to save resources.") + "</p>" +
+                                  "<p>" + _("Disable this option if you plan on receiving funds using your old change"
+                                            " addresses or if you suspect your old change addresses"
+                                            " may have unseen funds on them.") + "</p>")
+        limit_change_inner_w.setToolTip("<p>" + _("Specify how old a change address must be in order to be considered"
+                                                  " for retirement. This value is in terms of address index position"
+                                                  " from the most recent change address.") + "</o>")
+        per_wallet_tx_widgets.append((limit_change_w, None))
+
         # Fiat Tab (only build it if not on testnet)
         #
         # Note that at the present time self.fx is always defined, including for --offline mode;
@@ -4645,7 +4692,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         run_hook('close_settings_dialog')
         if self.need_restart:
-            self.show_message(_('Please restart Electron Cash to activate the new GUI settings'), title=_('Success'))
+            self.show_message(_('Please restart Electron Cash to activate the new settings'), title=_('Success'))
 
     def closeEvent(self, event):
         # It seems in some rare cases this closeEvent() is called twice.

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -4509,6 +4509,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.wallet.limit_change_addr_subs = limit_change_sb.value() if limit_change_chk.isChecked() else 0
             if self.wallet.limit_change_addr_subs != orig_limit_change_subs:
                 need_wallet_reopen = True
+                if self.wallet.synchronizer:
+                    self.wallet.synchronizer.clear_retired_change_addrs()
         limit_change_inner_w.setEnabled(limit_change_chk.isChecked())
         limit_change_sb.valueChanged.connect(limit_change_subs_changed)
         limit_change_chk.stateChanged.connect(limit_change_subs_changed)


### PR DESCRIPTION
Closes #2026

This new option allows the wallet to auto-retire "old" change addresses.  This should drastically improve startup times for large cashfusoin wallets and should also make it so that large cash fusion wallets can operate indefinitely.  Right now there is a server-side limit in Fulcrum and ElectrumX on the number of subscriptions a client may have (about 50k to 75k depending on server version). With very large/old cashfusion wallets, this limit may be reached currently.

With this PR, the limit shouldn't normally be reached.  See: #2026 for discussion.

An "old" change address is retired if:

- its index is < 1000 from the latest change address (this magic number of 1000 is GUI configurable)
- It has a trivial history of 2 txs: 1 in, 1 out
- It has 0 balance.

All other change addresses that don't meet the above criteria are never retired.  In practice this means that fusion addresses get retired, and normal change addresses also get retired, but change addresses that "broke" the invariant that they are only used once (and thus maybe the user has been sending funds to them), will not get retired.

A retired change address is not subscribed to more than once to get its initial history, after which time it is forever left unsubscribed.

The synchronizer has been updated to try and maintain the invariant that it never exceeds the configured change address subscribe limit (1000 subs limit by default, user configurable).  It may sometimes violate this invariant by as much as 2x, due to the way the synchronizer.py code is written, however in practice this is good enough.  

With this change it should be possible to use cashfusion into the indefinite future without fear of hitting the 50k or 75k server-sids subs limits.

---

From Settings -> Transactions

<img width="465" alt="Screen Shot 2022-02-24 at 7 07 03 PM" src="https://user-images.githubusercontent.com/266627/155634173-efe2227c-be82-4715-9f80-6e099e1875c6.png">

---

### Merge Instructions: Please squash