### PR TITLE
Tests: Fix docker-compose bind mount of configuration files

### DIFF
--- a/electroncash/tests/regtest/docker-compose.yml
+++ b/electroncash/tests/regtest/docker-compose.yml
@@ -32,4 +32,4 @@ volumes:
     driver_opts:
       o: bind
       type: none
-      device: electroncash/tests/regtest/configs
+      device: ./configs


### PR DESCRIPTION
`pytest-docker` switched from `docker-compose` to `docker compose` in version 2.0.0:

https://github.com/avast/pytest-docker/releases/tag/v2.0.0

The new docker compose v2 works slightly different in some cases. In this case the path for our bind mount must be relative to the `docker-compose.yml` file.

If the build fails make sure you can run `docker compose`, if not your docker installation is too old.