### PR TITLE
Change bch.ninja to cashnode.bch.ninja

### DIFF
--- a/electroncash/servers.json
+++ b/electroncash/servers.json
@@ -139,7 +139,7 @@
         "t": "50001",
         "version": "1.4.4"
     },
-    "bch.ninja": {
+    "cashnode.bch.ninja": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",


### PR DESCRIPTION
I moved my node to a different hosting provider and made some DNS changes. Updating server list appropriately.

Old clients will be able to connect to "bch.ninja" until 30 days after this change is released.