### PR TITLE
Update Trezor plug in to work with latest Trezor library

### DIFF
--- a/electroncash_plugins/trezor/clientbase.py
+++ b/electroncash_plugins/trezor/clientbase.py
@@ -254,8 +254,8 @@ class TrezorClientBase(PrintError):
 
     # ========= UI methods ==========
 
-    def button_request(self, code):
-        message = self.msg or MESSAGES.get(code) or MESSAGES['default']
+    def button_request(self, br):
+        message = self.msg or MESSAGES.get(br.code) or MESSAGES['default']
         def on_cancel():
             try:
                 self.client.cancel()

--- a/electroncash_plugins/trezor/trezor.py
+++ b/electroncash_plugins/trezor/trezor.py
@@ -111,8 +111,8 @@ class TrezorPlugin(HW_PluginBase):
     libraries_URL = 'https://pypi.org/project/trezor/'
     minimum_firmware = (1, 5, 2)
     keystore_class = TrezorKeyStore
-    minimum_library = (0, 12, 0)
-    maximum_library = (0, 13)
+    minimum_library = (0, 13, 8)
+    maximum_library = (0, 14)
 
     DEVICE_IDS = (TREZOR_PRODUCT_KEY,)
 


### PR DESCRIPTION
These changes will update the electron cash plugin so it will work with the latest trezor library.  This library is required for support of the newly released Trezor Safe 3.   In addition to updating the required and permitted versions of the library, it was necessary to edit two lines of code, because at version 0.13.0 of the library an incompatible change was made.

To use this library running from source it will be necessary to install Trezor library 0.13.8.
This can be done by pip3 install trezor 0.13.8

Testing message signing and transaction signing was made with these changes off of the released Electron Cash 4.3.1 on Ubuntu 22.04 with Python 3.10.12.  Verification worked with Trezor Model one and Trezor Model T as well as the new Trezor model 3.  For those wanting to test compatibility with the new libraries any model of Trezor should provide useful information. 

As I have all three Trezor models, I will be glad to help tests of code provided by others.  Please note that I initialized my new Trezor Safe 3 using the Trezor Suite which I also used to set up the original BCH wallet.  

If you have trouble with python dependencies, it may be useful to start with the 4.3.1 release tar.gz source get it working with software wallets and older trezors, and then replacing the two files I have updated with this pull request.

This pull request is with regard to issue #2756 and #2465.