### PR TITLE
Satochip plugin: patch method card_verify_authenticity() in qt.py

### DIFF
--- a/electroncash_plugins/satochip/qt.py
+++ b/electroncash_plugins/satochip/qt.py
@@ -454,7 +454,7 @@ class SatochipSettingsDialog(WindowModalDialog):
             return False, txt_ca, txt_subca, txt_device, txt_error
 
         # perform challenge-response with the card to ensure that the key is correctly loaded in the device
-        is_valid_chalresp, txt_error = self.cc.card_challenge_response_pki(device_pubkey)
+        is_valid_chalresp, txt_error = client.cc.card_challenge_response_pki(device_pubkey)
 
         return is_valid_chalresp, txt_ca, txt_subca, txt_device, txt_error
 


### PR DESCRIPTION
The method card_verify_authenticity() verifies the authenticity of a Satochip hardware wallet.

This PR replaces self.cc with client.cc to correct a bug that crashes the application.