### PR TITLE
Implemented a new wallet type: `multi_xpub`

### DIFF
--- a/electroncash/base_wizard.py
+++ b/electroncash/base_wizard.py
@@ -196,7 +196,8 @@ class BaseWizard(util.PrintError):
                 _("To create a spending wallet, please enter a master private key (xprv/yprv/zprv)."),
                 "\n\n" + _("You may enter multiple xpub and/or xprv keys to create a multi-xpub wallet."),
             ])
-            self.add_xpub_dialog(title=title, message=message, run_next=self.on_restore_from_key, is_valid=is_valid)
+            self.add_xpub_dialog(title=title, message=message, run_next=self.on_restore_from_key, is_valid=is_valid,
+                                 allow_multi=True)
         else:
             i = len(self.keystores) + 1
             self.add_cosigner_dialog(index=i, run_next=self.on_restore_from_key, is_valid=keystore.is_bip32_key)

--- a/electroncash/base_wizard.py
+++ b/electroncash/base_wizard.py
@@ -189,7 +189,7 @@ class BaseWizard(util.PrintError):
                 # Note: We accept multiple xpubs/xprvs here. For multiples ultimately the wallet created will be
                 # a MultiXpubWallet in self.on_keystore()
                 ks = keystore.from_master_keys(multiline_text)
