### PR TITLE
commands: getinfo and list_wallets daemon cmds to RPCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ xcuserdata/
 # mypy
 .mypy_cache/
 
+venv/

--- a/electron-cash
+++ b/electron-cash
@@ -281,8 +281,9 @@ def init_cmdline(config_options, server):
         print_stderr("In particular, DO NOT use 'redeem private key' services proposed by third parties.")
 
     # commands needing password
-    if (cmd.requires_wallet and storage.is_encrypted() and server is None)\
-       or (cmd.requires_password and (storage.get('use_encryption') or storage.is_encrypted())):
+    if  ( (cmd.requires_wallet and storage.is_encrypted() and server is False)\
+       or (cmdname == 'load_wallet' and storage.is_encrypted())\
+       or (cmd.requires_password and (storage.is_encrypted() or storage.get('use_encryption')))):
         if config.get('password'):
             password = config.get('password')
         else:
@@ -402,8 +403,6 @@ def run_start(config, config_options, subcommand):
 def run_daemon(config, config_options):
     """Run the daemon"""
     subcommand = config.get("subcommand")
-    if subcommand in ["load_wallet"]:
-        init_daemon(config_options)
     if subcommand in [None, "start"]:
         return run_start(config, config_options, subcommand)
     server = daemon.get_server(config)

--- a/electron-cash
+++ b/electron-cash
@@ -403,6 +403,8 @@ def run_start(config, config_options, subcommand):
 def run_daemon(config, config_options):
     """Run the daemon"""
     subcommand = config.get("subcommand")
+    if subcommand in ["load_wallet"]:
+        init_daemon(config_options)
     if subcommand in [None, "start"]:
         return run_start(config, config_options, subcommand)
     server = daemon.get_server(config)

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -202,6 +202,7 @@ class Commands:
             'connected': self.network.is_connected(),
             'auto_connect': net_params[4],
             'version': PACKAGE_VERSION,
+            'default_wallet': self.config.get_wallet_path(),
             'wallets': {k: w.is_up_to_date()
                         for k, w in self.daemon.wallets.items()},
             'fee_per_kb': self.config.fee_per_kb(),

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -48,7 +48,6 @@ from .transaction import Transaction, multisig_script, OPReturn
 from .util import bfh, bh2u, format_satoshis, json_decode, print_error, standardize_path, to_bytes
 from .paymentrequest import PR_PAID, PR_UNCONFIRMED, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
 from .simple_config import SimpleConfig
-from .plugins import run_hook
 from .version import PACKAGE_VERSION
 
 known_commands = {}
@@ -227,7 +226,6 @@ class Commands:
         wallet = self.daemon.load_wallet(path, self.config.get('password'))
         if wallet is not None:
             self.wallet = wallet
-            run_hook('load_wallet', wallet, None)
         response = wallet is not None
         return response
 

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -45,9 +45,11 @@ from .i18n import _
 from .plugins import run_hook
 from .wallet import create_new_wallet, restore_wallet_from_text
 from .transaction import Transaction, multisig_script, OPReturn
-from .util import bfh, bh2u, format_satoshis, json_decode, print_error, to_bytes
+from .util import bfh, bh2u, format_satoshis, json_decode, print_error, standardize_path, to_bytes
 from .paymentrequest import PR_PAID, PR_UNCONFIRMED, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
 from .simple_config import SimpleConfig
+from .plugins import run_hook
+from .version import PACKAGE_VERSION
 
 known_commands = {}
 
@@ -121,9 +123,10 @@ def command(s):
 
 class Commands:
 
-    def __init__(self, config, wallet, network, callback = None):
+    def __init__(self, config, wallet, network, daemon=None, callback = None):
         self.config = config
         self.wallet = wallet
+        self.daemon = daemon
         self.network = network
         self._callback = callback
 
@@ -186,6 +189,59 @@ class Commands:
     def commands(self):
         """List of commands"""
         return ' '.join(sorted(known_commands.keys()))
+
+    @command('n')
+    def getinfo(self):
+        """ network info """
+        net_params = self.network.get_parameters()
+        response = {
+            'path': self.network.config.path,
+            'server': net_params[0],
+            'blockchain_height': self.network.get_local_height(),
+            'server_height': self.network.get_server_height(),
+            'spv_nodes': len(self.network.get_interfaces()),
+            'connected': self.network.is_connected(),
+            'auto_connect': net_params[4],
+            'version': PACKAGE_VERSION,
+            'wallets': {k: w.is_up_to_date()
+                        for k, w in self.daemon.wallets.items()},
+            'fee_per_kb': self.config.fee_per_kb(),
+        }
+        return response
+
+    @command('n')
+    def stop(self):
+        """Stop daemon"""
+        self.daemon.stop()
+        return "Daemon stopped"
+
+    @command('n')
+    def list_wallets(self):
+        """List wallets open in daemon"""
+        return [{'path':k, 'synchronized':w.is_up_to_date()} for k, w in self.daemon.wallets.items()]
+
+    @command('n')
+    def load_wallet(self):
+        """Open wallet in daemon"""
+        path = self.config.get_wallet_path()
+        wallet = self.daemon.load_wallet(path, self.config.get('password'))
+        if wallet is not None:
+            self.wallet = wallet
+            run_hook('load_wallet', wallet, None)
+        response = wallet is not None
+        return response
+
+    @command('n')
+    def close_wallet(self):
+        """Close wallet"""
+        path = self.config.get_wallet_path()
+        if path in self.daemon.wallets:
+            self.daemon.stop_wallet(path)
+            response = True
+        else:
+            response = False
+        return response
+
 
     @command('')
     def create(self, passphrase=None, password=None, encrypt_file=True, seed_type=None, wallet_path=None):

