### PR TITLE
tests: Use Python 3.12

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12.0-rc.2']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3
@@ -30,13 +30,13 @@ jobs:
     - name: Test with tox
       run: tox
     - name: Archive code coverage (Unittest)
-      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11')
+      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12')
       uses: actions/upload-artifact@v3
       with:
         name: code-coverage-report
         path: htmlcov
     - name: Archive code coverage (Regtest)
-      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11')
+      if: (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12')
       uses: actions/upload-artifact@v3
       with:
         name: code-coverage-report-regtest


### PR DESCRIPTION
This changes the Python version from `3.12.0-rc.2` to `3.12` which was recently released and we also upload the artifacts from that version.