### PR TITLE
tests: improve regtest reliability

### DIFF
--- a/contrib/requirements/requirements-regtest.txt
+++ b/contrib/requirements/requirements-regtest.txt
@@ -2,3 +2,4 @@ pytest-docker>=0.10.1
 python-bitcoinrpc>=1.0
 jsonpath-ng>=1.5.3
 jsonrpcclient>=4.0.2
+coverage

--- a/electroncash/tests/regtest/configs/bitcoind.conf
+++ b/electroncash/tests/regtest/configs/bitcoind.conf
@@ -8,5 +8,4 @@ expire=0
 rpcallowip=0.0.0.0/0
 
 [regtest]
-rpcbind=0.0.0.0:18334
-rpcport=18334
+rpcbind=0.0.0.0

--- a/electroncash/tests/regtest/configs/fulcrum.conf
+++ b/electroncash/tests/regtest/configs/fulcrum.conf
@@ -1,4 +1,4 @@
-bitcoind = bitcoind:18334
+bitcoind = bitcoind:18443
 rpcuser = user
 rpcpassword = pass
 peering = 0

--- a/electroncash/tests/regtest/docker-compose.yml
+++ b/electroncash/tests/regtest/docker-compose.yml
@@ -8,16 +8,16 @@ services:
     networks:
       - bitcoin
     ports:
-      - 18333:18334
+      - 18443
   fulcrum:
     image: cculianu/fulcrum:v1.9.0
     command: "Fulcrum /conf/fulcrum.conf"
     networks:
      - bitcoin
     ports:
-      - 51001:51001
-      - 51002:51002
-      - 8081:8080
+      - 51001
+      - 51002
+      - 8080
     depends_on:
     - bitcoind
     volumes:

--- a/electroncash/tests/regtest/test_rpc_misc.py
+++ b/electroncash/tests/regtest/test_rpc_misc.py
@@ -1,4 +1,4 @@
-from .util import poll_for_answer, bitcoind_rpc_connection, EC_DAEMON_RPC_URL, docker_compose_file, fulcrum_service, SUPPORTED_PLATFORM
+from .util import poll_for_answer, get_bitcoind_rpc_connection, EC_DAEMON_RPC_URL, docker_compose_file, fulcrum_service, SUPPORTED_PLATFORM
 
 import pytest
 from typing import Any
@@ -30,7 +30,7 @@ def test_balance(fulcrum_service: Any) -> None:
     """ Verify the `getbalance` RPC """
     addr = poll_for_answer(EC_DAEMON_RPC_URL, request('getunusedaddress'))
 
-    bitcoind = bitcoind_rpc_connection()
+    bitcoind = get_bitcoind_rpc_connection()
 
     bitcoind.generatetoaddress(1, addr)
     result = poll_for_answer(EC_DAEMON_RPC_URL, request('getbalance'), expected_answer=('unmatured', '50'))

--- a/electroncash/tests/regtest/test_rpc_payment_request.py
+++ b/electroncash/tests/regtest/test_rpc_payment_request.py
@@ -1,4 +1,4 @@
-from .util import poll_for_answer, bitcoind_rpc_connection, EC_DAEMON_RPC_URL, docker_compose_file, fulcrum_service, SUPPORTED_PLATFORM
+from .util import poll_for_answer, get_bitcoind_rpc_connection, EC_DAEMON_RPC_URL, docker_compose_file, fulcrum_service, SUPPORTED_PLATFORM
 
 import pytest
 from typing import Any
@@ -9,7 +9,7 @@ from jsonrpcclient import request
 def test_addrequest(fulcrum_service: Any) -> None:
     """ Verify the `addrequest` RPC by creating a request, pay it and remove it """
 
-    bitcoind = bitcoind_rpc_connection()
+    bitcoind = get_bitcoind_rpc_connection()
 
     result = poll_for_answer(EC_DAEMON_RPC_URL, request('listrequests'))
     assert len(result) == 0

--- a/electroncash/tests/regtest/util.py
+++ b/electroncash/tests/regtest/util.py
@@ -8,6 +8,7 @@ import os
 import platform
 from typing import Any, Generator
 import pytest
+import pytest_docker
 import requests
 
 from bitcoinrpc.authproxy import AuthServiceProxy
@@ -20,8 +21,8 @@ _bitcoind = None
 SUPPORTED_PLATFORM = platform.machine() in ("AMD64", "x86_64") and platform.system() in "Linux"
 
 EC_DAEMON_RPC_URL = "http://user:pass@localhost:12342"
-FULCRUM_STATS_URL = "http://localhost:8081/stats"
-BITCOIND_RPC_URL = "http://user:pass@0.0.0.0:18333"
+FULCRUM_STATS_URL = "http://{host}:{port}/stats"
+BITCOIND_RPC_URL = "http://user:pass@{host}:{port}"
 
 def poll_for_answer(url: Any, json_req: Any = None, expected_answer: Any = None, poll_interval: int = 1, poll_timeout: int = 10) -> Any:
     """ Poll an RPC method until timeout or an expected answer has been received """
