### PR TITLE
AppImage: Update package versions

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -4,6 +4,7 @@ ARG UBUNTU_MIRROR=http://archive.ubuntu.com/ubuntu/
 
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
+# If a package version does not exist anymore you can use "apt-cache policy <pkg>" to display the available versions
 RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/apt/sources.list && \
     echo deb ${UBUNTU_MIRROR} bionic-updates main restricted universe multiverse >> /etc/apt/sources.list && \
     echo deb ${UBUNTU_MIRROR} bionic-backports main restricted universe multiverse >> /etc/apt/sources.list && \
@@ -18,7 +19,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
         libtool=2.4.6-2 \
         xz-utils=5.2.2-1.3 \
         libffi-dev=3.2.1-8 \
-        libncurses5-dev=6.1-1ubuntu1.18.04 \
+        libncurses5-dev=6.1-1ubuntu1.18.04.1 \
         libsqlite3-dev=3.22.0-1ubuntu0.7 \
         libusb-1.0-0-dev=2:1.0.21-2 \
         libudev-dev=237-3ubuntu10.57 \
@@ -47,7 +48,7 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
         zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
         libfreetype6=2.8.1-2ubuntu2.2 \
         libfontconfig1=2.12.6-0ubuntu2 \
-        libssl-dev=1.1.1-1ubuntu2.1~18.04.22 \
+        libssl-dev=1.1.1-1ubuntu2.1~18.04.23 \
         rustc=1.65.0+dfsg0ubuntu1~llvm2-0ubuntu0.18.04 \
         cargo=0.66.0+ds0ubuntu0.libgit2-0ubuntu0.18.04 \
         && \


### PR DESCRIPTION
Previous versions are unavailable. This also adds a small comment explaining how to query existing package versions now that the Ubuntu package search dropped support for 18.04 (Bionic).