### PR TITLE
Adding optional version parameter for serialization via Transaction.from_io

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -375,6 +375,7 @@ class Commands:
         inputs = jsontx.get('inputs')
         outputs = jsontx.get('outputs')
         locktime = jsontx.get('locktime', 0)
+        version = jsontx.get('version', 1)
         for txin in inputs:
             if txin.get('output'):
                 prevout_hash, prevout_n = txin['output'].split(':')
@@ -391,7 +392,7 @@ class Commands:
                 txin['num_sig'] = 1
 
         outputs = [(TYPE_ADDRESS, Address.from_string(x['address']), int(x['value'])) for x in outputs]
-        tx = Transaction.from_io(inputs, outputs, locktime=locktime, sign_schnorr=self.wallet and self.wallet.is_schnorr_enabled())
+        tx = Transaction.from_io(inputs, outputs, locktime=locktime, version=version, sign_schnorr=self.wallet and self.wallet.is_schnorr_enabled())
         tx.sign(keypairs)
         return tx.as_dict()
 

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -458,7 +458,7 @@ class Transaction:
         return d
 
     @classmethod
-    def from_io(cls, inputs, outputs, locktime=0, version=1, sign_schnorr=False, *, token_datas=None) -> object:
+    def from_io(cls, inputs, outputs, locktime=0, sign_schnorr=False, *, token_datas=None, version=1) -> object:
         assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
                    for output in outputs)
         self = cls(None)

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -458,12 +458,13 @@ class Transaction:
         return d
 
     @classmethod
-    def from_io(cls, inputs, outputs, locktime=0, sign_schnorr=False, *, token_datas=None) -> object:
+    def from_io(cls, inputs, outputs, locktime=0, version=1, sign_schnorr=False, *, token_datas=None) -> object:
         assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
                    for output in outputs)
         self = cls(None)
         self._inputs = inputs
         self._outputs = outputs.copy()
+        self.version = version
         if token_datas is not None:
             assert all(isinstance(td, (token.OutputData, type(None)))
                        for td in token_datas)


### PR DESCRIPTION
This fixes #2775 by adding `version` as an optional parameter for `Transaction.from_io` in `transaction.py` and including that parameter in the `serialize` command in `commands.py`.