### PR TITLE
contrib: fix find_restricted_dependencies for deps with version range

### DIFF
--- a/contrib/deterministic-build/find_restricted_dependencies.py
+++ b/contrib/deterministic-build/find_restricted_dependencies.py
@@ -28,13 +28,17 @@ for p in sys.stdin.read().split():
     except ValueError:
         raise Exception("Package could not be found: {}=={}".format(p, v))
     try:
-        for r in data["requires_dist"]:
+        for r in data["requires_dist"]:  # type: str
             if ";" not in r:
                 continue
-            d, restricted = r.split(";", 1)
-            if check_restriction(d, restricted):
-                print(d, sep=" ")
-                print("Installing {} from {} although it is only needed for {}".format(d, p, restricted), file=sys.stderr)
+            # example value for "r" at this point: "pefile (>=2017.8.1) ; sys_platform == \"win32\""
+            dep, restricted = r.split(";", 1)
+            dep = dep.strip()
+            restricted = restricted.strip()
+            dep_basename = dep.split(" ")[0]
+            if check_restriction(dep, restricted):
+                print(dep_basename, sep=" ")
+                print("Installing {} from {} although it is only needed for {}".format(dep, p, restricted), file=sys.stderr)
     except TypeError:
         # Has no dependencies at all
         continue


### PR DESCRIPTION
New release of pyinstaller (4.3) broke the script (which is used by freeze_packages.sh).

-----

Compare:

$ wget https://pypi.org/pypi/pyinstaller/4.3/json
$ cat json | jq ".info.requires_dist"
[
  "setuptools",
  "altgraph",
  "pyinstaller-hooks-contrib (>=2020.6)",
  "importlib-metadata ; python_version < \"3.8\"",
  "macholib (>=1.8) ; sys_platform == \"darwin\"",
  "pefile (>=2017.8.1) ; sys_platform == \"win32\"",
  "pywin32-ctypes (>=0.2.0) ; sys_platform == \"win32\"",
  "tinyaes (>=1.0.0) ; extra == 'encryption'",
  "pytest (>=2.7.3) ; extra == 'hook_testing'",
  "execnet (>=1.5.0) ; extra == 'hook_testing'",
  "psutil ; extra == 'hook_testing'"
]

$ wget https://pypi.org/pypi/pyinstaller/4.2/json | jq . $ cat json | jq ".info.requires_dist"
null

$ wget https://pypi.org/pypi/qrcode/6.1/json
$ cat json | jq ".info.requires_dist"
[
  "six",
  "colorama ; platform_system == \"Windows\"",
  "tox ; extra == 'dev'",
  "pytest ; extra == 'dev'",
  "mock ; (python_version < \"3\") and extra == 'dev'",
  "zest.releaser[recommended] ; extra == 'maintainer'",
  "pillow ; extra == 'pil'",
  "pytest ; extra == 'test'",
  "pytest-cov ; extra == 'test'",
  "mock ; (python_version < \"3\") and extra == 'test'"
]