### PR TITLE
Add python3.12 to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, py311
+envlist = py37, py38, py39, py310, py311, py312
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 deps=


### PR DESCRIPTION
This way tox can be running on its own on newer python version