### PR TITLE
Enable offline extraction of wallet transactions

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -277,6 +277,10 @@ def init_cmdline(config_options, server):
         print_stderr("Exposing a single private key can compromise your entire wallet!")
         print_stderr("In particular, DO NOT use 'redeem private key' services proposed by third parties.")
 
+    if cmdname == 'gettransaction' and storage.file_exists() and not server:
+        cmd.requires_wallet = True
+        cmd.requires_network = False
+
     # commands needing password
     if  ( (cmd.requires_wallet and storage.is_encrypted() and server is False)\
        or (cmdname == 'load_wallet' and storage.is_encrypted())\

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -772,6 +772,8 @@ class Commands:
         """Retrieve a transaction. """
         if self.wallet and txid in self.wallet.transactions:
             tx = self.wallet.transactions[txid]
+        elif not self.daemon:
+            raise BaseException("Transaction not in wallet")
         else:
             raw = self.network.synchronous_get(('blockchain.transaction.get', [txid]))
             if raw:


### PR DESCRIPTION
This enhancement allows getting raw transactions from local wallet files.  As this only works when the software is not already running, I check for server before adjusting the command requirements.  As any transaction not in the wallet will otherwise fall back to the non-existent network under these conditions, I added exception handling similar to that which already existed for unknown transactions.