### PR TITLE
build: fix python dev.msi installation in wine

### DIFF
--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -83,7 +83,8 @@ prepare_wine() {
 
         # Install Python
         info "Installing Python ..."
-        msifiles="core dev exe lib pip tools"
+        # dev needs to be after exe, otherwise there is a stack overflow in wine
+        msifiles="core exe dev lib pip tools"
 
         for msifile in $msifiles ; do
             info "Downloading $msifile..."


### PR DESCRIPTION
We need to install `exe.msi` before `dev.msi` or there will be a stack overflow in wine.