### PR TITLE
audit: Silence idna vulnerability

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,8 +28,10 @@ jobs:
           # PYSEC-2022-43012, PYSEC-2022-43017 and PYSEC-2023-228 are only at build time
           # Will go away once setuptools, wheel and pip is bumped
           # GHSA-wj6h-64fc-37mp is only for P-256 curve which isn't used in bitcoin
+          # GHSA-jjg7-2v4v-x38h is a minor issue that will be fixed on idna bump (>=3.7)
           ignore-vulns: |
             PYSEC-2022-43012
             PYSEC-2022-43017
             PYSEC-2023-228
             GHSA-wj6h-64fc-37mp
+            GHSA-jjg7-2v4v-x38h


### PR DESCRIPTION
GHSA-jjg7-2v4v-x38h is a minor issue that will be fixed when idna is bumped the next time.