### PR TITLE
Wine: Pass additional flags to reduce junk in the binaries

### DIFF
--- a/contrib/build-wine/docker/wrapper.cpp
+++ b/contrib/build-wine/docker/wrapper.cpp
@@ -16,7 +16,7 @@ namespace {
     };
 
     std::string ReplaceCommandAndPrependArg(std::string_view commandLine, const std::string& newCmd,
-                                            const std::string& arg)
+                                            const std::string& arg, const std::string& argPost)
     {
         bool in_quot{}, in_bs{};
         std::string_view::size_type pos{};
@@ -27,7 +27,7 @@ namespace {
             else if (ch == '"' && !in_bs) in_quot = !in_quot;
             else if (in_bs) in_bs = false;
         }
-        return newCmd + " " + arg + std::string{commandLine.substr(pos)};
+        return newCmd + " " + arg + std::string{commandLine.substr(pos)} + " " + argPost;
     }
 
     std::string GetErrorMessage(DWORD dwErrorCode)
@@ -60,7 +60,8 @@ int main()
 {
     const char* const prog = PROG;
     const char* const arg = ARG;
-    std::string cmdBuf = ReplaceCommandAndPrependArg(GetCommandLineA(), prog, arg);
+    const char* const argPost = ARG_POST;
+    std::string cmdBuf = ReplaceCommandAndPrependArg(GetCommandLineA(), prog, arg, argPost);
     //std::cerr << "Old: [" << GetCommandLineA() << "]" << std::endl;
     //std::cerr << "New: [" << cmdBuf << "]" << std::endl;
 

--- a/contrib/build-wine/docker/wrapper_install.bat
+++ b/contrib/build-wine/docker/wrapper_install.bat
@@ -9,9 +9,18 @@ set LINK_PATH=%VCToolsInstallDir%\bin\Hostx86\x86\link.exe
 set LINK_REAL=%VCToolsInstallDir%\bin\Hostx86\x86\link_real.exe
 set LINK_REAL_ESC=\\\"%LINK_REAL:\=\\%\\\"
 
-cl /nologo /std:c++17 /Fe:C:\link.exe "/DPROG=\"%LINK_REAL_ESC%\"" /DARG=\"/Brepro\" "/DARG_POST=\"\"" /EHsc C:\wrapper.cpp /link /Brepro
+cl /nologo /std:c++17 /Fe:C:\link.exe "/DPROG=\"%LINK_REAL_ESC%\"" "/DARG=\"/Brepro /emittoolversioninfo:no /emitpogophaseinfo\"" "/DARG_POST=\"\"" /EHsc C:\wrapper.cpp /link /Brepro
+
+set CL_PATH=%VCToolsInstallDir%\bin\Hostx86\x86\cl.exe
+set CL_REAL=%VCToolsInstallDir%\bin\Hostx86\x86\cl_real.exe
+set CL_REAL_ESC=\\\"%CL_REAL:\=\\%\\\"
+
+cl /nologo /std:c++17 /Fe:C:\cl.exe "/DPROG=\"%CL_REAL_ESC%\"" "/DARG=\"/Brepro\"" "/DARG_POST=\"/link /emittoolversioninfo:no /emitpogophaseinfo\"" /EHsc C:\wrapper.cpp /link /Brepro
 
 move "%LINK_PATH%" "%LINK_REAL%"
 move "C:\link.exe" "%LINK_PATH%"
+
+move "%CL_PATH%" "%CL_REAL%"
+move "C:\cl.exe" "%CL_PATH%"
 
 exit 0

--- a/contrib/build-wine/docker/wrapper_install.bat
+++ b/contrib/build-wine/docker/wrapper_install.bat
@@ -9,7 +9,7 @@ set LINK_PATH=%VCToolsInstallDir%\bin\Hostx86\x86\link.exe
 set LINK_REAL=%VCToolsInstallDir%\bin\Hostx86\x86\link_real.exe
 set LINK_REAL_ESC=\\\"%LINK_REAL:\=\\%\\\"
 
-cl /nologo /std:c++17 /Fe:C:\link.exe "/DPROG=\"%LINK_REAL_ESC%\"" /DARG=\"/Brepro\" /EHsc C:\wrapper.cpp /link /Brepro
+cl /nologo /std:c++17 /Fe:C:\link.exe "/DPROG=\"%LINK_REAL_ESC%\"" /DARG=\"/Brepro\" "/DARG_POST=\"\"" /EHsc C:\wrapper.cpp /link /Brepro
 
 move "%LINK_PATH%" "%LINK_REAL%"
 move "C:\link.exe" "%LINK_PATH%"

--- a/contrib/build-wine/docker/wrapper_install.bat
+++ b/contrib/build-wine/docker/wrapper_install.bat
@@ -5,17 +5,20 @@ set VCDIR=c:\Program Files\Microsoft Visual Studio\%VCYEAR%\BuildTools\VC
 
 call "%VCDIR%\Auxiliary\Build\vcvarsall.bat" x86
 
+set REPRO_ARGS=/Brepro
+set REPRO_ARGS_LINK=/emittoolversioninfo:no /emitpogophaseinfo
+
 set LINK_PATH=%VCToolsInstallDir%\bin\Hostx86\x86\link.exe
 set LINK_REAL=%VCToolsInstallDir%\bin\Hostx86\x86\link_real.exe
 set LINK_REAL_ESC=\\\"%LINK_REAL:\=\\%\\\"
 
-cl /nologo /std:c++17 /Fe:C:\link.exe "/DPROG=\"%LINK_REAL_ESC%\"" "/DARG=\"/Brepro /emittoolversioninfo:no /emitpogophaseinfo\"" "/DARG_POST=\"\"" /EHsc C:\wrapper.cpp /link /Brepro
+cl /nologo /std:c++17 /Fe:C:\link.exe "/DPROG=""%LINK_REAL_ESC%""" "/DARG=""%REPRO_ARGS% %REPRO_ARGS_LINK%""" "/DARG_POST=""""" /EHsc %REPRO_ARGS% C:\wrapper.cpp /link %REPRO_ARGS_LINK%
 
 set CL_PATH=%VCToolsInstallDir%\bin\Hostx86\x86\cl.exe
 set CL_REAL=%VCToolsInstallDir%\bin\Hostx86\x86\cl_real.exe
 set CL_REAL_ESC=\\\"%CL_REAL:\=\\%\\\"
 
-cl /nologo /std:c++17 /Fe:C:\cl.exe "/DPROG=\"%CL_REAL_ESC%\"" "/DARG=\"/Brepro\"" "/DARG_POST=\"/link /emittoolversioninfo:no /emitpogophaseinfo\"" /EHsc C:\wrapper.cpp /link /Brepro
+cl /nologo /std:c++17 /Fe:C:\cl.exe "/DPROG=""%CL_REAL_ESC%""" "/DARG=""%REPRO_ARGS%""" "/DARG_POST=""/link %REPRO_ARGS_LINK%""" /EHsc %REPRO_ARGS% C:\wrapper.cpp /link %REPRO_ARGS_LINK%
 
 move "%LINK_PATH%" "%LINK_REAL%"
 move "C:\link.exe" "%LINK_PATH%"

--- a/contrib/build-wine/docker/wrapper_install.bat
+++ b/contrib/build-wine/docker/wrapper_install.bat
@@ -1,12 +1,12 @@
 @echo off
 
-set VCVER=2019
-set VCDIR=c:\Program Files\Microsoft Visual Studio\%VCVER%\BuildTools\VC
+set VCYEAR=2019
+set VCDIR=c:\Program Files\Microsoft Visual Studio\%VCYEAR%\BuildTools\VC
 
 call "%VCDIR%\Auxiliary\Build\vcvarsall.bat" x86
 
-set LINK_PATH=%VCDIR%\Tools\MSVC\14.29.30133\bin\Hostx86\x86\link.exe
-set LINK_REAL=%VCDIR%\Tools\MSVC\14.29.30133\bin\Hostx86\x86\link_real.exe
+set LINK_PATH=%VCToolsInstallDir%\bin\Hostx86\x86\link.exe
+set LINK_REAL=%VCToolsInstallDir%\bin\Hostx86\x86\link_real.exe
 set LINK_REAL_ESC=\\\"%LINK_REAL:\=\\%\\\"
 
 cl /nologo /std:c++17 /Fe:C:\link.exe "/DPROG=\"%LINK_REAL_ESC%\"" /DARG=\"/Brepro\" /EHsc C:\wrapper.cpp /link /Brepro


### PR DESCRIPTION
This passes the undocumented `/emittoolversioninfo:no` to stop the linker from adding the "Rich" header which contains tool versions into the file. It also adds the also undocumented `/emitpogophaseinfo` to stop debug info from ending up in the file. Both of these seem to cause non-reproducible builds.

This also installs another wrapper for `cl.exe` which uses the post arguments of the wrapper to pass these flags to the linker.

This also improves the wrapper installer and adds support for post arguments to the wrapper.