### PR TITLE
Build: Fix PE file timestamp of MSVC generated binaries

### DIFF
--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -230,10 +230,12 @@ build_the_app() {
 
         rm -rf dist/
 
-        info "Resetting modification time in C:\Python..."
+        info "Resetting modification time and .pyd PE timestamps in C:\Python..."
         # (Because we just installed a bunch of stuff)
         pushd "$WINEPREFIX"/drive_c/python$PYTHON_VERSION
         find -exec touch -d '2000-11-11T11:11:11+00:00' {} +
+        find -type f -name '*.pyd' -exec python3 "$here"/fix-pe-timestamp.py {} \;
+        sed -i '/jsonschema\.exe/d' Lib/site-packages/jsonschema-*.dist-info/RECORD
         ls -l
         popd
 

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -53,7 +53,9 @@ RUN echo "78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6 /tmp/
         # xvfb is needed to launch the Visual Studio installer
         xvfb=2:1.20.13-1ubuntu1.1 \
         # winbind is needed for the Visual Studio installer and cl.exe PDB generation
-        winbind=2:4.13.17~dfsg-0ubuntu0.21.10.1
+        winbind=2:4.13.17~dfsg-0ubuntu0.21.10.1 \
+        # python3-pefile is needed to patch the MSVC binaries using fix-pe-timestamp.py
+        python3-pefile=2021.5.24-1
 
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/contrib/build-wine/fix-pe-timestamp.py
+++ b/contrib/build-wine/fix-pe-timestamp.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import sys
+
+import pefile
+
+if len(sys.argv) < 2:
+    sys.stderr.write(f'Usage: fix-pe-timestamp.py <pe filename>')
+    sys.exit(1)
+
+pe_filename = sys.argv[1]
+
+pe = pefile.PE(pe_filename)
+
+pe.FILE_HEADER.TimeDateStamp = 0xffffffff
+
+for de in pe.DIRECTORY_ENTRY_DEBUG:
+    de.struct.TimeDateStamp = 0xffffffff
+
+pe.write(filename=pe_filename)
+
+sys.exit(0)


### PR DESCRIPTION
These files included a `TimeDateStamp` in `IMAGE_NT_HEADERS32` and `IMAGE_DEBUG_DIRECTORY` making the build not reproducible.

There is a `/Brepro` argument that can be passed to the linker to set these to 0xffffffff but `setuptools` does not allow passing custom flags in the environment for MSVC.

To fix this we include a small Python tool that uses the pefile library to set the timestamps to 0xffffffff.