### PR TITLE
Use a non-zero nr of jobs

### DIFF
--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -273,7 +273,7 @@ if [ "${GIT_SUBMODULE_SKIP:-0}" -eq 0 ] ; then
         # See https://public-inbox.org/git/20191013064314.GA28018@sigill.intra.peff.net/
         gitflags="-c protocol.version=2"
     fi
-    git $gitflags submodule update --init --jobs 0 $GIT_SUBMODULE_FLAGS || fail "Failed to update git submodules"
+    git $gitflags submodule update --init --jobs 3 $GIT_SUBMODULE_FLAGS || fail "Failed to update git submodules"
 fi
 
 # This variable is set to avoid sourcing base.sh multiple times


### PR DESCRIPTION
Do not use zero jobs during `git submodule update`, since the git interface is changed. Zero jobs are no longer accepted.

See change: https://github.com/git/git/commit/51243f9f0f6a932ea579fd6f8014b348f8c2a523