### PR TITLE
secp256k1: Improve warning message by adding path and exception details

### DIFF
--- a/electroncash/secp256k1.py
+++ b/electroncash/secp256k1.py
@@ -56,15 +56,19 @@ def _load_library():
                          'libsecp256k1.so.0')  # fall back to system lib, if any
 
     secp256k1 = None
+    secp256k1_exceptions = {}
     for lp in library_paths:
         try:
             secp256k1 = ctypes.cdll.LoadLibrary(lp)
         except:
+            secp256k1_exceptions[lp] = sys.exc_info()[0]
             continue
         if secp256k1:
             break
     if not secp256k1:
         print_stderr('[secp256k1] warning: libsecp256k1 library failed to load')
+        for path, exception in secp256k1_exceptions.items():
+            print_stderr(f'[secp256k1] warning: loading from {path} failed with: {exception}')
         return None
 
     try:


### PR DESCRIPTION
To be better able to diagnose loading failures of `libsecp256k1-0.dll` this patch adds a more detailed warning print to the failure case where all tried paths and their errors are listed.

Example:

```
[secp256k1] warning: libsecp256k1 library failed to load
[secp256k1] warning: loading from libsecp256k1-0.dll failed with: <class 'FileNotFoundError'>
[secp256k1] warning: loading from H:\dev\Electron-Cash\electroncash\libsecp256k1-0.dll failed with: <class 'FileNotFoundError'>
```