### PR TITLE
Exclude python versions in GitHub Actions

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -16,6 +16,30 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        exclude:
+            # Only use the python version we package for macos/win
+            # Better exclude handling would be nice
+            # (https://github.com/orgs/community/discussions/7835)
+          - os: macos-latest
+            python-version: '3.7'
+          - os: macos-latest
+            python-version: '3.8'
+          - os: macos-latest
+            python-version: '3.9'
+          - os: macos-latest
+            python-version: '3.10'
+          - os: macos-latest
+            python-version: '3.12'                  
+          - os: windows-latest
+            python-version: '3.7'
+          - os: windows-latest
+            python-version: '3.8'
+          - os: windows-latest
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.10'
+          - os: windows-latest
+            python-version: '3.12'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Only run all supported version on the linux version. Only run the packaged version on macos/windows.