### PR TITLE
Update build-linux to work with new trezor library

### DIFF
--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -196,7 +196,7 @@ export SOURCE_DATE_EPOCH=1530212462
 # If the manifest changed, contrib/build-wine/manifest.xml needs to be updated.
 export PYTHON_VERSION=3.8.9  # Windows, OSX & Linux AppImage use this to determine what to download/build
 export PYTHON_SRC_TARBALL_HASH="5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572"  # If you change PYTHON_VERSION above, update this by downloading the tarball manually and doing a sha256sum on it.
-export DEFAULT_GIT_REPO=https://github.com/Electron-Cash/Electron-Cash
+export DEFAULT_GIT_REPO=https://github.com/tl121/Electron-Cash
 if [ -z "$GIT_REPO" ] ; then
     # If no override from env is present, use default. Support for overrides
     # for the GIT_REPO has been added to allows contributors to test containers

--- a/contrib/build-linux/appimage/Dockerfile_ub2204
+++ b/contrib/build-linux/appimage/Dockerfile_ub2204
@@ -1,0 +1,61 @@
+FROM ubuntu:22.04@sha256:bbf3d1baa208b7649d1d0264ef7d522e1dc0deeeaaf6085bf8e4618867f03494
+
+ARG UBUNTU_MIRROR=http://archive.ubuntu.com/ubuntu/
+
+ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
+
+# If a package version does not exist anymore you can use "apt-cache policy <pkg>" to display the available versions
+RUN echo deb ${UBUNTU_MIRROR} jammy main restricted universe multiverse > /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} jammy-updates main restricted universe multiverse >> /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} jammy-backports main restricted universe multiverse >> /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} jammy-security main restricted universe multiverse >> /etc/apt/sources.list && \
+    apt-get update -q && \
+    apt-get install -qy \
+        git=1:2.34.1-1ubuntu1.10 \
+        wget=1.21.2-2ubuntu1 \
+        make=4.3-4.1build1 \
+        autotools-dev=20220109.1 \
+        autoconf=2.71-2 \
+        libtool=2.4.6-15build2 \
+        xz-utils=5.2.5-2ubuntu1 \
+        libffi-dev=3.4.2-4 \
+        libncurses5-dev=6.3-2ubuntu0.1 \
+        libsqlite3-dev=3.37.2-2ubuntu0.3 \
+        libusb-1.0-0-dev=2:1.0.25-1ubuntu2 \
+        libudev-dev=249.11-0ubuntu3.11 \
+        gettext=0.21-4ubuntu4 \
+        pkg-config=0.29.2-1ubuntu3 \
+        libdbus-1-3=1.12.20-2ubuntu4.1 \
+        libpcsclite-dev=1.9.5-3ubuntu1 \
+        swig=4.0.2-1ubuntu1 \
+        libxkbcommon-x11-0=1.4.0-1 \
+        libxcb1=1.14-3ubuntu3 \
+        libxcb-icccm4=0.4.1-1.1build2 \
+        libxcb-image0=0.4.0-2 \
+        libxcb-keysyms1=0.4.0-1build3 \
+        libxcb-randr0=1.14-3ubuntu3 \
+        libxcb-render-util0=0.3.9-1build3 \
+        libxcb-render0=1.14-3ubuntu3 \
+        libxcb-shape0=1.14-3ubuntu3 \
+        libxcb-shm0=1.14-3ubuntu3 \
+        libxcb-sync1=1.14-3ubuntu3 \
+        libxcb-util1=0.4.0-1build2 \
+        libxcb-xfixes0=1.14-3ubuntu3 \
+        libxcb-xinerama0=1.14-3ubuntu3 \
+        libxcb-xkb1=1.14-3ubuntu3 \
+        libx11-xcb1=2:1.7.5-1ubuntu0.3 \
+        autopoint=0.21-4ubuntu4 \
+        zlib1g-dev=1:1.2.11.dfsg-2ubuntu9.2 \
+        libfreetype6=2.11.1+dfsg-1ubuntu0.2 \
+        libfontconfig1=2.13.1-4.2ubuntu5 \
+        libssl-dev=3.0.2-0ubuntu1.12 \
+        gcc-9=9.5.0-1ubuntu1~22.04 \
+        g++=4:11.2.0-1ubuntu1 \
+        rustc=1.70.0+dfsg0ubuntu1~bpo2-0ubuntu0.22.04.2 \
+        cargo=1.70.0+dfsg0ubuntu1~bpo2-0ubuntu0.22.04.2 \ 
+        && \
+    ln -sf /usr/bin/x86_64-linux-gnu-gcc-9 /usr/bin/gcc && \ 
+    ln -sf /usr/bin/x86_64-linux-gnu-gcc-9 /usr/bin/cc && \ 
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && \
+    apt-get clean

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -46,7 +46,7 @@ if [ -z ${SUDO+x} ] ; then
     fi
 fi
 
-DOCKER_SUFFIX=ub1804
+DOCKER_SUFFIX=ub2204
 
 info "Creating docker image ..."
 $SUDO docker build -t electroncash-appimage-builder-img-$DOCKER_SUFFIX \

--- a/contrib/deterministic-build/requirements-hw.txt
+++ b/contrib/deterministic-build/requirements-hw.txt
@@ -95,7 +95,7 @@ pyscard==2.0.0 \
 trezor==0.13.8 \
     --hash=sha256:634d4eddf35603257c321618d8548c6a35b27384657b65e3b0bdbad635a57cff \
     --hash=sha256:0bd22f761622199df99f8dada3327a94e68542d0b4b5ccfdfaca133308616c86
-typing-extensions==3.7.4.2 \
-    --hash=sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5 \
-    --hash=sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae \
-    --hash=sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392
+typing-extensions==4.9.0 \
+    --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
+    --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
+


### PR DESCRIPTION
The new trezor library needed for support of all Trezor products requires a newer version of typing-extensions.  This was added to deterministic requirements-hw.  

However, for the build to complete successfully it was also necessary to update the Docker version of Ubuntu from the end of life 18.04 to the current 22.04.  A new Docker file includes updated versions of needed software for a successful build.  This build was tested with software wallets and hardware wallets with all three models of Trezor hardware.

(Without the change in Docker file, the build would run unless a wallet was selected that required a Trezor device.)