### PR TITLE
Make bottom panel resizable. Other layout tweaks

### DIFF
--- a/electroncash_gui/qt/token_history_list.py
+++ b/electroncash_gui/qt/token_history_list.py
@@ -74,8 +74,8 @@ class TokenHistoryList(MyTreeWidget, PrintError):
         MyTreeWidget.__init__(self, parent, self.create_menu, [], self.Col.description, deferred_updates=True)
         PrintError.__init__(self)
 
-        headers = ['', '', _('Date'), _('Description'), _(""), _(""), _('Category ID'), _('Fungible Amount'),
-                   _('NFT Amount'), _("Fungible Balance"), _("NFT Balance")]
+        headers = ['', '', _('Date'), _('Description'), '', '', _('Category ID'), _('Fungible Amount'),
+                   _('NFT Amount'), _('Fungible Balance'), _('NFT Balance')]
         self.update_headers(headers)
         self.setColumnHidden(1, True)
         self.setSortingEnabled(True)

--- a/electroncash_gui/qt/token_list.py
+++ b/electroncash_gui/qt/token_list.py
@@ -70,7 +70,7 @@ class TokenList(MyTreeWidget, util.PrintError):
 
     def __init__(self, parent: ElectrumWindow):
         assert isinstance(parent, ElectrumWindow)
