### PR TITLE
Qt: Fix PyQt5 import from PyQt5.Qt instead of PyQt5.QtCore

### DIFF
--- a/electroncash_gui/qt/wallet_information.py
+++ b/electroncash_gui/qt/wallet_information.py
@@ -25,7 +25,7 @@
 import os
 from typing import List, Optional
 
-from PyQt5.Qt import Qt, QMargins
+from PyQt5.QtCore import Qt, QMargins
 from PyQt5.QtWidgets import QDialog, QGridLayout, QVBoxLayout, QLabel, QPushButton, QToolButton, QGroupBox
 
 from electroncash import keystore


### PR DESCRIPTION
The `PyQt5.Qt` namespace should not be used.

```
ImportError: cannot import name 'Qt' from 'PyQt5.Qt' (unknown location)
```