### PR TITLE
Update apk translations source

### DIFF
--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -42,6 +42,7 @@ COPY contrib/make_locale contrib/
 COPY electroncash_gui electroncash_gui
 COPY ios/ElectronCash/electroncash_gui/ios_native ios/ElectronCash/electroncash_gui/ios_native
 COPY electroncash_plugins electroncash_plugins
+COPY contrib/electrum-locale contrib/electrum-locale
 
 # The app itself.
 COPY android android

--- a/contrib/make_locale
+++ b/contrib/make_locale
@@ -103,16 +103,17 @@ if len(sys.argv) > 1:
 # Convert .po to .mo
 print('Installing')
 os.chdir('..')
-src_dir = 'contrib/electrum-locale/locale' if use_electrum_locale else 'contrib'
+dst_dir= 'electroncash/locale'
+src_dir = 'contrib/electrum-locale/locale' if use_electrum_locale else dst_dir
 for lang in os.listdir(src_dir):
     if not isdir(join(src_dir, lang)) or lang == "__pycache__":
         continue
-    msg_dir = src_dir + '/{}'.format(lang)
-    msg_mo_dir = msg_dir + '/LC_MESSAGES'
-    msg_po_dir = msg_dir if use_electrum_locale else msg_mo_dir
-    # Check LC_MESSAGES folder
-    if not os.path.exists(msg_mo_dir):
-        os.mkdir(msg_mo_dir)
-    cmd = 'msgfmt --output-file="{0}/electron-cash.mo" "{1}/electron-cash.po"'.format(msg_mo_dir, msg_po_dir)
+    msg_src_dir = src_dir + '/{}'.format(lang)
+    if not use_electrum_locale:
+        msg_src_dir += '/LC_MESSAGES'
+    msg_dst_dir = dst_dir + '/{}/LC_MESSAGES'.format(lang)
+    if not os.path.exists(msg_dst_dir):
+        os.makedirs(msg_dst_dir)
+    cmd = 'msgfmt --output-file="{0}/electron-cash.mo" "{1}/electron-cash.po"'.format(msg_dst_dir, msg_src_dir)
     print('Installing', lang)
     run(cmd)

--- a/contrib/make_locale
+++ b/contrib/make_locale
@@ -8,6 +8,7 @@ from os.path import isdir, join
 from pathlib import Path
 import requests
 import shlex
+import shutil
 from subprocess import check_call
 import sys
 import zipfile
@@ -114,6 +115,10 @@ for lang in os.listdir(src_dir):
     msg_dst_dir = dst_dir + '/{}/LC_MESSAGES'.format(lang)
     if not os.path.exists(msg_dst_dir):
         os.makedirs(msg_dst_dir)
-    cmd = 'msgfmt --output-file="{0}/electron-cash.mo" "{1}/electron-cash.po"'.format(msg_dst_dir, msg_src_dir)
+    src_file = msg_src_dir + '/electron-cash.po'
+    dst_file = msg_dst_dir + '/electron-cash.mo'
+    cmd = 'msgfmt --output-file="{0}" "{1}"'.format(dst_file, src_file)
+    if use_electrum_locale:
+        shutil.copy(src_file, msg_dst_dir)
     print('Installing', lang)
     run(cmd)


### PR DESCRIPTION
This is on top of #2904 

Now that we are using `contrib/electrum-locale` as the source for translation files by default (rather than straight from Crowdin), this PR makes these files available to the Android build process