### PR TITLE
update default cashfusion server to fusion.servo.cash

### DIFF
--- a/electroncash_plugins/fusion/conf.py
+++ b/electroncash_plugins/fusion/conf.py
@@ -163,7 +163,7 @@ def _get_default_server_list() -> List[Tuple[str, int, bool]]:
     """
     return [
         # first one is the default
-        CashFusionServer('cashfusion.electroncash.dk', 8788, True),
+        CashFusionServer('fusion.servo.cash', 8789, True),
     ]
 
 


### PR DESCRIPTION
- per https://t.me/cashfusion/13483

Should there also be some update to https://github.com/Electron-Cash/Electron-Cash/blob/e6b891a70f55e22e64f172157b137fb433736123/electroncash_plugins/fusion/plugin.py#L310 ?