### PR TITLE
Set BitPay as requestor on jsonPayPro invoices

### DIFF
--- a/electroncash/paymentrequest.py
+++ b/electroncash/paymentrequest.py
@@ -857,7 +857,7 @@ class PaymentRequest_BitPay20(PaymentRequest, PrintError):
                 else:
                     # TODO: Fixme -- for now this branch will always be taken because we turned off key download in _get_signing_keys() above
                     self.print_error('Warning: Could not verify whether signing public key is valid:', pubkey.hex(), "(PGP verification is currently disabled)")
-                self.requestor = sig_addr.to_ui_string()
+                self.requestor = owner
                 break
         else:
             self.error = 'failed to verify signature against retrieved keys'


### PR DESCRIPTION
Setting an address based on a public signing key as the requestor can (and has) caused confusion where users think they can send funds. Set the key owner which is hard coded to 'BitPay, Inc.' instead.

Fix has been verified with invoice from test.bitpay.com.

Fixes #2505