### PR TITLE
invoice list: Fix window title when importing a file

### DIFF
--- a/electroncash_gui/qt/invoice_list.py
+++ b/electroncash_gui/qt/invoice_list.py
@@ -68,7 +68,7 @@ class InvoiceList(MyTreeWidget):
 
     def import_invoices(self):
         wallet_folder = self.parent.get_wallet_folder()
-        filename, __ = QFileDialog.getOpenFileName(self.parent, "Select your wallet file", wallet_folder)
+        filename, __ = QFileDialog.getOpenFileName(self.parent, _("Select your invoice file"), wallet_folder)
         if not filename:
             return
         try:


### PR DESCRIPTION
The old string refers to a wallet, changed it to invoice instead and made the string translatable.