### PR TITLE
AppImage: Fix package versions and add cargo dependency

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -10,7 +10,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
     echo deb ${UBUNTU_MIRROR} bionic-security main restricted universe multiverse >> /etc/apt/sources.list && \
     apt-get update -q && \
     apt-get install -qy \
-        git=1:2.17.1-1ubuntu0.11 \
+        git=1:2.17.1-1ubuntu0.12 \
         wget=1.19.4-1ubuntu2.2 \
         make=4.1-9.1ubuntu1 \
         autotools-dev=20180224.1 \
@@ -45,10 +45,11 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
         libx11-xcb1=2:1.6.4-3ubuntu0.4 \
         autopoint=0.19.8.1-6ubuntu0.3 \
         zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
-        libfreetype6=2.8.1-2ubuntu2.1 \
+        libfreetype6=2.8.1-2ubuntu2.2 \
         libfontconfig1=2.12.6-0ubuntu2 \
-        libssl-dev=1.1.1-1ubuntu2.1~18.04.17 \
-        rustc=1.57.0+dfsg1+llvm-0ubuntu1~18.04.1 \
+        libssl-dev=1.1.1-1ubuntu2.1~18.04.20 \
+        rustc=1.59.0+dfsg1~ubuntu1~llvm-1~ubuntu1~18.04.2 \
+        cargo=0.60.0ubuntu1-0ubuntu1~18.04.1 \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \


### PR DESCRIPTION
This replaces outdated package versions and adds `cargo` to the package list which is needed to build `cryptography` with the new `rustc` package.