### PR TITLE
Tor: Update to version 0.4.7.7 with a patch for static linking

### DIFF
--- a/contrib/make_tor
+++ b/contrib/make_tor
@@ -38,6 +38,7 @@ if ! [ -r config.status ] ; then
         --disable-seccomp \
         --disable-libscrypt \
         --disable-module-dirauth \
+        --disable-module-relay \
         $EXTRA_FLAGS || fail "Could not configure $pkgname"
 fi
 make -j$WORKER_COUNT || fail "Could not build $pkgname"


### PR DESCRIPTION
This upgrades Tor from version 0.4.5.7 to version 0.4.7.7.

This also disables the relay module which is not needed for our use.

Release notes:

* https://blog.torproject.org/new-release-tor-0458/
* https://blog.torproject.org/new-stable-security-releases-03515-0449-0459-0465/
* https://blog.torproject.org/new-stable-releases-tor-03516-04510-and-0467/
* https://forum.torproject.net/t/release-0-3-5-17-0-4-5-11-0-4-6-8-and-0-4-7-2-alpha/148
* https://forum.torproject.net/t/release-0-4-5-12-and-0-4-6-10/2024
* https://forum.torproject.net/t/stable-release-0-4-7-7/3108/2

This includes important security updates:

Version 0.4.6.5:

* Major bugfixes (security):
  * Don't allow relays to spoof RELAY_END or RELAY_RESOLVED cell on half-closed streams. Previously, clients failed to validate which hop sent these cells: this would allow a relay on a circuit to end a stream that wasn't actually built with it. Fixes bug 40389; bugfix on 0.3.5.1-alpha. This issue is also tracked as TROVE-2021-003 and CVE-2021-34548.

* Major bugfixes (security, defense-in-depth):
  * Detect more failure conditions from the OpenSSL RNG code. Previously, we would detect errors from a missing RNG implementation, but not failures from the RNG code itself. Fortunately, it appears those failures do not happen in practice when Tor is using OpenSSL's default RNG implementation. Fixes bug 40390; bugfix on 0.2.8.1-alpha. This issue is also tracked as TROVE-2021-004. Reported by Jann Horn at Google's Project Zero.

* Major bugfixes (security, denial of service):
  * Resist a hashtable-based CPU denial-of-service attack against relays. Previously we used a naive unkeyed hash function to look up circuits in a circuitmux object. An attacker could exploit this to construct circuits with chosen circuit IDs, to create collisions and make the hash table inefficient. Now we use a SipHash construction here instead. Fixes bug 40391; bugfix on 0.2.4.4-alpha. This issue is also tracked as TROVE-2021-005 and CVE-2021-34549. Reported by Jann Horn from Google's Project Zero.
  * Fix an out-of-bounds memory access in v3 onion service descriptor parsing. An attacker could exploit this bug by crafting an onion service descriptor that would crash any client that tried to visit it. Fixes bug 40392; bugfix on 0.3.0.1-alpha. This issue is also tracked as TROVE-2021-006 and CVE-2021-34550. Reported by Sergei Glazunov from Google's Project Zero.

Version 0.4.6.7:

* Major bugfixes (cryptography, security):
  * Resolve an assertion failure caused by a behavior mismatch between our batch-signature verification code and our single-signature verification code. This assertion failure could be triggered remotely, leading to a denial of service attack. We fix this issue by disabling batch verification. Fixes bug 40078; bugfix on 0.2.6.1-alpha. This issue is also tracked as TROVE-2021-007 and CVE-2021-38385. Found by Henry de Valence.

This also disables the use of V2 onion services and adds flow control, for further details see the release notes:

https://gitweb.torproject.org/tor.git/tree/ReleaseNotes?h=tor-0.4.7.7

Tree built from:

https://github.com/EchterAgo/tor/commits/electroncash_0_4_7_7

This includes a static linking fix.