### PR TITLE
regtest: Bump docker containers

### DIFF
--- a/electroncash/tests/regtest/docker-compose.yml
+++ b/electroncash/tests/regtest/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   bitcoind:
-    image: zquestz/bitcoin-cash-node:26.0.0
+    image: zquestz/bitcoin-cash-node:27.0.0
     command: "bitcoind -conf=/conf/bitcoind.conf"
     volumes:
       - conf-files:/conf
@@ -10,7 +10,7 @@ services:
     ports:
       - 18443
   fulcrum:
-    image: cculianu/fulcrum:v1.9.0
+    image: cculianu/fulcrum:v1.10.0
     command: "Fulcrum /conf/fulcrum.conf"
     networks:
      - bitcoin


### PR DESCRIPTION
bitcoin-cash-node:27.0.0
fulcrum:v1.10.0