### PR TITLE
build: remove deprecated apt-key for winehq key

### DIFF
--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -40,8 +40,8 @@ ENV WINEDIST=devel
 ENV WINEVERSION=9.0.0~${UBUNTUDIST}-1
 
 RUN echo "78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6 /tmp/winehq.key" | sha256sum -c - && \
-    apt-key add /tmp/winehq.key && \
-    echo deb https://dl.winehq.org/wine-builds/ubuntu/ ${UBUNTUDIST} main >> /etc/apt/sources.list && \
+    cat /tmp/winehq.key | gpg --dearmor -o /etc/apt/keyrings/winehq.gpg && \
+    echo deb [signed-by=/etc/apt/keyrings/winehq.gpg] https://dl.winehq.org/wine-builds/ubuntu/ ${UBUNTUDIST} main >> /etc/apt/sources.list.d/winehq.list && \
     apt-get update -q && \
     apt-get install -qy \
         wine-${WINEDIST}-amd64:amd64=${WINEVERSION} \


### PR DESCRIPTION
apt-key is deprecated and keys should be specified per source instead of for all sources.