--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -31,6 +31,7 @@ import sys
 import jsonrpclib
 from .jsonrpc import VerifyingJSONRPCServer
 
+from .version import PACKAGE_VERSION
 from .network import Network
 from .util import (json_decode, DaemonThread, print_error, to_string,
                    standardize_path)
@@ -193,10 +194,42 @@ class Daemon(DaemonThread):
         sub = config.get('subcommand')
         subargs = config.get('subargs')
         plugin_cmd = self.plugins and self.plugins.daemon_commands.get(sub)
-        if subargs and sub in [None, 'start', 'stop']:
+        if subargs and sub in [None, 'start', 'stop', 'status']:
             return "Unexpected arguments: {!r}. {!r} takes no options.".format(subargs, sub)
+        if subargs and sub in ['load_wallet', 'close_wallet']:
+            return "Unexpected arguments: {!r}. Provide options to {!r} using the -w and -wp options.".format(subargs, sub)
         if sub in [None, 'start']:
             response = "Daemon already running"
+        elif sub == 'load_wallet':
+            path = config.get_wallet_path()
+            wallet = self.load_wallet(path, config.get('password'))
+            self.cmd_runner.wallet = wallet
+            response = True
+        elif sub == 'close_wallet':
+            path = config.get_wallet_path()
+            if path in self.wallets:
+                self.stop_wallet(path)
+                response = True
+            else:
+                response = False
+        elif sub == 'status':
+            if self.network:
+                p = self.network.get_parameters()
+                response = {
+                    'path': self.network.config.path,
+                    'server': p[0],
+                    'blockchain_height': self.network.get_local_height(),
+                    'server_height': self.network.get_server_height(),
+                    'spv_nodes': len(self.network.get_interfaces()),
+                    'connected': self.network.is_connected(),
+                    'auto_connect': p[4],
+                    'version': PACKAGE_VERSION,
+                    'wallets': {k: w.is_up_to_date()
+                                for k, w in self.wallets.items()},
+                    'fee_per_kb': self.config.fee_per_kb(),
+                }
+            else:
+                response = "Daemon offline"
         elif sub == 'stop':
             self.stop()
             response = "Daemon stopped"

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -633,6 +633,8 @@ class ElectrumGui(QObject, PrintError):
 
                 try:
                     wallet = self.daemon.load_wallet(path, None)
+                    if wallet is not None:
+                        self.daemon.cmd_runner.wallet = wallet
                 except BaseException as e:
                     self.print_error(repr(e))
                     if self.windows:
@@ -662,6 +664,7 @@ class ElectrumGui(QObject, PrintError):
                         return
                     wallet.start_threads(self.daemon.network)
                     self.daemon.add_wallet(wallet)
+                    self.daemon.cmd_runner.wallet = wallet
                     self._cache_password(wallet, password)
             except BaseException as e:
                 traceback.print_exc(file=sys.stdout)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3090,7 +3090,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         console.updateNamespace({'util' : util, 'bitcoin':bitcoin})
 
         set_json = Weak(self.console.set_json)
-        c = commands.Commands(self.config, self.wallet, self.network, lambda: set_json(True))
+        c = commands.Commands(self.config, self.wallet, self.network, self.gui_object.daemon, lambda: set_json(True))
         methods = {}
         password_getter = Weak(self.password_dialog)
         def mkfunc(f, method):


### PR DESCRIPTION
This continues https://github.com/Electron-Cash/Electron-Cash/pull/2399, which sought to backport https://github.com/Electron-Cash/Electron-Cash/commit/9cfeadea706dbbb46b1a4ab7b38ec11a4f527669

This PR retains the commits from ecdsa and jonas-lundqvist, and also:
- Adds the prerequisite commit https://github.com/spesmilo/electrum/commit/de903103dafd46e1073d0e4de5df86e2407386bd so that these RPCs are usable from the GUI console.
- Adds back the `default_wallet` field to the `getinfo` response for maximum compatibility with JSON-RPC clients.
- Retains the daemon commands to avoid breaking changes, for now.
- qt: on GUI wallet loading or creation, sets the JSON-RPC server's command runner wallet.

![image](https://user-images.githubusercontent.com/9373513/196287090-1027caf9-8827-4814-9070-529881ef5117.png)
