### PR TITLE
Only archive GH Actions artifacts once

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -29,12 +29,13 @@ jobs:
     - name: Test with tox
       run: tox
     - name: Archive code coverage (Unittest)
+      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11')
       uses: actions/upload-artifact@v3
       with:
         name: code-coverage-report
         path: htmlcov
     - name: Archive code coverage (Regtest)
-      if: matrix.os == 'ubuntu-latest'
+      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11')
       uses: actions/upload-artifact@v3
       with:
         name: code-coverage-report-regtest


### PR DESCRIPTION
It's redundant and error prone to archive the coverage report(s) for all test jobs. Only do it for linux+python3.11.