### PR TITLE
Tests: Update Python 3.12 to 3.12.0-rc.2, include Windows

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -15,10 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12.0-beta.4']
-        exclude:
-          - os: windows-latest
-            python-version: '3.12.0-beta.4'
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12.0-rc.2']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This updates the Python 3.12 tests to the latest RC2 version.

This also removes the exclusion of Windows that was added in https://github.com/Electron-Cash/Electron-Cash/pull/2662 because the current release candidate does not crash on startup anymore.

fixes #2673