### PR TITLE
CTOR workaround approach 1: Display history in pseudo-topological order per block

### DIFF
--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -1610,7 +1610,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
     def export_history(self, domain=None, from_timestamp=None, to_timestamp=None, fx=None,
                        show_addresses=False, decimal_point=8,
                        *, fee_calc_timeout=10.0, download_inputs=False,
-                       progress_callback=None):
+                       progress_callback=None, topo_sort=False):
         ''' Export history. Used by RPC & GUI.
 
         Arg notes:
@@ -1707,7 +1707,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                                    is_diff=is_diff)
 
         # grab history
-        h = self.get_history(domain, reverse=True)
+        h = self.get_history(domain, reverse=True, topo_sort=topo_sort)
         out = []
 
         n, l = 0, max(1, float(len(h)))

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -1565,7 +1565,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
 
             def get_vpos(txid, txid_set, vpos=0):
                 addr_dict = self.txi.get(txid)
-                if not addr_dict: return 0  # Hmm. Missing inputs for this tx (doesn't involve wallet)
+                if not addr_dict: return vpos  # Hmm. Missing inputs for this tx (doesn't involve wallet)
                 vpos_out = vpos
                 for _, txis in addr_dict.items():
                     for tup in txis:

--- a/electroncash_gui/qt/history_list.py
+++ b/electroncash_gui/qt/history_list.py
@@ -112,7 +112,8 @@ class HistoryList(MyTreeWidget):
     @profiler
     def on_update(self):
         self.wallet = self.parent.wallet
-        h = self.wallet.get_history(self.get_domain(), reverse=True)
+        h = self.wallet.get_history(self.get_domain(), reverse=True,
+                                    topo_sort=bool(self.config.get('topo_sort_tx_history', True)))
         sels = self.selectedItems()
         current_tx = sels[0].data(0, Qt.UserRole) if sels else None
         del sels #  make sure not to hold stale ref to C++ list of items which will be deleted in clear() call below

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -4554,6 +4554,19 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         legacy_p2sh_cb.stateChanged.connect(on_legacy_p2sh_cb)
         global_tx_widgets.append((legacy_p2sh_cb, None))
 
+        # Sort txns in natural order (TTOR) vs blockchain order (CTOR)
+        blockchain_order_cb = QCheckBox(_("Display history in blockchain order (CTOR)"))
+        blockchain_order_cb.setChecked(not self.config.get('topo_sort_tx_history', True))
+        blockchain_order_cb.setToolTip(_('If checked, the transaction history tab will display transactions in the\n'
+                                         'order in which they appear on the blockchain, which is CTOR order (sorted\n'
+                                         'by txid per block, descending). If disabled, transactions will be sorted\n'
+                                         'topologically per block (natural order).'))
+        def on_blockchain_order_cb(b):
+            self.config.set_key('topo_sort_tx_history', not b)
+            self.history_list.update()  # this won't happen too often since it's rate-limited
+        blockchain_order_cb.stateChanged.connect(on_blockchain_order_cb)
+        global_tx_widgets.append((blockchain_order_cb, None))
+
         # Schnorr
         use_schnorr_cb = QCheckBox(_("Sign with Schnorr signatures"))
         use_schnorr_cb.setChecked(self.wallet.is_schnorr_enabled())

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3835,7 +3835,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                                          decimal_point=self.decimal_point,
                                          fee_calc_timeout=timeout,
                                          download_inputs=download_inputs,
-                                         progress_callback=update_prog)
+                                         progress_callback=update_prog,
+                                         topo_sort=bool(self.config.get('topo_sort_tx_history', True)))
         success = False
         def on_success(history):
             nonlocal success


### PR DESCRIPTION
As discussed in telegram, it is confusing to users how the blockchain
ordering is used for the txns in the history tab. This is CTOR ordering
and sometimes it leads to intermediate balance values that make no
sense (spends coming before receives, negative temporary balances, etc).
This is because blockchain ordering is by txid and is not natural ordering
since the HF in Nov 2018.

Now, by default, the history will try and sort txs by "natural" order or
topologically.  (Actually, since the wallet lacks full tx history information
for txns not involving the wallet, this is more a weak pseudo-topological order,
but is still ordering chains of txns involving the wallet topologically).

This ordering will guarantee that receives of a coin come before
spends of the same coin in the history, thus the balance always is
positive and never dips into negatives, and is the natural order that
the txns likely were issued in.

A config option was added in the settings UI to revert to the old
behavior, but the default now is to sort in natural order rather than
the less useful CTOR ordering.

<img width="516" alt="Screen Shot 2022-05-03 at 11 33 42 AM" src="https://user-images.githubusercontent.com/266627/166424814-a595c5ed-44ba-4d84-a225-3709fae6b371.png">


---

Special thanks to molecular and matricz for reminding me of this
issue.
