### PR TITLE
Correct if statement for commands needing password

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -278,7 +278,7 @@ def init_cmdline(config_options, server):
         print_stderr("In particular, DO NOT use 'redeem private key' services proposed by third parties.")
 
     # commands needing password
-    if  ( (cmd.requires_wallet and storage.is_encrypted() and server is False)\
+    if  ( (cmd.requires_wallet and storage.is_encrypted() and not server)\
        or (cmdname == 'load_wallet' and storage.is_encrypted())\
        or (cmd.requires_password and (storage.is_encrypted() or storage.get('use_encryption')))):
         if config.get('password'):


### PR DESCRIPTION
This is a bugfix.  The previous version of this statement would not evaluate correctly, so commands needing passwords would fail returning the following if there was no daemon/gui:
```
Traceback (most recent call last):
  File "/tmp/.mount_ElectrnnTI9Z/usr/bin/electron-cash", line 589, in <module>
    main()
  File "/tmp/.mount_ElectrnnTI9Z/usr/bin/electron-cash", line 581, in main
    result = run_cmdline(config, config_options, cmdname)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.mount_ElectrnnTI9Z/usr/bin/electron-cash", line 427, in run_cmdline
    result = run_offline_command(config, config_options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.mount_ElectrnnTI9Z/usr/bin/electron-cash", line 310, in run_offline_command
    storage.decrypt(password)
  File "/tmp/.mount_ElectrnnTI9Z/usr/lib/python3.11/site-packages/electroncash/util.py", line 362, in <lambda>
    return lambda *args, **kw_args: do_profile(args, kw_args)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.mount_ElectrnnTI9Z/usr/lib/python3.11/site-packages/electroncash/util.py", line 357, in do_profile
    o = func(*args, **kw_args)
        ^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.mount_ElectrnnTI9Z/usr/lib/python3.11/site-packages/electroncash/storage.py", line 146, in decrypt
    ec_key = self.get_key(password)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.mount_ElectrnnTI9Z/usr/lib/python3.11/site-packages/electroncash/storage.py", line 140, in get_key
    secret = hashlib.pbkdf2_hmac('sha512', password.encode('utf-8'), b'', iterations=1024)
                                           ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'encode'
```