### PR TITLE
Add instructions to compile the icons for Qt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,11 @@ You can also install Electron Cash on your system, by running this command::
     sudo apt-get install python3-setuptools
     python3 setup.py install
 
+Compile the icons file for Qt::
+
+    sudo apt-get install pyqt5-dev-tools
+    pyrrc5 icons.qrc -o electroncash_gui/qt/icons.py
+
 This will download and install the Python dependencies used by
 Electron Cash, instead of using the 'packages' directory.
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ You can also install Electron Cash on your system, by running this command::
     sudo apt-get install python3-setuptools
     python3 setup.py install
 
-Compile the icons file for Qt::
+Compile the icons file for Qt (normally you can skip this step, run this command if icons are missing)::
 
     sudo apt-get install pyqt5-dev-tools
     pyrrc5 icons.qrc -o electroncash_gui/qt/icons.py


### PR DESCRIPTION
I tried to run Electron Cash from source on Ubuntu 20.04 and 18.04.6 and it did not create the icons automatically

This command fixes the error:

"Cannot open file ':icons/electron-cash.svg', because: No such file or directory"