### PR TITLE
plugins: Fix Optional Features list and External Plugin loading

### DIFF
--- a/electroncash/plugins.py
+++ b/electroncash/plugins.py
@@ -265,7 +265,10 @@ class Plugins(DaemonThread):
             raise RuntimeError("%s implementation for %s plugin not found"
                                % (self.gui_name, name))
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        if sys.version_info >= (3, 10):
+            spec.loader.exec_module(module)
+        else:
+            module = spec.loader.load_module(full_name)
         plugin = module.Plugin(self, self.config, name)
         plugin.set_enabled_prefix(EXTERNAL_USE_PREFIX)
         self.add_jobs(plugin.thread_jobs())

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -5152,7 +5152,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 run_hook('init_qt', gui_object)
 
         for i, descr in enumerate(plugins.internal_plugin_metadata.values()):
-            name = descr['__name__']
+            # descr["__name__"] is the fully qualified package name
+            # (electroncash_plugins.name)
+            name = descr["__name__"].split(".")[-1]
             p = plugins.get_internal_plugin(name)
             if descr.get('registers_keystore'):
                 continue


### PR DESCRIPTION
I accidentally broke this in #2662, not sure how I missed this when testing :\

One of these is a backport of Electrum-ABC.