### PR TITLE
Update commands.py to standardize capitalization of locktime

### DIFF
--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -269,7 +269,7 @@ def deserialize(raw):
     d['inputs'] = [parse_input(vds) for i in range(n_vin)]
     n_vout = vds.read_compact_size()
     d['outputs'] = [parse_output(vds, i) for i in range(n_vout)]
-    d['lockTime'] = vds.read_uint32()
+    d['locktime'] = vds.read_uint32()
     if vds.can_read_more():
         raise SerializationError('extra junk at the end')
     return d
@@ -453,7 +453,7 @@ class Transaction:
                    for output in self._outputs)
         assert all(isinstance(td, (token.OutputData, type(None)))
                    for td in self._token_datas)
-        self.locktime = d['lockTime']
+        self.locktime = d['locktime']
         self.version = d['version']
         return d
 

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -269,7 +269,7 @@ def deserialize(raw):
     d['inputs'] = [parse_input(vds) for i in range(n_vin)]
     n_vout = vds.read_compact_size()
     d['outputs'] = [parse_output(vds, i) for i in range(n_vout)]
-    d['locktime'] = vds.read_uint32()
+    d['lockTime'] = vds.read_uint32()
     if vds.can_read_more():
         raise SerializationError('extra junk at the end')
     return d
@@ -453,7 +453,7 @@ class Transaction:
                    for output in self._outputs)
         assert all(isinstance(td, (token.OutputData, type(None)))
                    for td in self._token_datas)
-        self.locktime = d['locktime']
+        self.locktime = d['lockTime']
         self.version = d['version']
         return d
 


### PR DESCRIPTION
Fixes #2780

Adjusting "lockTime" case to "locktime" for deserialize to match case for serialize in commands.py as per option (1) of the issue.  This case also matches with raw tx output of bchblockexplorer.com and fullstack.cash ElectrumX/Fulcrum API as well as Electrum's commands.py.  Additional change for serialize to accept both capitalizations discussed as option (3) in the issue is NOT included in this PR.

The fixed problem is also mentioned in #2775 but this commit does not fix the main problem reported in that issue.