### PR TITLE
fix/address coingecko historical price data issue

### DIFF
--- a/electroncash/currencies.json
+++ b/electroncash/currencies.json
@@ -568,5 +568,9 @@
     ],
     "BitstampYadio": [
     "ARS"
+    ],
+     "YahooFinance": [
+    "AUD",
+    "USD"
     ]
 }

--- a/electroncash/exchange_rate.py
+++ b/electroncash/exchange_rate.py
@@ -135,6 +135,8 @@ class ExchangeBase(PrintError):
                     # Paranoia: No data; abort early rather than write out an
                     # empty file
                     raise RuntimeWarning(f"received empty history for {ccy}")
+                if not cached_history:
+                    cached_history = {}
                 cached_history.update(new_history)
                 self._cache_historical_rates(cached_history, ccy, cache_dir)
             except Exception as e:

--- a/electroncash/exchange_rate.py
+++ b/electroncash/exchange_rate.py
@@ -291,7 +291,6 @@ class YahooFinance(ExchangeBase):
 		# URL requires exact GMT epoch date with no time
         gmt_epoch_date = int(time.time()) - (int(time.time()) % 86400)
         path = '/v7/finance/download/BCH-{}?period1=1510272000&period2={}&interval=1d&events=history&includeAdjustedClose=true'.format(ccy, gmt_epoch_date)
-        print(path)
         history = self.get_csv('query1.finance.yahoo.com', path)
         
         def safe_float(value):

--- a/electroncash/exchange_rate.py
+++ b/electroncash/exchange_rate.py
@@ -125,22 +125,23 @@ class ExchangeBase(PrintError):
         return True
 
     def get_historical_rates_safe(self, ccy, cache_dir):
-        h, timestamp = self.read_historical_rates(ccy, cache_dir)
-        if not h or self._is_timestamp_old(timestamp):
+        cached_history, timestamp = self.read_historical_rates(ccy, cache_dir)
+        if not cached_history or self._is_timestamp_old(timestamp):
             try:
                 self.print_error("requesting fx history for", ccy)
-                h = self.request_history(ccy)
+                new_history = self.request_history(ccy)
                 self.print_error("received fx history for", ccy)
-                if not h:
+                if not new_history:
                     # Paranoia: No data; abort early rather than write out an
                     # empty file
                     raise RuntimeWarning(f"received empty history for {ccy}")
-                self._cache_historical_rates(h, ccy, cache_dir)
+                cached_history.update(new_history)
+                self._cache_historical_rates(cached_history, ccy, cache_dir)
             except Exception as e:
-                self.print_error("failed fx history:", repr(e))
+                self.print_error("failed fx new_history:", repr(e))
                 return
-        self.print_error("received history rates of length", len(h))
-        self.history[ccy] = h
+            self.print_error("received history rates of length", len(new_history))
+        self.history[ccy] = cached_history
         self.history_timestamps[ccy] = timestamp
         self.on_history()
 
@@ -266,7 +267,7 @@ class CoinGecko(ExchangeBase):
                 'ZAR']
 
     def request_history(self, ccy):
-        history = self.get_json('api.coingecko.com', '/api/v3/coins/bitcoin-cash/market_chart?vs_currency=%s&days=max' % ccy)
+        history = self.get_json('api.coingecko.com', '/api/v3/coins/bitcoin-cash/market_chart?vs_currency=%s&days=365' % ccy)
 
         from datetime import datetime as dt
         return dict([(dt.utcfromtimestamp(h[0]/1000).strftime('%Y-%m-%d'), h[1])

--- a/electroncash/exchange_rate.py
+++ b/electroncash/exchange_rate.py
@@ -275,6 +275,37 @@ class CoinGecko(ExchangeBase):
         return dict([(dt.utcfromtimestamp(h[0]/1000).strftime('%Y-%m-%d'), h[1])
                      for h in history['prices']])
 
+class YahooFinance(ExchangeBase):
+	
+    # Current price not easily available from YahooFinance, so we get from CoinGecko instead
+    def get_rates(self, ccy):
+        json = self.get_json('api.coingecko.com', '/api/v3/coins/bitcoin-cash?localization=False&sparkline=false')
+        prices = json["market_data"]["current_price"]
+        return dict([(a[0].upper(),to_decimal(a[1])) for a in prices.items()])
+
+    def history_ccys(self):
+        return ['AUD', 'USD']
+
+    # Historical prices are OK though
+    def request_history(self, ccy):
+		# URL requires exact GMT epoch date with no time
+        gmt_epoch_date = int(time.time()) - (int(time.time()) % 86400)
+        path = '/v7/finance/download/BCH-{}?period1=1510272000&period2={}&interval=1d&events=history&includeAdjustedClose=true'.format(ccy, gmt_epoch_date)
+        print(path)
+        history = self.get_csv('query1.finance.yahoo.com', path)
+        
+        def safe_float(value):
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return 0
+        # average of open,high,low,close prices. interpret garbage data as zero
+        return dict({
+            i['Date']: (safe_float(i.get('Open', 0)) + safe_float(i.get('High', 0)) + safe_float(i.get('Low', 0)) + safe_float(i.get('Close', 0))) / 4 
+            for i in history
+        })
+
+
 class BitstampYadio(ExchangeBase):
     def get_rates(self, ccy):
         json_usd = self.get_json('www.bitstamp.net', '/api/v2/ticker/bchusd')


### PR DESCRIPTION
Update CoinGecko request_history from max days to 365, to match what their API now allows
Modify ExchangeBase get_historical_rates_safe to update the historical price cache, instead of replacing 
This addresses the 'No Data' issue shown here https://t.me/electroncashwallet/119941
Code taken from https://reviews.bitcoinabc.org/D15841