-                return len(ks) >= 1
+                return len(ks) >= 1 and len(ks) == len(multiline_text.split())
             title = _("Create keystore from one or more master key(s)")
             message = ' '.join([
                 _("To create a watching-only wallet, please enter your master public key (xpub/ypub/zpub)."),

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -25,6 +25,7 @@
 # SOFTWARE.
 
 import inspect
+from typing import Optional
 from . import bitcoin
 from .bitcoin import *
 
@@ -285,6 +286,11 @@ class Xpub:
         self.xpub_receive = None
         self.xpub_change = None
 
+    def dump(self):
+        d = dict()
+        d['xpub'] = self.xpub
+        return d
+
     def get_master_public_key(self):
         return self.xpub
 
@@ -357,25 +363,38 @@ class Xpub:
         return derivation
 
 
-class BIP32_KeyStore(Deterministic_KeyStore, Xpub):
+class Xprv(Xpub):
 
-    def __init__(self, d):
-        Xpub.__init__(self)
-        Deterministic_KeyStore.__init__(self, d)
-        self.xpub = d.get('xpub')
-        self.xprv = d.get('xprv')
-        self.derivation = d.get('derivation')
+    xprv: Optional[str] = None
 
     def dump(self):
-        d = Deterministic_KeyStore.dump(self)
-        d['type'] = 'bip32'
-        d['xpub'] = self.xpub
-        d['xprv'] = self.xprv
-        d['derivation'] = self.derivation
+        d = super().dump()  # Adds key: "xpub" -> Optional[str]
+        d["xprv"] = self.xprv
         return d
 
-    def get_master_private_key(self, password):
+    def get_master_private_key(self, password: Optional[str]) -> Optional[str]:
+        """Returns the xprv as a string, if self.has_master_private_key(). Raises InvalidPassword if we lack
+        an xprv and password is not None.
+
+        Also raises InvalidPassword if the password param doesn't correspond to the xprv's encryption
+        (if any).
+
+        Pass password=None if you know the xprv is unencrypted or if you want to see the encrypted
+        version of it.  Passing password=None never raises, and will always return either None (if we lack
+        an xprv), or an str if we have one (in which case it may be the encrypted xprv if
+        self.is_master_private_key_encrypted() == True)"""
         return pw_decode(self.xprv, password)
+
+    def has_master_private_key(self):
+        return self.xprv is not None
+
+    def is_master_private_key_encrypted(self):
+        if self.has_master_private_key():
+            try:
+                self.check_password(None)
+            except InvalidPassword:
+                return True
+        return False
 
     def check_password(self, password):
         xprv = pw_decode(self.xprv, password)
@@ -387,6 +406,39 @@ class BIP32_KeyStore(Deterministic_KeyStore, Xpub):
         if deserialize_xprv(xprv)[4] != deserialize_xpub(self.xpub)[4]:
             raise InvalidPassword()
 
+    def add_xprv(self, xprv):
+        self.xprv = xprv
+        self.xpub = bitcoin.xpub_from_xprv(xprv)
+        self.xpub_change = self.xpub_receive = None  # Clear cached
+
+    def get_private_key(self, sequence, password):
+        xprv = self.get_master_private_key(password)
+        _, _, _, _, c, k = deserialize_xprv(xprv)
+        pk = bip32_private_key(sequence, k, c)
+        return pk, True
+
+    def update_password(self, old_password, new_password):
+        if self.xprv is not None:
+            b = pw_decode(self.xprv, old_password)
+            self.xprv = pw_encode(b, new_password)
+
+
+class BIP32_KeyStore(Deterministic_KeyStore, Xprv):
+
+    def __init__(self, d):
+        Xprv.__init__(self)
+        Deterministic_KeyStore.__init__(self, d)
+        self.xpub = d.get('xpub')
+        self.xprv = d.get('xprv')
+        self.derivation = d.get('derivation')
+
+    def dump(self):
+        d = Xprv.dump(self)  # Adds keys: "xpub" -> Optional[str], "xprv" -> Optional[str]
+        d.update(Deterministic_KeyStore.dump(self))  # Adds seed, passphrase, seed_type
+        d['type'] = 'bip32'
+        d['derivation'] = self.derivation
+        return d
+
     def update_password(self, old_password, new_password):
         self.check_password(old_password)
         if new_password == '':
@@ -397,9 +449,7 @@ class BIP32_KeyStore(Deterministic_KeyStore, Xpub):
         if self.passphrase:
             decoded = self.get_passphrase(old_password)
             self.passphrase = pw_encode(decoded, new_password)
-        if self.xprv is not None:
-            b = pw_decode(self.xprv, old_password)
-            self.xprv = pw_encode(b, new_password)
+        Xprv.update_password(self, old_password, new_password)
 
     def has_derivation(self) -> bool:
         """ Note: the derivation path may not always be saved. Older versions
@@ -407,11 +457,7 @@ class BIP32_KeyStore(Deterministic_KeyStore, Xpub):
         return bool(self.derivation)
 
     def is_watching_only(self):
-        return self.xprv is None
-
-    def add_xprv(self, xprv):
-        self.xprv = xprv
-        self.xpub = bitcoin.xpub_from_xprv(xprv)
+        return not self.has_master_private_key()
 
     def add_xprv_from_seed(self, bip32_seed, xtype, derivation):
         xprv, xpub = bip32_root(bip32_seed, xtype)
@@ -419,13 +465,7 @@ class BIP32_KeyStore(Deterministic_KeyStore, Xpub):
         self.add_xprv(xprv)
         self.derivation = derivation
 
-    def get_private_key(self, sequence, password):
-        xprv = self.get_master_private_key(password)
-        _, _, _, _, c, k = deserialize_xprv(xprv)
-        pk = bip32_private_key(sequence, k, c)
-        return pk, True
-
-    def set_wallet_advice(self, addr, advice): #overrides KeyStore.set_wallet_advice
+    def set_wallet_advice(self, addr, advice):  # overrides KeyStore.set_wallet_advice
         self.wallet_advice[addr] = advice
 
 

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -835,8 +835,10 @@ def from_master_keys(multiline_text: str):
     ret = []
     for line in multiline_text.split():
         line = line.strip()
-        if not line:
-            continue
-        k = from_master_key(line)
-        ret.append(k)
+        if line:
+            try:
+                k = from_master_key(line)
+            except:
+                continue
+            ret.append(k)
     return ret

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -690,7 +690,6 @@ def hardware_keystore(d):
     raise BaseException('unknown hardware type', hw_type)
 
 def load_keystore(storage, name):
-    w = storage.get('wallet_type', 'standard')
     d = storage.get(name, {})
     t = d.get('type')
     if not t:
@@ -831,3 +830,13 @@ def from_master_key(text):
     else:
         raise BaseException('Invalid key')
     return k
+
+def from_master_keys(multiline_text: str):
+    ret = []
+    for line in multiline_text.split():
+        line = line.strip()
+        if not line:
+            continue
+        k = from_master_key(line)
+        ret.append(k)
+    return ret

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -4442,7 +4442,6 @@ class MultiXPubWallet(Multi_Wallet, Deterministic_Wallet):
         for d in l:
             assert isinstance(d, dict)
             k = load_keystore({"dummy": d}, "dummy")
-            #assert isinstance(k, BIP32_KeyStore), "MultiXPubWallet currently only supports BIP32_KeyStore"
             self.keystores.append(k)
 
     def get_pubkey(self, c, i):

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -3517,6 +3517,15 @@ class Abstract_Wallet(PrintError, SPVDelegate):
     def get_fingerprint(self):
         raise NotImplementedError()
 
+    def is_watching_only(self):
+        """Reimplemented in subclasses"""
+        raise NotImplementedError()
+
+    def can_fully_sign_for_all_addresses(self):
+        """Checks that all keystores are able to sign. Relevant for MultiXPubWallet hybrid wallets which have
+        multiple keystores, not all of which have the private keys for their associated addresses."""
+        return not self.is_watching_only() and all(not ks.is_watching_only() for ks in self.get_keystores())
+
     def can_import_privkey(self):
         return False
 

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -408,7 +408,12 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         return self.basename()
 
     def get_master_public_key(self):
+        """Subclasses that use master pubkeys should reimplement this"""
         return None
+
+    def get_master_public_keys(self):
+        """Subclasses that use master pubkeys should reimplement this"""
+        return []
 
     def load_keystore_wrapper(self):
         """ Loads the keystore, but also tries to preserve derivation(s). Older

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -4614,6 +4614,7 @@ class MultiXPubWallet(Deterministic_Wallet):
         for d in l:
             assert isinstance(d, dict)
             k = load_keystore({"dummy": d}, "dummy")
+            assert k.is_deterministic(), "This class only supports deterministic wallets"
             self.keystores.append(k)
 
     def save_keystore(self):

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -3728,7 +3728,7 @@ class Multi_Wallet(Abstract_Wallet):
         return all(k.is_watching_only() for k in self.get_keystores())
 
     def can_change_password(self):
-        return all(k.can_change_password() for k in self.get_keystores())
+        return any(k.can_change_password() for k in self.get_keystores())
 
     def update_password(self, old_pw, new_pw, encrypt=False):
         if old_pw is None and self.has_password():

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -29,6 +29,7 @@
 #   - ImportedPrivkeyWallet: imported private keys, keystore
 #   - Standard_Wallet: one keystore, P2PKH
 #   - Multisig_Wallet: several keystores, P2SH
+#   - MultiXPubWallet: several keystores, P2PKH
 
 import copy
 import errno
@@ -1472,6 +1473,19 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         """ Must be reimplemented in subclasses """
         raise RuntimeError("'get_receiving_addresses' is not implemented in this class: " + str(type(self)))
 
+    def get_preferred_change_addresses(self):
+        """ In most subclasses this is just self.get_change_addresses(), but in the MultiXPubWallet, it is
+        the addresses from one of the XPubs we have the private keys for (if any), otherwise it's just
+        the regular change addresses."""
+        return self.get_change_addresses()
+
+    def get_preferred_receiving_addresses(self):
+        """Reimplemented in MultiXPubWallet"""
+        return self.get_receiving_addresses()
+
+    def get_preferred_addresses(self):
+        return self.get_preferred_receiving_addresses() + self.get_preferred_change_addresses()
+
     def get_frozen_balance(self):
         if not self.frozen_coins and not self.frozen_coins_tmp:
             # performance short-cut -- get the balance of the frozen address set only IFF we don't have any frozen coins
@@ -2333,11 +2347,11 @@ class Abstract_Wallet(PrintError, SPVDelegate):
 
         On non-deterministic wallets, this returns an empty list.
         """
-        if count <= 0 or not hasattr(self, 'create_new_address'):
+        if count <= 0 or not hasattr(self, 'create_new_preferred_address'):
             return []
 
         with self.lock:
-            last_change_addrs = self.get_change_addresses()[-self.gap_limit_for_change:]
+            last_change_addrs = self.get_preferred_change_addresses()[-self.gap_limit_for_change:]
             if not last_change_addrs:
                 # this happens in non-deterministic wallets but the above
                 # hasattr check should have caught those.
@@ -2352,7 +2366,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 for addr in last_change_addrs:
                     yield addr
                 while True:
-                    yield self.create_new_address(for_change=True)
+                    yield self.create_new_preferred_address(for_change=True)
 
             result = []
             for addr in gen_change():
@@ -2485,7 +2499,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                         # to picking first max_change change_addresses that have
                         # no history
                         change_addrs = []
-                        for addr in self.get_change_addresses()[-self.gap_limit_for_change:]:
+                        for addr in self.get_preferred_change_addresses()[-self.gap_limit_for_change:]:
                             if self.get_num_tx(addr) == 0:
                                 change_addrs.append(addr)
                                 if len(change_addrs) >= max_change:
@@ -2495,7 +2509,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                             # Fall back to picking ANY wallet address
                             try:
                                 # Pick a random address
-                                change_addrs = [random.choice(self.get_addresses())]
+                                change_addrs = [random.choice(self.get_preferred_addresses())]
                             except IndexError:
                                 change_addrs = []  # Address-free wallet?!
                         # This should never happen
@@ -3268,26 +3282,32 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             except UserCancelled:
                 continue
 
-    def get_unused_addresses(self, *, for_change=False, frozen_ok=True):
+    def get_unused_addresses(self, *, for_change=False, frozen_ok=True, preferred=False):
         # fixme: use slots from expired requests
         with self.lock:
-            domain = self.get_receiving_addresses() if not for_change else (self.get_change_addresses() or self.get_receiving_addresses())
+            if preferred:
+                domain = (self.get_preferred_receiving_addresses() if not for_change
+                          else (self.get_preferred_change_addresses() or self.get_preferred_receiving_addresses()))
+            else:
+                domain = (self.get_receiving_addresses() if not for_change
+                          else (self.get_change_addresses() or self.get_receiving_addresses()))
             return [addr for addr in domain
                     if not self.get_address_history(addr)
                     and addr not in self.receive_requests
                     and (frozen_ok or addr not in self.frozen_addresses)
                     and (not for_change or not self.is_retired_change_addr(addr))]
 
-    def get_unused_address(self, *, for_change=False, frozen_ok=True):
-        addrs = self.get_unused_addresses(for_change=for_change, frozen_ok=frozen_ok)
+    def get_unused_address(self, *, for_change=False, frozen_ok=True, preferred=False):
+        addrs = self.get_unused_addresses(for_change=for_change, frozen_ok=frozen_ok, preferred=preferred)
         if addrs:
             return addrs[0]
 
-    def get_receiving_address(self, *, frozen_ok=True):
+    def get_receiving_address(self, *, frozen_ok=True, preferred=True):
         """Returns a receiving address or None."""
-        domain = self.get_unused_addresses(for_change=False, frozen_ok=frozen_ok)
+        domain = self.get_unused_addresses(for_change=False, frozen_ok=frozen_ok, preferred=preferred)
         if not domain:
-                domain = [a for a in self.get_receiving_addresses()
+                addr_list = self.get_preferred_receiving_addresses() if preferred else self.get_receiving_addresses()
+                domain = [a for a in addr_list
                           if frozen_ok or a not in self.frozen_addresses]
         if domain:
             return domain[0]
@@ -3584,7 +3604,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         with self.lock:
             self.transactions.clear(); self.unverified_tx.clear(); self.verified_tx.clear()
             self.clear_history()
-            if isinstance(self, Standard_Wallet):
+            if isinstance(self, (Standard_Wallet, MultiXPubWallet)):
                 # reset the address list to default too, just in case. New synchronizer will pick up the addresses again.
                 self.receiving_addresses, self.change_addresses = self.receiving_addresses[:self.gap_limit], self.change_addresses[:self.gap_limit_for_change]
                 do_addr_save = True
@@ -3723,40 +3743,6 @@ class Simple_Wallet(Abstract_Wallet):
         self.storage.put('keystore', self.keystore.dump())
 
 
-class Multi_Wallet(Abstract_Wallet):
-    """ wallet with a multiple keystores """
-
-    def get_keystore(self):
-        ks = self.get_keystores()
-        return ks[0] if ks else None
-
-    def get_keystores(self):
-        return self.keystores
-
-    def is_watching_only(self):
-        return all(k.is_watching_only() for k in self.get_keystores())
-
-    def can_change_password(self):
-        return any(k.can_change_password() for k in self.get_keystores())
-
-    def update_password(self, old_pw, new_pw, encrypt=False):
-        if old_pw is None and self.has_password():
-            raise InvalidPassword()
-        for k in self.get_keystores():
-            if k is not None and k.can_change_password():
-                k.update_password(old_pw, new_pw)
-        self.save_keystore()
-        self.storage.set_password(new_pw, encrypt)
-        self.storage.write()
-
-    def save_keystore(self):
-        self.storage.put('keystores', [k.dump() for k in self.get_keystores()])
-
-    @property
-    def keystore(self):
-        return self.get_keystore()
-
-
 class ImportedWalletBase(Simple_Wallet):
 
     txin_type = 'p2pkh'
@@ -3890,7 +3876,7 @@ class ImportedAddressWallet(ImportedWalletBase):
     def can_import_address(self):
         return True
 
-    def get_addresses(self, include_change=False):
+    def get_addresses(self):
         if not self._sorted:
             self._sorted = sorted(self.addresses,
                                   key=lambda addr: addr.to_ui_string())
@@ -3964,7 +3950,7 @@ class ImportedPrivkeyWallet(ImportedWalletBase):
     def can_import_address(self):
         return False
 
-    def get_addresses(self, include_change=False):
+    def get_addresses(self):
         return self.keystore.get_addresses()
 
     def delete_address_derived(self, address):
@@ -4090,7 +4076,7 @@ class RpaWallet(ImportedWalletBase):
     def can_import_address(self):
         return False
 
-    def get_addresses(self, include_change=False):
+    def get_addresses(self):
         return self.keystore.get_addresses()
 
     def delete_address_derived(self, address):
@@ -4245,6 +4231,11 @@ class Deterministic_Wallet(Abstract_Wallet):
                 self.save_addresses()
             self.add_address(address, for_change=for_change)
             return address
+
+    def create_new_preferred_address(self, for_change=False, save=True):
+        """Default just calls create_new_address(). MultiXPubWallet reimplements this to keep generating
+        until it gets a preferred address."""
+        return self.create_new_address(for_change=for_change, save=save)
 
     def synchronize_sequence(self, for_change):
         limit = self.gap_limit_for_change if for_change else self.gap_limit
@@ -4420,15 +4411,140 @@ class Multisig_Wallet(Deterministic_Wallet):
         return True
 
 
-class MultiXPubWallet(Multi_Wallet, Deterministic_Wallet):
-    """ Deterministic Wallet with a single pubkey per address, but each address index
-    is modded into a particular BIP32_Keystore. """
+class PrivateKeyMissing(RuntimeError):
+    """Only ever raised by MultiXPubWallet below if calling code attempts to retrieve a private key
+    for an address for which the wallet lacks the xprv."""
+
+
+class MultiXPubWallet(Deterministic_Wallet):
+    """ P2PKH "aggregate" wallet. A deterministic wallet which combines multiple xpubs into one view.
+    The addresses are interleaved modulo len(self.keystores). """
 
     txin_type = 'p2pkh'
     wallet_type = 'multi_xpub'
 
     def __init__(self, storage):
         Deterministic_Wallet.__init__(self, storage)
+        # Scale gap limit to catch everything from all sub-xpubs
+        self.gap_limit = max(self.gap_limit, 20 * len(self.keystores))
+        self.gap_limit_for_change = max(self.gap_limit_for_change, self.gap_limit)
+
+    class _KeyStoreFacade:
+        """This class is used as a facade to catch calls to wallet.keystore by code in the app
+        and forward and/or translate the call appropriately so that things work as expected."""
+        def __init__(self, parent):
+            self.parent = parent
+
+        def is_deterministic(self):
+            return self.parent.is_deterministic()
+
+        def get_private_key(self, sequence, password):
+            for_change, index = sequence
+            ks, real_index = self.parent._map_address_index(index)
+            if ks.is_watching_only():
+                raise PrivateKeyMissing(_("This address is watching-only"))
+            return ks.get_private_key((for_change, real_index), password)
+
+        def check_password(self, password):
+            for ks in self.parent.get_keystores():
+                if ks.may_have_password():
+                    ks.check_password(password)
+
+        def sign_message(self, sequence, message, password):
+            for_change, index = sequence
+            ks, real_index = self.parent._map_address_index(index)
+            if ks.is_watching_only():
+                raise PrivateKeyMissing(_("This address is watching-only"))
+            return ks.sign_message((for_change, real_index), message, password)
+
+        def decrypt_message(self, sequence, message, password):
+            for_change, index = sequence
+            ks, real_index = self.parent._map_address_index(index)
+            return ks.decrypt_message((for_change, real_index), message, password)
+
+        def get_pubkey_derivation(self, x_pubkey):
+            for which_ks, ks in enumerate(self.parent.get_keystores()):
+                derivation = ks.get_pubkey_derivation(x_pubkey)
+                if derivation:
+                    for_change, real_index = derivation
+                    index = self.parent._unmap_address_index(which_ks, real_index)
+                    return for_change, index
+
+    def get_keystore(self):
+        return self._KeyStoreFacade(self)
+
+    @property
+    def keystore(self):
+        return self.get_keystore()
+
+    def get_keystores(self):
+        return self.keystores
+
+    def is_watching_only(self):
+        return all(k.is_watching_only() for k in self.get_keystores())
+
+    def get_preferred_receiving_addresses(self):
+        return self._get_preferred_addresses(False)
+
+    def get_preferred_change_addresses(self):
+        return self._get_preferred_addresses(True)
+
+    @property
+    def _signing_xpubs(self) -> Set[str]:
+        return {k.get_master_public_key() for k in self.get_keystores() if not k.is_watching_only()}
+
+    def _get_preferred_addresses(self, for_change):
+        signing_xpubs = self._signing_xpubs
+        domain = self.get_change_addresses() if for_change else self.get_receiving_addresses()
+        if not signing_xpubs or len(signing_xpubs) >= len(self.get_keystores()):
+            # We can't sign, or we can sign all, so we prefer nothing in particular, return all addresses
+            return domain
+        # Remove addresses we can't sign for and return the rest, since we "prefer" those
+        ret = []
+        for i, addr in enumerate(domain):
+            ks, _ = self._map_address_index(i)
+            if ks.get_master_public_key() in signing_xpubs:
+                ret.append(addr)
+        return ret or domain  # If ret empty, fallback to full set of addresses
+
+    def create_new_preferred_address(self, for_change=False, save=True):
+        signing_xpubs = self._signing_xpubs
+        if not signing_xpubs or len(signing_xpubs) >= len(self.get_keystores()):
+            # Can't sign, or all xpubs can sign, so just take normal path
+            return self.create_new_address(for_change=for_change, save=save)
+        # Keep looping until we get a new address we can sign for
+        while True:
+            address = self.create_new_address(for_change=for_change, save=save)
+            c, index = self.get_address_index(address)
+            assert bool(c) == bool(for_change)
+            ks, _ = self._map_address_index(index)
+            if ks.get_master_public_key() in signing_xpubs:
+                return address
+
+    def can_change_password(self):
+        return any(k.can_change_password() for k in self.get_keystores())
+
+    def update_password(self, old_pw, new_pw, encrypt=False):
+        if old_pw is None and self.has_password():
+            raise InvalidPassword()
+        for k in self.get_keystores():
+            if k is not None and k.can_change_password():
+                k.update_password(old_pw, new_pw)
+        self.save_keystore()
+        self.storage.set_password(new_pw, encrypt)
+        self.storage.write()
+
+    def load_keystore(self):
+        l = self.storage.get("keystores")
+        assert l and isinstance(l, list)
+        self.keystores = []
+        for d in l:
+            assert isinstance(d, dict)
+            k = load_keystore({"dummy": d}, "dummy")
+            self.keystores.append(k)
+
+    def save_keystore(self):
+        self.storage.put('keystores', [k.dump() for k in self.get_keystores()])
 
     def has_seed(self):
         return False
@@ -4439,19 +4555,13 @@ class MultiXPubWallet(Multi_Wallet, Deterministic_Wallet):
     def add_seed(self, seed, pw):
         pass
 
+    def is_deterministic(self):
+        return all(k.is_deterministic() for k in self.keystores)
+
     def get_public_key(self, address):
         sequence = self.get_address_index(address)
         pubkey = self.get_pubkey(*sequence)
         return pubkey
-
-    def load_keystore(self):
-        l = self.storage.get("keystores")
-        assert l and isinstance(l, list)
-        self.keystores = []
-        for d in l:
-            assert isinstance(d, dict)
-            k = load_keystore({"dummy": d}, "dummy")
-            self.keystores.append(k)
 
     def get_pubkey(self, c, i):
         return self.derive_pubkeys(c, i)
@@ -4464,6 +4574,12 @@ class MultiXPubWallet(Multi_Wallet, Deterministic_Wallet):
         which_ks = index % n_ks
         real_index = index // n_ks
         return self.keystores[which_ks], real_index
+
+    def _unmap_address_index(self, ks: Union[object, int], real_index):
+        n_ks = len(self.keystores)
+        which_ks = ks if isinstance(ks, int) else self.keystores.index(ks)
+        index = real_index * n_ks + which_ks
+        return index
 
     def add_input_sig_info(self, txin, address):
         is_change, index = self.get_address_index(address)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -70,11 +70,12 @@ import electroncash.web as web
 from .amountedit import AmountEdit, BTCAmountEdit, MyLineEdit, BTCSatsByteEdit
 from .qrcodewidget import QRCodeWidget, QRDialog
 from .qrtextedit import ShowQRTextEdit, ScanQRTextEdit
-from .seed_dialog import SeedDialog, KeysLayout
+from .seed_dialog import SeedDialog
 from .transaction_dialog import show_transaction
 from .fee_slider import FeeSlider
 from .popup_widget import ShowPopupLabel, KillPopupLabel
 from . import cashacctqt
+from . import wallet_information
 from .util import *
 from .token_meta import TokenMetaQt
 
@@ -3265,151 +3266,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                                               add_to_contacts_button = True, pay_to_button = True)
 
     def show_master_public_keys(self):
-        dialog = WindowModalDialog(self.top_level_window(), _("Wallet Information"))
-        dialog.setMinimumSize(500, 100)
-        mpk_list: List[str] = self.wallet.get_master_public_keys()
-        orig_mpk_list = mpk_list[:]
-        vbox = QVBoxLayout()
-        wallet_type = self.wallet.storage.get('wallet_type', '')
-        grid = QGridLayout()
-        basename = os.path.basename(self.wallet.storage.path)
-        grid.addWidget(QLabel(_("Wallet name") + ':'), 0, 0)
-        grid.addWidget(QLabel(basename), 0, 1)
-        grid.addWidget(QLabel(_("Wallet type") + ':'), 1, 0)
-        grid.addWidget(QLabel(wallet_type), 1, 1)
-        grid.addWidget(QLabel(_("Script type") + ':'), 2, 0)
-        grid.addWidget(QLabel(self.wallet.txin_type), 2, 1)
-        vbox.addLayout(grid)
-        bottom_buttons = Buttons(CloseButton(dialog))
-        if self.wallet.is_deterministic():
-            has_prvkey_ct = sum(ks.has_master_private_key() for ks in self.wallet.get_keystores()
-                                if isinstance(ks, keystore.Xprv))
-            mpk_text = ShowQRTextEdit()
-            mpk_text.setMaximumHeight(150)
-            mpk_text.addCopyButton()
-            mpk_del_button: Optional[QPushButton] = None
-            show_privkey_button: Optional[QToolButton] = None
-            selected_index: Optional[int] = None
-            title_lbl: Optional[QLabel] = None
-            title_gb: Optional[QGroupBox] = None
-            password: Optional[str] = None
-            def mpk_selected(clayout, index):
-                nonlocal selected_index
-                selected_index = index
-                mpk_text.setText(mpk_list[index])
-                name = (clayout and clayout.group.checkedButton() and clayout.group.checkedButton().text()) or _("Key")
-                if mpk_del_button:
-                    mpk_del_button.setText(_("Delete") + " " + name)
-                if show_privkey_button:
-                    ks = self.wallet.get_keystores()[index]
-                    if not show_privkey_button.isChecked():
-                        show_privkey_button.setEnabled(isinstance(ks, keystore.Xprv) and ks.has_master_private_key())
-            # only show the combobox in case multiple accounts are available
-            labels_clayout = None
-            if len(mpk_list) > 1:
-                def label(key):
-                    if isinstance(self.wallet, Multisig_Wallet):
-                        return _("cosigner") + ' ' + str(key+1)
-                    elif isinstance(self.wallet, MultiXPubWallet):
-                        return _("Key") + f" {key + 1}"
-                    return ''
-                labels = [label(i) for i in range(len(mpk_list))]
-                labels_clayout = ChoicesLayout(_("Master Public Keys"), labels, on_id_clicked=mpk_selected)
-                title_gb = labels_clayout.group_box()
-                vbox.addLayout(labels_clayout.layout())
-            else:
-                title_lbl = QLabel(_("Master Public Key"))
-                vbox.addWidget(title_lbl)
-            vbox.addWidget(mpk_text)
-            if self.wallet.can_delete_keystore() and labels_clayout:
-                def on_click(checked):
-                    if selected_index is not None:
-                        if self.wallet_delete_xpub(selected_index):
-                            dialog.close()
-                mpk_del_button = mpk_text.addButton(icon_name=None, on_click=on_click, index=0,
-                                                    tooltip=_("Delete this key from the wallet"),
-                                                    # This is tmp text for layout, gets set to real text by mpk_selected
-                                                    # above ...
-                                                    text="Delete Key 1")
-                red = ColorScheme.RED.get_html(True)
-                red_alt = ColorScheme.RED.get_html(False)
-                mpk_del_button.setStyleSheet("QPushButton { border: 2px solid "
-                                             + red + "; padding: 2px; border-radius: 2px; font-size: 11px; } " +
-                                             "QPushButton:hover { border: 2px solid "
-                                             + red_alt + "; padding: 2px; border-radius: 2px; font-size: 11px; } ")
-            if self.wallet.can_add_keystore():
-                add_but = QPushButton(_("Add Key..."))
-                marg: QMargins = add_but.contentsMargins()
-                marg.setLeft(marg.left() // 2)
-                marg.setRight(marg.right() // 2)
-                add_but.setContentsMargins(marg)
-                bottom_buttons.insertWidget(0, add_but, Qt.AlignLeft)
-                def on_click(checked):
-                    d = QDialog(parent=dialog)
-                    d.setWindowModality(Qt.WindowModal)
-                    d.setMinimumSize(400, 200)
-                    title = _("Add Master Key")
-                    d.setWindowTitle(title)
-                    message = '  '.join([
-                        _("Enter an xpub or xprv key to add to this wallet."),
-                        _("Addresses derived from this key will be a part of the wallet and will appear in this"
-                          " wallet's transaction history."),
-                        _("If adding an xprv key, this wallet will also be able to spend from these addresses."),
-                    ])
-                    cancel_but = CancelButton(d)
-                    cancel_but.setDefault(True)
-                    d.next_button = ok_but = QPushButton(_("Add Key"))  # KeysLayout widget expects this attribute
-                    ok_but.clicked.connect(d.accept)
-                    ok_but.setEnabled(False)
-                    l = KeysLayout(parent=d, title=message, allow_multi=False, is_valid=keystore.is_master_key)
-                    l.addLayout(Buttons(ok_but, cancel_but))
-                    d.setLayout(l)
-                    if d.exec_() == QDialog.Accepted:
-                        if self.wallet_add_xpub(l.get_text().strip()):
-                            dialog.close()
-                add_but.clicked.connect(on_click)
-            if has_prvkey_ct > 0:
-                show_privkey_button = QToolButton()
-                show_privkey_button.setText(_("Show XPrv"))
-                show_privkey_button.setToolTip(_("Toggle display of public versus private master keys"))
-                show_privkey_button.setCheckable(True)
-                show_privkey_button.setContentsMargins(1, 1, 1, 1)
-                mpk_text.addWidget(show_privkey_button)
-                def on_toggle(checked):
-                    nonlocal mpk_list, password
-                    if not checked:
-                        mpk_list = orig_mpk_list[:]
-                        mpk_selected(labels_clayout, selected_index)  # Force redraw of text area with new text
-                    else:
-                        for i, ks in enumerate(self.wallet.get_keystores()):
-                            if isinstance(ks, keystore.Xprv) and ks.has_master_private_key():
-                                if ks.is_master_private_key_encrypted() and password is None:
-                                    password = self.password_dialog(parent=dialog)
-                                    if password is None:
-                                        show_privkey_button.setChecked(False)
-                                        return
-                                try:
-                                    mpk_list[i] = ks.get_master_private_key(password)
-                                except InvalidPassword as e:
-                                    password = None  # Clear nonlocal
-                                    self.show_error(e)
-                                    show_privkey_button.setChecked(False)
-                                    return
-                            else:
-                                mpk_list[i] = _('No XPrv')
-                        mpk_selected(labels_clayout, selected_index)  # Forces redraw of text area
-                    if title_lbl is not None:
-                        title_lbl.setText(_("Master Public Key") if not checked else _("Master Private Key"))
-                    if title_gb is not None:
-                        title_gb.setTitle(_("Master Public Keys") if not checked else _("Master Private Keys"))
-
-                show_privkey_button.toggled.connect(on_toggle)
-            bottom_buttons.insertStretch(bottom_buttons.count()-1, 2)
-            mpk_selected(labels_clayout, 0)
-        vbox.addStretch(1)
-        vbox.addLayout(bottom_buttons)
-        dialog.setLayout(vbox)
-        dialog.exec_()
+        wallet_information.show_wallet_information(self)
 
     def remove_wallet(self):
         if self.question('\n'.join([

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -58,7 +58,7 @@ from electroncash import Transaction
 from electroncash import util, bitcoin, commands, cashacct, token
 from electroncash import paymentrequest
 from electroncash.transaction import OPReturn
-from electroncash.wallet import Multisig_Wallet, sweep_preparations
+from electroncash.wallet import Multisig_Wallet, sweep_preparations, MultiXPubWallet
 from electroncash.contacts import Contact
 from electroncash import rpa
 try:
@@ -3289,6 +3289,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 def label(key):
                     if isinstance(self.wallet, Multisig_Wallet):
                         return _("cosigner") + ' ' + str(key+1)
+                    elif isinstance(self.wallet, MultiXPubWallet):
+                        return _("Key") + f" {key + 1}"
                     return ''
                 labels = [label(i) for i in range(len(mpk_list))]
                 on_click = lambda clayout: show_mpk(clayout.selected_index())

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -58,7 +58,7 @@ from electroncash import Transaction
 from electroncash import util, bitcoin, commands, cashacct, token
 from electroncash import paymentrequest
 from electroncash.transaction import OPReturn
-from electroncash.wallet import Multisig_Wallet, sweep_preparations, MultiXPubWallet
+from electroncash.wallet import Multisig_Wallet, sweep_preparations, MultiXPubWallet, PrivateKeyMissing
 from electroncash.contacts import Contact
 from electroncash import rpa
 try:
@@ -3821,6 +3821,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 except InvalidPassword:
                     # See #921 -- possibly a corrupted wallet or other strangeness
                     privkey = 'INVALID_PASSWORD'
+                except PrivateKeyMissing:
+                    privkey = 'WATCHING_ONLY'
                 private_keys[addr.to_ui_string()] = privkey
                 strong_d = weak_d()
                 try:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -1522,7 +1522,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.saved = True
 
     def new_payment_request(self):
-        addr = self.wallet.get_unused_address(frozen_ok=False)
+        addr = self.wallet.get_unused_address(frozen_ok=False, preferred=True)
         if addr is None:
             if not self.wallet.is_deterministic():
                 msg = [
@@ -1537,7 +1537,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 # Warn if past gap limit.
                 if not self.question(_("Warning: The next address will not be recovered automatically if you restore your wallet from seed; you may need to add it manually.\n\nThis occurs because you have too many unused addresses in your wallet. To avoid this situation, use the existing addresses first.\n\nCreate anyway?")):
                     return
-                addr = self.wallet.create_new_address(False)
+                addr = self.wallet.create_new_preferred_address(False)
         self.set_receive_address(addr)
         self.expires_label.hide()
         self.expires_combo.show()
@@ -1581,7 +1581,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if addr is None:
                 if self.wallet.is_deterministic():
                     # creae a new one if deterministic
-                    addr = self.wallet.create_new_address(False)
+                    addr = self.wallet.create_new_preferred_address(False)
                 else:
                     # otherwise give up and just re-use one.
                     addr = self.wallet.get_receiving_address()
@@ -2453,7 +2453,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.payment_request = None
                 return False, _("Payment request has expired")
             if pr:
-                refund_address = self.wallet.get_receiving_addresses()[0]
+                refund_address = self.wallet.get_receiving_address(preferred=True)
                 ack_status, ack_msg = pr.send_payment(str(tx), refund_address)
                 if not ack_status:
                     if ack_msg == "no url":
@@ -4081,10 +4081,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         return success
 
     def sweep_key_dialog(self):
-        addresses = self.wallet.get_unused_addresses()
+        addresses = self.wallet.get_unused_addresses(preferred=True)
         if not addresses:
             try:
-                addresses = self.wallet.get_receiving_addresses()
+                addresses = self.wallet.get_preferred_receiving_addresses()
             except AttributeError:
                 addresses = self.wallet.get_addresses()
         if not addresses:
@@ -5339,7 +5339,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             addr = self._pick_address(title=_("Register A New Cash Account"), icon=QIcon(":icons/cashacct-logo.png"))
             if addr is None:
                 return  # user cancel
-        addr = addr or self.receive_address or self.wallet.get_receiving_address()
+        addr = addr or self.receive_address or self.wallet.get_receiving_address(preferred=True)
         if not addr:
             self.print_error("register_new_cash_account: no receive address specified")
             return

--- a/electroncash_gui/qt/util.py
+++ b/electroncash_gui/qt/util.py
@@ -10,6 +10,7 @@ import webbrowser
 from collections import namedtuple
 from functools import partial, wraps
 from locale import atof
+from typing import Optional
 
 from electroncash.address import Address
 from electroncash.util import print_error, PrintError, Weak, finalization_print_error
@@ -501,12 +502,16 @@ class ChoicesLayout(object):
             group.idClicked.connect(partial(on_id_clicked, self))
 
         self.vbox = vbox
+        self.gb = gb2
 
     def layout(self):
         return self.vbox
 
     def selected_index(self):
         return self.group.checkedId()
+
+    def group_box(self):
+        return self.gb
 
 def address_combo(addresses):
     addr_combo = QComboBox()

--- a/electroncash_gui/qt/util.py
+++ b/electroncash_gui/qt/util.py
@@ -474,7 +474,7 @@ def text_dialog(parent, title, label, ok_label, default=None, allow_multi=False)
         return txt.toPlainText()
 
 class ChoicesLayout(object):
-    def __init__(self, msg, choices, on_clicked=None, checked_index=0):
+    def __init__(self, msg, choices, on_clicked=None, on_id_clicked=None, checked_index=0):
         vbox = QVBoxLayout()
         if len(msg) > 50:
             vbox.addWidget(WWLabel(msg))
@@ -497,6 +497,8 @@ class ChoicesLayout(object):
 
         if on_clicked:
             group.buttonClicked.connect(partial(on_clicked, self))
+        if on_id_clicked:
+            group.idClicked.connect(partial(on_id_clicked, self))
 
         self.vbox = vbox
 

--- a/electroncash_gui/qt/wallet_information.py
+++ b/electroncash_gui/qt/wallet_information.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+#
+# Electron Cash - lightweight Bitcoin Cash client
+# Copyright (C) 2023 The Electron Cash Developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+from typing import List, Optional
+
+from PyQt5.Qt import Qt, QMargins
+from PyQt5.QtWidgets import QDialog, QGridLayout, QVBoxLayout, QLabel, QPushButton, QToolButton, QGroupBox
+
+from electroncash import keystore
+from electroncash.i18n import _
+from electroncash.util import InvalidPassword
+from electroncash.wallet import Multisig_Wallet, MultiXPubWallet
+from electroncash_gui.qt.qrtextedit import ShowQRTextEdit
+from electroncash_gui.qt.seed_dialog import KeysLayout
+from electroncash_gui.qt.util import Buttons, CloseButton, WindowModalDialog, ColorScheme, ChoicesLayout, CancelButton
+
+
+def show_wallet_information(main_window):
+    """Shows the 'Wallet Information' popup dialog. This was refactored out of main_window.py to
+    reduce line count in that file."""
+    from .main_window import ElectrumWindow
+    assert isinstance(main_window, ElectrumWindow)
+    wallet = main_window.wallet
+    dialog = WindowModalDialog(main_window.top_level_window(), _("Wallet Information"))
+    dialog.setMinimumSize(500, 100)
+    mpk_list: List[str] = wallet.get_master_public_keys()
+    orig_mpk_list = mpk_list[:]
+    vbox = QVBoxLayout()
+    wallet_type = wallet.storage.get('wallet_type', '')
+    grid = QGridLayout()
+    basename = os.path.basename(wallet.storage.path)
+    grid.addWidget(QLabel(_("Wallet name") + ':'), 0, 0)
+    grid.addWidget(QLabel(basename), 0, 1)
+    grid.addWidget(QLabel(_("Wallet type") + ':'), 1, 0)
+    grid.addWidget(QLabel(wallet_type), 1, 1)
+    grid.addWidget(QLabel(_("Script type") + ':'), 2, 0)
+    grid.addWidget(QLabel(wallet.txin_type), 2, 1)
+    vbox.addLayout(grid)
+    bottom_buttons = Buttons(CloseButton(dialog))
+    if wallet.is_deterministic():
+        has_prvkey_ct = sum(ks.has_master_private_key() for ks in wallet.get_keystores()
+                            if isinstance(ks, keystore.Xprv))
+        mpk_text = ShowQRTextEdit()
+        mpk_text.setMaximumHeight(150)
+        mpk_text.addCopyButton()
+        mpk_del_button: Optional[QPushButton] = None
+        show_privkey_button: Optional[QToolButton] = None
+        selected_index: Optional[int] = None
+        title_lbl: Optional[QLabel] = None
+        title_gb: Optional[QGroupBox] = None
+        password: Optional[str] = None
+
+        def mpk_selected(clayout, index):
+            nonlocal selected_index
+            selected_index = index
+            mpk_text.setText(mpk_list[index])
+            name = (clayout and clayout.group.checkedButton() and clayout.group.checkedButton().text()) or _("Key")
+            if mpk_del_button:
+                mpk_del_button.setText(_("Delete") + " " + name)
+            if show_privkey_button:
+                ks = wallet.get_keystores()[index]
+                if not show_privkey_button.isChecked():
+                    show_privkey_button.setEnabled(isinstance(ks, keystore.Xprv) and ks.has_master_private_key())
+        # only show the combobox in case multiple accounts are available
+        labels_clayout = None
+        if len(mpk_list) > 1:
+            def label(key):
+                if isinstance(wallet, Multisig_Wallet):
+                    return _("cosigner") + ' ' + str(key +1)
+                elif isinstance(wallet, MultiXPubWallet):
+                    return _("Key") + f" {key + 1}"
+                return ''
+            labels = [label(i) for i in range(len(mpk_list))]
+            labels_clayout = ChoicesLayout(_("Master Public Keys"), labels, on_id_clicked=mpk_selected)
+            title_gb = labels_clayout.group_box()
+            vbox.addLayout(labels_clayout.layout())
+        else:
+            title_lbl = QLabel(_("Master Public Key"))
+            vbox.addWidget(title_lbl)
+        vbox.addWidget(mpk_text)
+
+        # Support for deleting keys
+        if wallet.can_delete_keystore() and labels_clayout:
+            def on_click(checked):
+                if selected_index is not None:
+                    if main_window.wallet_delete_xpub(selected_index):
+                        dialog.close()
+            mpk_del_button = mpk_text.addButton(icon_name=None, on_click=on_click, index=0,
+                                                tooltip=_("Delete this key from the wallet"),
+                                                # This is tmp text for layout, gets set to real text by mpk_selected
+                                                # above ...
+                                                text="Delete Key 1")
+            red = ColorScheme.RED.get_html(True)
+            red_alt = ColorScheme.RED.get_html(False)
+            mpk_del_button.setStyleSheet("QPushButton { border: 2px solid "
+                                         + red + "; padding: 2px; border-radius: 2px; font-size: 11px; } " +
+                                         "QPushButton:hover { border: 2px solid "
+                                         + red_alt + "; padding: 2px; border-radius: 2px; font-size: 11px; } ")
+
+        # Support for the "Add Key" button
+        if wallet.can_add_keystore():
+            add_but = QPushButton(_("Add Key..."))
+            marg: QMargins = add_but.contentsMargins()
+            marg.setLeft(marg.left() // 2)
+            marg.setRight(marg.right() // 2)
+            add_but.setContentsMargins(marg)
+            bottom_buttons.insertWidget(0, add_but, Qt.AlignLeft)
+
+            def on_click(checked):
+                d = QDialog(parent=dialog)
+                d.setWindowModality(Qt.WindowModal)
+                d.setMinimumSize(400, 200)
+                title = _("Add Master Key")
+                d.setWindowTitle(title)
+                message = '  '.join([
+                    _("Enter an xpub or xprv key to add to this wallet."),
+                    _("Addresses derived from this key will be a part of the wallet and will appear in this"
+                      " wallet's transaction history."),
+                    _("If adding an xprv key, this wallet will also be able to spend from these addresses."),
+                ])
+                cancel_but = CancelButton(d)
+                cancel_but.setDefault(True)
+                d.next_button = ok_but = QPushButton(_("Add Key"))  # KeysLayout widget expects this attribute
+                ok_but.clicked.connect(d.accept)
+                ok_but.setEnabled(False)
+                l = KeysLayout(parent=d, title=message, allow_multi=False, is_valid=keystore.is_master_key)
+                l.addLayout(Buttons(ok_but, cancel_but))
+                d.setLayout(l)
+                if d.exec_() == QDialog.Accepted:
+                    if main_window.wallet_add_xpub(l.get_text().strip()):
+                        dialog.close()
+            add_but.clicked.connect(on_click)
+
+        # Support for "Show XPrv"
+        if has_prvkey_ct > 0:
+            show_privkey_button = QToolButton()
+            show_privkey_button.setText(_("Show XPrv"))
+            show_privkey_button.setToolTip(_("Toggle display of public versus private master keys"))
+            show_privkey_button.setCheckable(True)
+            show_privkey_button.setContentsMargins(1, 1, 1, 1)
+            mpk_text.addWidget(show_privkey_button)
+
+            def on_toggle(checked):
+                nonlocal mpk_list, password
+                if not checked:
+                    mpk_list = orig_mpk_list[:]
+                    mpk_selected(labels_clayout, selected_index)  # Force redraw of text area with new text
+                else:
+                    for i, ks in enumerate(wallet.get_keystores()):
+                        if isinstance(ks, keystore.Xprv) and ks.has_master_private_key():
+                            if ks.is_master_private_key_encrypted() and password is None:
+                                password = main_window.password_dialog(parent=dialog)
+                                if password is None:
+                                    show_privkey_button.setChecked(False)
+                                    return
+                            try:
+                                mpk_list[i] = ks.get_master_private_key(password)
+                            except InvalidPassword as e:
+                                password = None  # Clear nonlocal
+                                main_window.show_error(e)
+                                show_privkey_button.setChecked(False)
+                                return
+                        else:
+                            mpk_list[i] = _('No XPrv')
+                    mpk_selected(labels_clayout, selected_index)  # Forces redraw of text area
+                if title_lbl is not None:
+                    title_lbl.setText(_("Master Public Key") if not checked else _("Master Private Key"))
+                if title_gb is not None:
+                    title_gb.setTitle(_("Master Public Keys") if not checked else _("Master Private Keys"))
+
+            show_privkey_button.toggled.connect(on_toggle)
+        bottom_buttons.insertStretch(bottom_buttons.count( ) -1, 2)
+        mpk_selected(labels_clayout, 0)
+    vbox.addStretch(1)
+    vbox.addLayout(bottom_buttons)
+    dialog.setLayout(vbox)
+    dialog.exec_()

--- a/electroncash_plugins/fusion/fusion.py
+++ b/electroncash_plugins/fusion/fusion.py
@@ -34,7 +34,7 @@ from electroncash import networks, schnorr
 from electroncash.bitcoin import public_key_from_private_key
 from electroncash.i18n import _, ngettext, pgettext
 from electroncash.util import format_satoshis, do_in_main_thread, PrintError, ServerError, TxHashMismatch, TimeoutException
-from electroncash.wallet import Standard_Wallet, Multisig_Wallet
+from electroncash.wallet import Standard_Wallet, Multisig_Wallet, MultiXPubWallet
 
 from . import encrypt
 from . import fusion_pb2 as pb
@@ -83,15 +83,18 @@ MAX_FEE = MAX_COMPONENT_FEERATE * 7 + MAX_EXCESS_FEE
 # (distinct tx inputs, and tx outputs)
 MIN_TX_COMPONENTS = 11
 
+
 def can_fuse_from(wallet):
     """We can only fuse from wallets that are p2pkh, and where we are able
     to extract the private key."""
-    return not (wallet.is_watching_only() or wallet.is_hardware() or isinstance(wallet, Multisig_Wallet))
+    return (not wallet.is_watching_only() and not wallet.is_hardware() and not isinstance(wallet, Multisig_Wallet)
+            and wallet.can_fully_sign_for_all_addresses())
+
 
 def can_fuse_to(wallet):
     """We can only fuse to wallets that are p2pkh with HD generation. We do
     *not* need the private keys."""
-    return isinstance(wallet, Standard_Wallet)
+    return isinstance(wallet, (Standard_Wallet, MultiXPubWallet))
 
 
 

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -195,8 +195,8 @@ class Plugin(FusionPlugin, QObject):
             self.server_status_changed_signal.connect(sbbtn.update_server_error)
         else:
             # If we can not fuse we create a dummy fusion button that just displays a message
-            sbmsg = _('This wallet type ({wtype}) cannot be used with CashFusion.\n\n'
-                      'Please use a standard deterministic spending wallet with CashFusion.').format(wtype=wallet.wallet_type)
+            sbmsg = _('This wallet cannot be used with CashFusion.\n\n'
+                      'Please use a standard deterministic spending wallet with CashFusion.')
             sbbtn = DisabledFusionButton(wallet, sbmsg)
 
         # bit of a dirty hack, to insert our status bar icon (always using index 4, should put us just after the password-changer icon)


### PR DESCRIPTION
This PR adds a new wallet type `multi_xpub`, which is an "aggregate" wallet able to manage multiple `xpub`s (and/or `xprv`s, if so specified by user).  The wallet can manage any combination of multiple `xpub`/`xprv` HD master keys, and provide a unified "view" over the addresses that those master keys generate.

Creating the wallet involves the same steps as a regular single-`xpub` wallet in the wizard: "Standard wallet" -> "Use keys", then just paste multiple unique `xpub` and/or `xprv`s into the wizard and instead of a "standard" wallet you get this new aggregate wallet type.

Behind the scenes, this wallet type is somewhat similar to the MultiSig wallet in that it basically manages multiple `KeyStore` objects, except that it produces `p2pkh` addresses.

The addresses are generated by interleaving the addresses generated by each of the `KeyStore` objects it manages.

Facilities have been added to add/delete individual `xpub`/`xprv` keys from the wallet (which necessarily involves modifying the set of addresses the wallet manages, and requires a wallet history rebuild to 100% work as expected).

This PR also includes:

- The "Wallet Information" dialog now allows the user to see the `xprv` associated with a wallet's keystore(s) (if any).
- Fixed a bug in the `ImportedWallet*` address delete method: it was not fully clearing out all data structures (such as `self.pruned_txo*` and `self.ct_tx*`).
- In the wallet: Added the concept of "preferred change addresses" and "preferred receiving addresses" and used it in the GUI and various places in the wallet. 
  - This address set is the exact same as the regular addresses for all wallets, other than the new `MultiXPubWallet` type.
  -  For the `MultiXpubWallet` type, these "preferred" sets consists of the set of addresses for which it can sign (has `xprv` master keys), if any. 
    - If it can't sign for any addresees, then the "preferred" address sets are identical to the regular address sets.
    - If the "preferred" sets differ, transaction change and/or payment requests will preferentially be sent to these addresses.
      - The idea being that if an aggregate `MultiXpubWallet` can sign for some only some subset of addresses, it should be sending to self only to addresses it can sign for!
- Lost of refactoring
  - Tweaked the class hierarchy for the various `KeyStore` subclasses to unify their API a little bit and also make them slightly more uniform.
  - Tweaked slightly the `wallet.py` class hierarchy as well for similar reasons
  - The  "Wallet Information" dialog in the Qt desktop app now lives in its own file: `wallet_information.py`, rather than the ever-so-long `main_window.py`

