### PR TITLE
build: switch AppImage to gcc 10 and remove mksquashfs build

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub2004
+++ b/contrib/build-linux/appimage/Dockerfile_ub2004
@@ -52,13 +52,13 @@ RUN echo deb ${UBUNTU_MIRROR} ${UBUNTU_DIST} main restricted universe multiverse
         libfreetype6=2.10.1-2ubuntu0.3 \
         libfontconfig1=2.13.1-2ubuntu3 \
         libssl-dev=1.1.1f-1ubuntu2.22 \
-        gcc-9=9.4.0-1ubuntu1~20.04.2 \
-        g++=4:9.3.0-1ubuntu2 \
+        gcc-10=10.5.0-1ubuntu1~20.04 \
+        g++-10=10.5.0-1ubuntu1~20.04 \
         rustc=1.75.0+dfsg0ubuntu1~bpo0-0ubuntu0.20.04 \
         cargo=1.75.0+dfsg0ubuntu1~bpo0-0ubuntu0.20.04 \
         && \
-    ln -sf /usr/bin/x86_64-linux-gnu-gcc-9 /usr/bin/gcc && \
-    ln -sf /usr/bin/x86_64-linux-gnu-gcc-9 /usr/bin/cc && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean

--- a/contrib/build-linux/appimage/Dockerfile_ub2004
+++ b/contrib/build-linux/appimage/Dockerfile_ub2004
@@ -56,6 +56,7 @@ RUN echo deb ${UBUNTU_MIRROR} ${UBUNTU_DIST} main restricted universe multiverse
         g++-10=10.5.0-1ubuntu1~20.04 \
         rustc=1.75.0+dfsg0ubuntu1~bpo0-0ubuntu0.20.04 \
         cargo=1.75.0+dfsg0ubuntu1~bpo0-0ubuntu0.20.04 \
+        squashfs-tools=1:4.4-1ubuntu0.3 \
         && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -19,7 +19,6 @@ git config --global --add safe.directory $(readlink -f "$PROJECT_ROOT")
 . "$CONTRIB"/base.sh
 
 # pinned versions
-SQUASHFSKIT_COMMIT="ae0d656efa2d0df2fcac795b6823b44462f19386"
 PKG2APPIMAGE_COMMIT="eb8f3acdd9f11ab19b78f5cb15daa772367daf15"
 
 
@@ -69,17 +68,6 @@ tar xf "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" -C "$BUILDDIR"
     # Some more info: https://bugs.python.org/issue27631
     sed -i -e 's/\.exe//g' "$PYDIR"/_sysconfigdata*
 )
-
-info "Building squashfskit"
-BUILDDIR_ABS=`readlink -f "$BUILDDIR"`
-git config --global --add safe.directory "$BUILDDIR_ABS/squashfskit" # Workaround for building on macOS docker
-git clone "https://github.com/squashfskit/squashfskit.git" "$BUILDDIR/squashfskit"
-(
-    cd "$BUILDDIR/squashfskit"
-    git checkout -b pinned "$SQUASHFSKIT_COMMIT^{commit}" || fail "Could not find squashfskit commit $SQUASHFSKIT_COMMIT"
-    make -C squashfs-tools mksquashfs || fail "Could not build squashfskit"
-)
-MKSQUASHFS="$BUILDDIR/squashfskit/squashfs-tools/mksquashfs"
 
 appdir_python() {
   env \
@@ -248,7 +236,7 @@ info "Creating the AppImage"
     cat > ./squashfs-root/usr/lib/appimagekit/mksquashfs << EOF
 #!/bin/sh
 args=\$(echo "\$@" | sed -e 's/-mkfs-fixed-time 0//')
-"$MKSQUASHFS" \$args
+mksquashfs \$args
 EOF
     env VERSION="$VERSION" ARCH=x86_64 SOURCE_DATE_EPOCH=1530212462 \
                 ./squashfs-root/AppRun --no-appstream --verbose "$APPDIR" "$APPIMAGE" \


### PR DESCRIPTION
This is to make `zxing-cpp` build again. The root cause is an issue in `pybind11`, see:

* https://github.com/pybind/pybind11/releases/tag/v2.13.1
* https://github.com/pybind/pybind11/issues/5201
* https://github.com/pybind/pybind11/pull/5205
* https://github.com/zxing-cpp/zxing-cpp/issues/803

The currently used `mksquashfs` does not build with gcc 10 and the source has not been updated for 5 years. We switch to the Ubuntu package instead of another upstream.