### PR TITLE
Setup: Replace imp module with importlib

### DIFF
--- a/electroncash/tests/regtest/docker-compose.yml
+++ b/electroncash/tests/regtest/docker-compose.yml
@@ -32,4 +32,4 @@ volumes:
     driver_opts:
       o: bind
       type: none
-      device: electroncash/tests/regtest/configs
+      device: ./configs

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import setuptools.command.sdist
 import os
 import sys
 import platform
-import imp
+import importlib.util
 import argparse
 
 with open('contrib/requirements/requirements.txt') as f:
@@ -19,7 +19,13 @@ with open('contrib/requirements/requirements-hw.txt') as f:
 with open('contrib/requirements/requirements-binaries.txt') as f:
     requirements_binaries = f.read().splitlines()
 
-version = imp.load_source('version', 'electroncash/version.py')
+def load_source(module_name, module_path):
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+version = load_source('version', 'electroncash/version.py')
 
 if sys.version_info[:3] < (3, 7):
     sys.exit("Error: Electron Cash requires Python version >= 3.7...")


### PR DESCRIPTION
Fixes https://github.com/Electron-Cash/Electron-Cash/issues/2661

The imp module was removed in Python 3.12 so the old code does not work anymore. Since we only support Python >= 3.6 we don't need to deal with compatibility with older versions.

This depends on #2664 to unbreak the build.