### PR TITLE
Fix various strings that were wrong, inconsistent or not translatable

### DIFF
--- a/electroncash_gui/qt/contact_list.py
+++ b/electroncash_gui/qt/contact_list.py
@@ -125,7 +125,7 @@ class ContactList(PrintError, MyTreeWidget):
 
     def import_contacts(self):
         wallet_folder = self.parent.get_wallet_folder()
-        filename, __ = QFileDialog.getOpenFileName(self.parent, "Select your wallet file", wallet_folder)
+        filename, __ = QFileDialog.getOpenFileName(self.parent, _("Select your contacts file"), wallet_folder)
         if not filename:
             return
         try:

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -185,7 +185,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         wallet_folder = os.path.dirname(self.storage.path)
 
         def on_choose():
-            path, __ = QFileDialog.getOpenFileName(self, "Select your wallet file", wallet_folder)
+            path, __ = QFileDialog.getOpenFileName(self, _("Select your wallet file"), wallet_folder)
             if path:
                 self.name_e.setText(path)
 

--- a/electroncash_gui/qt/invoice_list.py
+++ b/electroncash_gui/qt/invoice_list.py
@@ -68,7 +68,7 @@ class InvoiceList(MyTreeWidget):
 
     def import_invoices(self):
         wallet_folder = self.parent.get_wallet_folder()
-        filename, __ = QFileDialog.getOpenFileName(self.parent, "Select your wallet file", wallet_folder)
+        filename, __ = QFileDialog.getOpenFileName(self.parent, _("Select your invoice file"), wallet_folder)
         if not filename:
             return
         try:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -583,7 +583,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             return
         if not os.path.exists(wallet_folder):
             wallet_folder = None
-        filename, __ = QFileDialog.getOpenFileName(self, "Select your wallet file", wallet_folder)
+        filename, __ = QFileDialog.getOpenFileName(self, _("Select your wallet file"), wallet_folder)
         if not filename:
             return
         if filename.lower().endswith('.txn'):

--- a/electroncash_gui/qt/token_meta_edit.py
+++ b/electroncash_gui/qt/token_meta_edit.py
@@ -282,7 +282,7 @@ class TokenMetaEditorForm(QtWidgets.QWidget, MessageBoxMixin, PrintError, OnDest
         self.close()
 
     def on_but_icon(self):
-        fn, filt = QtWidgets.QFileDialog.getOpenFileName(self, _("Open File"), "",
+        fn, filt = QtWidgets.QFileDialog.getOpenFileName(self, _("Open icon file"), "",
                                                          "Images (*.png *.svg *.jpg *.jpeg *.ico)")
         if not fn:
             return

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -1677,7 +1677,7 @@ class ElectrumGui(PrintError):
         path = os.path.join(wallets.WalletsMgr.wallets_dir(), wallet_name)
         storage = WalletStorage(path, manual_upgrades=True)
         if not storage.file_exists():
-            onFailure("Wallet File Not Found")
+            onFailure(_("Wallet file not found"))
             return
 
         def DoSwicheroo(pw = None) -> None:
@@ -1740,7 +1740,7 @@ class ElectrumGui(PrintError):
     def show_wallet_share_actions(self, info : wallets.WalletsMgr.Info, vc : UIViewController = None, ipadAnchor : object = None, warnIfUnsafe : bool = True) -> None:
         if vc is None: vc = self.get_presented_viewcontroller()
         if not os.path.exists(info.full_path):
-            self.show_error("Wallet file not found", vc = vc)
+            self.show_error(_("Wallet file not found"), vc = vc)
             return
         if warnIfUnsafe:
             try:
@@ -1770,7 +1770,7 @@ class ElectrumGui(PrintError):
                     utils.show_share_actions(vc = waitDlg, fileName = fn, ipadAnchor = ipadAnchor, objectName = _('Wallet file'),
                                              finishedCompletion = lambda x: Dismiss())
                 else:
-                    def MyCompl() -> None: self.show_error("Could not copy wallet file", vc = vc)
+                    def MyCompl() -> None: self.show_error(_("Could not copy wallet file"), vc = vc)
                     Dismiss(MyCompl, False)
             except:
                 err = str(sys.exc_info()[1])
@@ -1862,7 +1862,7 @@ class ElectrumGui(PrintError):
             if not isinstance(storage, WalletStorage):
                 raise ValueError('usingStorage parameter needs to be a WalletStorage instance or a string path!')
             if not storage.file_exists():
-                raise WalletFileNotFound('Wallet File Not Found')
+                raise WalletFileNotFound(_('Wallet file not found'))
             wallet_name = os.path.split(storage.path)[-1]
             if not storage.is_encrypted():
                 callBack(None)


### PR DESCRIPTION
The titles of load / save dialogs used the wrong title in various locations, this fixes it.

There were also some inconsistent strings which have been made consistent.

This also makes some previously untranlatable string translatable.