-        columns = [_('Category ID'), _('Label'), _('Fungible Amount'), _('NFTs'), _(''), _(''), _('NFT Flags'),
+        columns = [_('Category ID'), _('Label'), _('Fungible Amount'), _('NFTs'), '', '', _('NFT Flags'),
                    _('Num UTXOs'),
                    self.amount_heading.format(unit=parent.base_unit()), _('Output Point')]
         super().__init__(parent=parent, create_menu=self.create_menu, headers=columns,

--- a/electroncash_gui/qt/token_send.py
+++ b/electroncash_gui/qt/token_send.py
@@ -163,7 +163,7 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
         if self.form_mode == self.FormMode.mint:
             tw.setHeaderLabels(self.headers_baton)
             tw.setStyleSheet("QTreeView::item:hover { background: none; }")
-            tw.header().setSectionResizeMode(self.ColsBaton.category_id, QtWidgets.QHeaderView.ResizeToContents)
+            tw.header().setSectionResizeMode(self.ColsBaton.category_id, QtWidgets.QHeaderView.Stretch)
             tw.header().setSectionResizeMode(self.ColsBaton.buttons, QtWidgets.QHeaderView.ResizeToContents)
             tw.header().setStretchLastSection(False)
             tw.header().resizeSection(self.ColsBaton.icon, 42)
@@ -173,9 +173,9 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
             tw.header().setSectionResizeMode(self.ColsTok.amount_send, QtWidgets.QHeaderView.Stretch)
         vbox_gb.addWidget(tw)
         splitter.addWidget(gb)
-        splitter.setStretchFactor(splitter.count()-1, 10)
+        splitter.setStretchFactor(splitter.count()-1, 38)
 
-        # Middle pannel
+        # Middle panel
         if self.form_mode == self.FormMode.send:
             gb_nft_title = _("NFTs to Send")
         elif self.form_mode == self.FormMode.edit:
@@ -214,9 +214,11 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
         self.tw_nft.itemChanged.connect(self.on_nft_item_changed)
 
         splitter.addWidget(gb_nft)
-        splitter.setStretchFactor(splitter.count()-1, 10)
+        splitter.setStretchFactor(splitter.count()-1, 100)
 
         # Pay To
+        vbox_bottom = QtWidgets.QVBoxLayout()
+        vbox_bottom.setContentsMargins(0, 0, 0, 0)  # No inset
         gb_payto = self.gb_payto = QtWidgets.QGroupBox(_("Pay To"))
         vbox_payto = QtWidgets.QVBoxLayout(gb_payto)
         self.te_payto = te = ScanQRTextEdit()
@@ -230,13 +232,12 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
             gb_payto.setHidden(True)
             self.te_payto.setText(self.wallet.get_unused_address(for_change=True).to_token_string())
 
-        splitter.addWidget(gb_payto)
-        splitter.setStretchFactor(splitter.count()-1, 1)
-        vbox.addWidget(splitter)
-        vbox.setStretch(vbox.count()-1, 10)
+        vbox_bottom.addWidget(gb_payto)
+        vbox_bottom.setStretch(vbox_bottom.count()-1, 1)
 
         # BCH to send plus description
         hbox = QtWidgets.QHBoxLayout()
+        vbox_bottom.setStretch(vbox.count()-1, 100)
         hbox.setContentsMargins(0, 0, 0, 0)  # No inset
         # Additional BCH to Send
         self._setup_additional_bch_gbox(hbox)
@@ -250,8 +251,15 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
         self.te_desc.setPlaceholderText(_("Memo") + "...")
         hbox.addWidget(gb_desc)
 
-        vbox.addLayout(hbox)
-        vbox.setStretch(vbox.count()-1, 1)
+        vbox_bottom.addLayout(hbox)
+        vbox_bottom.setStretch(vbox_bottom.count()-1, 100)
+        w_bottom = QtWidgets.QWidget()
+        w_bottom.setContentsMargins(0, 0, 0, 0)  # No inset
+        w_bottom.setLayout(vbox_bottom)
+        splitter.addWidget(w_bottom)
+        splitter.setStretchFactor(splitter.count()-1, 20)
+        vbox.addWidget(splitter)
+        vbox.setStretch(vbox.count()-1, 100)
 
         # Bottom buttons
         hbox = QtWidgets.QHBoxLayout()
@@ -433,7 +441,7 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
         self.on_ui_state_changed()
 
     def on_mint_mode_top_tree_dbl_click(self, item, column):
-        """Slot to make double-clicks do the same things as clicking the "Mint NFTs..." button"""
+        """Slot to make double-clicks do the same things as clicking the "Mint..." button"""
         if self.form_mode != self.FormMode.mint:
             return
         baton_name = item.data(0, self.DataRoles.output_point)
@@ -538,7 +546,7 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
                         self.add_nft_to_mint(_category_id, _baton_name)
                         self.on_ui_state_changed()
                     but.clicked.connect(on_clicked)
-                    but.setText(_("Mint NFTs..."))
+                    but.setText(_("Mint..."))
                     but.setObjectName("mint_" + baton_name)
                     but.setToolTip("Use this Minting token to mint new NFTs")
                     hbox.addWidget(but)

--- a/electroncash_gui/qt/token_send.py
+++ b/electroncash_gui/qt/token_send.py
@@ -173,7 +173,10 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
             tw.header().setSectionResizeMode(self.ColsTok.amount_send, QtWidgets.QHeaderView.Stretch)
         vbox_gb.addWidget(tw)
         splitter.addWidget(gb)
-        splitter.setStretchFactor(splitter.count()-1, 38)
+        if self.form_mode == self.FormMode.mint:
+            splitter.setStretchFactor(splitter.count()-1, 38)
+        else:
+            splitter.setStretchFactor(splitter.count()-1, 100)
 
         # Middle panel
         if self.form_mode == self.FormMode.send:
@@ -257,7 +260,10 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
         w_bottom.setContentsMargins(0, 0, 0, 0)  # No inset
         w_bottom.setLayout(vbox_bottom)
         splitter.addWidget(w_bottom)
-        splitter.setStretchFactor(splitter.count()-1, 20)
+        if self.form_mode == self.FormMode.mint:
+            splitter.setStretchFactor(splitter.count()-1, 38)
+        else:
+            splitter.setStretchFactor(splitter.count()-1, 26)
         vbox.addWidget(splitter)
         vbox.setStretch(vbox.count()-1, 100)
 


### PR DESCRIPTION
- Adjusted the lower panel on the send_token form so that it's adjustable while keeping the Pay To field small, using stretch factors.  If this still causes issues, I can backtrack a little to my first tweak that stops the Pay To field from being adjustable
- Set more useful initial height ratios - particularly so that the middle panel on the mint form (which will typically have the most content) is largest.
- Adjusted the top table on the Mint form so that the category ID fits on narrow views without pushing content off the right
- Dealt with a couple leftover `_("")`s