@@ -55,14 +56,22 @@ def poll_for_answer(url: Any, json_req: Any = None, expected_answer: Any = None,
         time.sleep(poll_interval)
         current = time.time()
 
-def bitcoind_rpc_connection() -> AuthServiceProxy:
+def get_bitcoind_rpc_connection() -> AuthServiceProxy:
+    if _bitcoind is not None:
+        return _bitcoind
+    raise RuntimeError("Bitcoind connection not created yet")
+
+def make_bitcoind_rpc_connection(docker_ip: str, docker_services: pytest_docker.plugin.Services) -> AuthServiceProxy:
     """ Connects to bitcoind, generates 100 blocks and returns the connection """
     global _bitcoind
     if _bitcoind is not None:
         return _bitcoind
-    _bitcoind = AuthServiceProxy(BITCOIND_RPC_URL)
 
-    poll_for_answer(BITCOIND_RPC_URL, request('uptime'))
+    url = BITCOIND_RPC_URL.format(host=docker_ip, port=docker_services.port_for("bitcoind", 18443))
+
+    _bitcoind = AuthServiceProxy(url)
+
+    poll_for_answer(url, request('uptime'))
     block_count = _bitcoind.getblockcount()
     if block_count < 101:
         _bitcoind.generate(101)
@@ -71,7 +80,7 @@ def bitcoind_rpc_connection() -> AuthServiceProxy:
 
 # Creates a temp directory on disk for wallet storage
 # Starts a deamon, creates and loads a wallet
-def start_ec_daemon() -> None:
+def start_ec_daemon(docker_ip: str, docker_services: pytest_docker.plugin.Services) -> None:
     """
     Creates a temp directory on disk for wallet storage
     Starts a deamon, creates and loads a wallet
@@ -80,8 +89,27 @@ def start_ec_daemon() -> None:
         assert False
     os.mkdir(_datadir + "/regtest")
     shutil.copyfile("electroncash/tests/regtest/configs/electron-cash-config", _datadir + "/regtest/config")
-    subprocess.run(["python3", "-m", "coverage", "run", "--data-file=.coverage-regtest", "electron-cash", "--regtest", "-D", _datadir, "-w", _datadir+"/default_wallet", "daemon", "start"], check=True)
-    result = poll_for_answer(EC_DAEMON_RPC_URL, request('version'))
+
+    args = ["python3", "-m", "coverage", "run", "--data-file=.coverage-regtest"]
+
+    fulcrum_ssl_port = docker_services.port_for("fulcrum", 51002)
+    args += [
+        "electron-cash",
+        "-v",
+        "--regtest",
+        "-D",
+        _datadir,
+        "-w",
+        _datadir + "/default_wallet",
+        "daemon",
+        "start",
+        "--oneserver",
+        "--server",
+        f"{docker_ip}:{fulcrum_ssl_port}:s",
+    ]
+
+    subprocess.run(args, check=True)
+    result = poll_for_answer(EC_DAEMON_RPC_URL, request("version"))
 
     from ...version import PACKAGE_VERSION
     assert result == PACKAGE_VERSION
@@ -110,7 +138,7 @@ def docker_compose_file(pytestconfig) -> str:
     return os.path.join(str(pytestconfig.rootdir), "electroncash/tests/regtest/docker-compose.yml")
 
 @pytest.fixture(scope="session")
-def fulcrum_service(docker_services: Any) -> Generator[None, None, None]:
+def fulcrum_service(docker_ip: str, docker_services: pytest_docker.plugin.Services) -> Generator[None, None, None]:
     """ Makes sure all services (bitcoind, fulcrum and the EC daemon) are up and running """
     global _datadir
     global _bitcoind
@@ -118,11 +146,13 @@ def fulcrum_service(docker_services: Any) -> Generator[None, None, None]:
         yield
     else:
         _datadir = tempfile.mkdtemp()
-        _bitcoind = bitcoind_rpc_connection()
-        poll_for_answer(FULCRUM_STATS_URL, expected_answer=('Controller.TxNum', 102))
+        _bitcoind = make_bitcoind_rpc_connection(docker_ip, docker_services)
+
+        stats_url = FULCRUM_STATS_URL.format(host=docker_ip, port=docker_services.port_for("fulcrum", 8080))
+        poll_for_answer(stats_url, expected_answer=('Controller.TxNum', 102))
 
         try:
-            start_ec_daemon()
+            start_ec_daemon(docker_ip, docker_services)
             yield
         finally:
             stop_ec_daemon()

--- a/electroncash/tests/regtest/util.py
+++ b/electroncash/tests/regtest/util.py
@@ -12,7 +12,7 @@ import pytest_docker
 import requests
 
 from bitcoinrpc.authproxy import AuthServiceProxy
-from jsonrpcclient import parse as rpc_parse, request
+from jsonrpcclient import parse as rpc_parse, request, Error as rpc_Error, Ok as rpc_Ok
 from jsonpath_ng import parse as path_parse
 
 _datadir = None
@@ -39,7 +39,11 @@ def poll_for_answer(url: Any, json_req: Any = None, expected_answer: Any = None,
                 if resp.status_code == 500:
                     retry = True
                 else:
-                    json_result = rpc_parse(resp.json()).result
+                    parsed = rpc_parse(resp.json())
+                    if isinstance(parsed, rpc_Ok):
+                        json_result = parsed.result
+                    else:
+                        raise RuntimeError(f"Unable to parse JSON-RPC: {parsed.message}")
 
             if expected_answer is not None and not retry:
                 path, answer = expected_answer

--- a/electroncash/tests/regtest/util.py
+++ b/electroncash/tests/regtest/util.py
@@ -59,6 +59,7 @@ def poll_for_answer(url: Any, json_req: Any = None, expected_answer: Any = None,
             pass
         time.sleep(poll_interval)
         current = time.time()
+    raise TimeoutError("Timed out waiting for an answer")
 
 def get_bitcoind_rpc_connection() -> AuthServiceProxy:
     if _bitcoind is not None:


### PR DESCRIPTION
The regtest tests are sometimes flaky when the machine running the test already has a port bound. To fix this we let docker choose free ports to bind on the host and get them via pytest-docker's `port_for` method.

There are also some other minor fixes in this.
