### PR TITLE
Trigger on Master branch + Add GitHub Action badge to README

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -1,7 +1,12 @@
 name: Testing
 
 on:
-  - pull_request
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/README.rst
+++ b/README.rst
@@ -8,22 +8,21 @@ Electron Cash - Lightweight Bitcoin Cash client
   Language: Python
   Homepage: https://electroncash.org/
 
-
 .. image:: https://d322cqt584bo4o.cloudfront.net/electron-cash/localized.svg
     :target: https://crowdin.com/project/electron-cash
     :alt: Help translate Electron Cash online
-
 
 .. image:: https://img.shields.io/travis/Electron-Cash/Electron-Cash
     :target: https://travis-ci.org/github/Electron-Cash/Electron-Cash
     :alt: Travis CI
 
+.. image:: https://github.com/Electron-Cash/Electron-Cash/actions/workflows/run-tox.yml/badge.svg?branch=master
+    :target: https://github.com/Electron-Cash/Electron-Cash/actions/workflows/run-tox.yml?query=branch%3Amaster
+    :alt: GitHub Actions Tests
 
 .. image:: https://img.shields.io/coveralls/github/Electron-Cash/Electron-Cash
     :target: https://coveralls.io/github/Electron-Cash/Electron-Cash
     :alt: Coveralls code coverage
-
-
 
 Getting started
 ===============


### PR DESCRIPTION
It's advised to run also on the `master` branch to avoid regression impact. This configuration now also avoids double runs when pushing to pull requests.

Also display the pipeline status of the `master` branch with the link to the workflow of the master overview to the README.rst file.