### PR TITLE
CTOR workaround approach 2: Always display receives before sends (for the same block)

### DIFF
--- a/electroncash_gui/qt/history_list.py
+++ b/electroncash_gui/qt/history_list.py
@@ -112,7 +112,9 @@ class HistoryList(MyTreeWidget):
     @profiler
     def on_update(self):
         self.wallet = self.parent.wallet
-        h = self.wallet.get_history(self.get_domain(), reverse=True)
+        h = self.wallet.get_history(self.get_domain(), reverse=True,
+                                    receives_before_sends=bool(self.config.get('tx_history_receives_before_sends',
+                                                                               True)))
         sels = self.selectedItems()
         current_tx = sels[0].data(0, Qt.UserRole) if sels else None
         del sels #  make sure not to hold stale ref to C++ list of items which will be deleted in clear() call below

--- a/electroncash_gui/qt/history_list.py
+++ b/electroncash_gui/qt/history_list.py
@@ -112,9 +112,7 @@ class HistoryList(MyTreeWidget):
     @profiler
     def on_update(self):
         self.wallet = self.parent.wallet
-        h = self.wallet.get_history(self.get_domain(), reverse=True,
-                                    receives_before_sends=bool(self.config.get('tx_history_receives_before_sends',
-                                                                               True)))
+        h = self.wallet.get_history(self.get_domain(), reverse=True, receives_before_sends=True)
         sels = self.selectedItems()
         current_tx = sels[0].data(0, Qt.UserRole) if sels else None
         del sels #  make sure not to hold stale ref to C++ list of items which will be deleted in clear() call below

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3836,8 +3836,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                                          fee_calc_timeout=timeout,
                                          download_inputs=download_inputs,
                                          progress_callback=update_prog,
-                                         receives_before_sends=bool(self.config.get('tx_history_receives_before_sends',
-                                                                                    True)))
+                                         receives_before_sends=True)
         success = False
         def on_success(history):
             nonlocal success
@@ -4555,25 +4554,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.config.set_key('allow_legacy_p2sh', bool(b))
         legacy_p2sh_cb.stateChanged.connect(on_legacy_p2sh_cb)
         global_tx_widgets.append((legacy_p2sh_cb, None))
-
-        # Sort txns in "receives before sends" ordervs blockchain order (CTOR)
-        receives_before_sends_cb = QCheckBox(_("Display history with receives ordered before sends"))
-        receives_before_sends_cb.setChecked(self.config.get('tx_history_receives_before_sends', True))
-        receives_before_sends_cb.setToolTip(
-                                    _('If checked, the transaction history tab will display transactions in such\n'
-                                      'a way so as to avoid disconcerting negative temporary balances. Receives\n'
-                                      'of funds will always be ordered before sends appearing in the same block.\n'
-                                      'This is necessary since CTOR ordering may create non-natural tx history\n'
-                                      'ordering for confirmed transactions, leading to temporary negative balances\n'
-                                      'for intermediate transactions in a chain appearing in the same block.\n\n'
-                                      'This option works around CTOR by at least ensuring that wallet balances will\n'
-                                      'always appear positive in the history tab, even if transactions are re-ordered\n'
-                                      'due to CTOR.'))
-        def on_receives_before_sends_cb(b):
-            self.config.set_key('tx_history_receives_before_sends', b)
-            self.history_list.update()  # this won't happen too often since it's rate-limited
-        receives_before_sends_cb.stateChanged.connect(on_receives_before_sends_cb)
-        global_tx_widgets.append((receives_before_sends_cb, None))
 
         # Schnorr
         use_schnorr_cb = QCheckBox(_("Sign with Schnorr signatures"))


### PR DESCRIPTION
This option is default-on.  This implementation is an alternative to
PR #2431.  It is a second attempt to "undo the damage" of CTOR on the
wallet UI and avoid temporary negative intermediate balances.

The approach taken here is to always sort txns in the same block by
receives-first.  Thus all txns for the same block that have a net
positive effect on wallet balance will appear before these txns in the
same block with a net negative effect on wallet balance.  This is a
quick and performant way to avoid intermediate negative wallet balances
in the history tab (due to CTOR).

---

Special thanks to matricz, molecular, Jonas, and @imaginaryusername for helping to brainstorm this one.
