### PR TITLE
	Correct Docker File in Pull Request #2774modified:   contrib/build-linux/appimage/Dockerfile_ub2004

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub2004
+++ b/contrib/build-linux/appimage/Dockerfile_ub2004
@@ -23,7 +23,7 @@ RUN echo deb ${UBUNTU_MIRROR} focal main restricted universe multiverse > /etc/a
         libncurses5-dev=6.2-0ubuntu2.1 \
         libsqlite3-dev=3.31.1-4ubuntu0.6 \
         libusb-1.0-0-dev=2:1.0.23-2build1 \
-        libudev-dev=245.4-4ubuntu3.22 \
+        libudev-dev=245.4-4ubuntu3.23 \
         gettext=0.19.8.1-10build1 \
         pkg-config=0.29.1-0ubuntu4 \
         libdbus-1-3=1.12.16-2ubuntu2.3 \


### PR DESCRIPTION
In the last few days, the Ubuntu version number of one of the packages changed its Ubuntu version, preventing a successful build of the image.  This pull request corrects this situation. 