### PR TITLE
Servers: Fix missing comma

### DIFF
--- a/electroncash/servers.json
+++ b/electroncash/servers.json
@@ -147,7 +147,7 @@
     },
     "fulcrum.jettscythe.xyz": {
         "pruning": "-",
-        "s": "50002"
+        "s": "50002",
         "version": "1.5.0"
     }
 }


### PR DESCRIPTION
`fulcrum.jettscythe.xyz` was missing a comma