### PR TITLE
portable: fix usage of temp directory and enable portable AppImages

### DIFF
--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -51,9 +51,9 @@ RUN echo "78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6 /tmp/
         # cabextract is needed for winetricks to install the .NET framework
         cabextract=1.9-3 \
         # xvfb is needed to launch the Visual Studio installer
-        xvfb=2:21.1.4-2ubuntu1.7~22.04.8 \
+        xvfb=2:21.1.4-2ubuntu1.7~22.04.10 \
         # winbind is needed for the Visual Studio installer and cl.exe PDB generation
-        winbind=2:4.15.13+dfsg-0ubuntu1.5
+        winbind=2:4.15.13+dfsg-0ubuntu1.6
 
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/electron-cash
+++ b/electron-cash
@@ -29,11 +29,6 @@
 import os
 import sys
 
-# Workaround for PyQt5 5.12.3
-# see https://github.com/pyinstaller/pyinstaller/issues/4293
-if sys.platform == "win32" and hasattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
-    os.environ['PATH'] = sys._MEIPASS + ";" + os.environ['PATH']
-
 # Note CashShuffle's .proto files have namespace conflicts with keepkey
 # This is a workaround to force the python implementation versus the C++
 # implementation which does more intelligent things with protobuf namespaces

--- a/electron-cash
+++ b/electron-cash
@@ -444,15 +444,14 @@ def process_config_options(args):
         config_options["auto_connect"] = False
     config_options["cwd"] = os.getcwd()
 
-    # fixme: this can probably be achieved with a runtime hook (pyinstaller)
-    try:
-        tmp_folder = os.path.join(
-                sys._MEIPASS,  # pylint: disable=W0212
-                "is_portable"
-        )
-        config_options["portable"] = is_bundle and os.path.exists(tmp_folder)
-    except AttributeError:
-        config_options["portable"] = False
+    if not config_options.get("portable"):
+        # auto detect whether we are started from the portable bundle
+        # we only do this when the user has not already specified portable mode
+        # fixme: this can probably be achieved with a runtime hook (pyinstaller)
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            tmp_folder = os.path.join(meipass, "is_portable")
+            config_options["portable"] = is_bundle and os.path.exists(tmp_folder)
 
     if config_options.get("portable"):
         config_options["electron_cash_path"] = os.path.join(

--- a/electron-cash
+++ b/electron-cash
@@ -54,9 +54,11 @@ if jnius:
     threading.Thread.run = thread_check_run
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
-is_bundle = getattr(sys, 'frozen', False)
-is_local = not is_bundle and os.path.exists(os.path.join(script_dir, "electron-cash.desktop"))
+is_pyinstaller = getattr(sys, 'frozen', False)
 is_android = 'ANDROID_DATA' in os.environ
+is_appimage = 'APPIMAGE' in os.environ
+is_binary_distributable = is_pyinstaller or is_android or is_appimage
+is_local = not is_binary_distributable and os.path.exists(os.path.join(script_dir, "electron-cash.desktop"))
 
 if is_local:
     sys.path.insert(0, os.path.join(script_dir, 'packages'))
@@ -451,12 +453,24 @@ def process_config_options(args):
         meipass = getattr(sys, "_MEIPASS", None)
         if meipass:
             tmp_folder = os.path.join(meipass, "is_portable")
-            config_options["portable"] = is_bundle and os.path.exists(tmp_folder)
+            config_options["portable"] = is_pyinstaller and os.path.exists(tmp_folder)
 
     if config_options.get("portable"):
-        config_options["electron_cash_path"] = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "electron_cash_data"
-        )
+        if is_local:
+            # Running from git clone or local source: put datadir next to main script
+            portable_dir = os.path.dirname(os.path.realpath(__file__))
+        else:
+            # Running a binary or installed source
+            if is_pyinstaller:
+                # PyInstaller sets sys.executable to the bundle file
+                portable_dir = os.path.dirname(os.path.realpath(sys.executable))
+            elif is_appimage:
+                # AppImage sets the APPIMAGE environment variable to the bundle file
+                portable_dir = os.path.dirname(os.path.realpath(os.environ["APPIMAGE"]))
+            else:
+                # We fall back to getcwd in case nothing else can be used
+                portable_dir = os.getcwd()
+        config_options['electron_cash_path'] = os.path.join(portable_dir, 'electron_cash_data')
 
     set_verbosity(config_options.get("verbose"))
 


### PR DESCRIPTION
portable: don't override portable user preference if not PyInstaller

```
The previous code would set `portable` to `False` when not ran using
PyInstaller, overriding user preference. This meant that AppImage could
not be used portable.

We now only do the portable auto detection when the user hasn't passed
the `--portable` flag already.
```

portable: fix for newer PyInstaller and AppImage support

```
Starting with PyInstaller 4.3 the behaviour of `__file__` was changed
and we can't rely on it anymore to construct the portable path as that
will result in the data directory being created in the `TEMP` folder and
deleted later.

Instead of using `__file__` we now use `sys.executable` instead.

For the AppImage we also use the `APPIMAGE` environment variable which
points to the AppImage file.

There is a fallback to the current working directory in case the other
methods do not work.

This was tested with all the .exe and .AppImage files, with `--portable`
and without. Also tested using a local git checkout.
```
