### PR TITLE
Consolidate tool CLI 

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -467,7 +467,7 @@ class Commands:
     def broadcast(self, tx):
         """Broadcast a transaction to the network. """
         tx = Transaction(tx)
-        return self.network.broadcast_transaction3(tx)
+        return self.network.broadcast_transaction(tx)
 
     @command('')
     def createmultisig(self, num, pubkeys):

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -41,6 +41,7 @@ from . import rpa
 from . import util
 from .address import Address, AddressError
 from .bitcoin import hash_160, COIN, TYPE_ADDRESS
+from .consolidate import AddressConsolidator
 from .i18n import _
 from .plugins import run_hook
 from .wallet import create_new_wallet, restore_wallet_from_text
@@ -51,11 +52,6 @@ from .simple_config import SimpleConfig
 from .version import PACKAGE_VERSION
 
 
-from electroncash.consolidate import (
-    MAX_STANDARD_TX_SIZE,
-    MAX_TX_SIZE,
-    AddressConsolidator,
-)
 known_commands = {}
 
 
@@ -353,47 +349,23 @@ class Commands:
         return self.network.synchronous_get(('blockchain.scripthash.get_history', [sh]))
 
     @command('w')
-    def consolidatecoins(self,address):
-        
-        """Minimal CLI implementation for consolidate coins tool.  
-        Can be expanded to include additional paramaters.
-        
-        Currently takes a single parameter for the address to
-        consolidate and creates transactions to a destination
-        of the same address.
-        
-        Returns the array of (unsigned) transactions.
-        """
-        address_obj = Address.from_string(address)
-        include_coinbase=True
-        include_non_coinbase=True
-        include_frozen=False
-        include_slp=False
-        minimum_value=0
-        maximum_value=999999999999999
-        minimum_height=0
-        maximum_height=999999999
-        max_tx_size=MAX_STANDARD_TX_SIZE
-        output_address = address_obj
-        self.consolidator = AddressConsolidator(
-            address_obj,
-            self.wallet,
-            include_coinbase,
-            include_non_coinbase,
-            include_frozen,
-            include_slp,
-            minimum_value,
-            maximum_value,
-            minimum_height,
-            maximum_height,
-            output_address,
-            max_tx_size,
-        )
-        transactions = []
-        for i, tx in enumerate(self.consolidator.iter_transactions()):
-            transactions.append(tx) 
-        return transactions
-   
+    def consolidatecoins(self, address):
+        """Minimal CLI implementation for consolidate coins tool.
+        Can be expanded to include additional parameters.
+
+        Currently, takes a single parameter for the address to
+        consolidate and creates 1 or more transaction(s) to a
+        destination of the same address.
+
+        Returns the array of (unsigned) transaction(s) (as hex strings)."""
+        if isinstance(address, str):
+            address = Address.from_string(address)
+        elif not isinstance(address, Address):
+            raise TypeError('address parameter must be either a string or an Address object')
+
+        consolidator = AddressConsolidator(address=address, wallet_instance=self.wallet, output_address=address)
+        return [tx.serialize() for tx in consolidator.iter_transactions()]
+
     @command('w')
     def listunspent(self):
         """List unspent outputs. Returns the list of unspent transaction

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# Electrum ABC - lightweight eCash client
+# Copyright (C) 2021 The Electrum ABC developers 
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module provides coin consolidation tools.  
+Attribution: https://github.com/scinklja/Electron-Cash/tree/consolidate_address
+""" 
+import copy
+from typing import Iterator, List, Optional, Tuple
+
+from . import wallet
+from .address import Address
+from .bitcoin import TYPE_ADDRESS
+from .transaction import Transaction
+
+MAX_STANDARD_TX_SIZE: int = 100_000
+"""Maximum size for transactions that nodes are willing to relay/mine.
+"""
+
+MAX_TX_SIZE: int = 1_000_000
+"""
+Maximum allowed size for a transaction in a block.
+"""
+
+FEERATE: int = 1
+"""satoshis per byte"""
+
+
+class AddressConsolidator:
+    """Consolidate coins for a single address in a wallet."""
+
+    def __init__(
+        self,
+        address: Address,
+        wallet_instance: wallet.Abstract_Wallet,
+        include_coinbase: bool = True,
+        include_non_coinbase: bool = True,
+        include_frozen: bool = False,
+        include_slp: bool = False,
+        min_value_sats: Optional[int] = None,
+        max_value_sats: Optional[int] = None,
+        min_height: Optional[int] = None,
+        max_height: Optional[int] = None,
+        output_address: Optional[Address] = None,
+        max_tx_size: Optional[int] = MAX_STANDARD_TX_SIZE,
+    ):
+        # output address defaults to input address if unspecified
+        self.output_address = output_address or address
+        self.max_tx_size = max_tx_size
+        assert self.max_tx_size <= MAX_TX_SIZE
+
+        self._coins = [
+            utxo
+            for utxo in wallet_instance.get_addr_utxo(address).values()
+            if (
+                (include_coinbase or not utxo["coinbase"])
+                and (include_non_coinbase or utxo["coinbase"])
+                and (include_slp or utxo["slp_token"] is None)
+                and (include_frozen or not utxo["is_frozen_coin"])
+                and (min_value_sats is None or utxo["value"] >= min_value_sats)
+                and (max_value_sats is None or utxo["value"] <= max_value_sats)
+                and (min_height is None or utxo["height"] >= min_height)
+                and (max_height is None or utxo["height"] <= max_height)
+            )
+        ]
+        self.wallet = wallet_instance
+
+        # Cache data common to all coins
+        self.address = address
+        self.txin_type = wallet_instance.get_txin_type(address)
+        self.received = {}
+        for tx_hash, height in wallet_instance.get_address_history(address):
+            l = self.wallet.txo.get(tx_hash, {}).get(address, [])
+            for n, v, is_cb in l:
+                self.received[tx_hash + f":{n}"] = (height, v, is_cb)
+
+        if isinstance(self.wallet, wallet.ImportedAddressWallet):
+            sig_info = {
+                "x_pubkeys": ["fd" + address.to_script_hex()],
+                "signatures": [None],
+            }
+        elif isinstance(self.wallet, wallet.ImportedPrivkeyWallet):
+            pubkey = self.wallet.keystore.address_to_pubkey(address)
+            sig_info = {
+                "x_pubkeys": [pubkey.to_ui_string()],
+                "signatures": [None],
+                "num_sig": 1,
+            }
+        elif isinstance(self.wallet, wallet.Multisig_Wallet):
+            derivation = self.wallet.get_address_index(address)
+            sig_info = {
+                "x_pubkeys": [
+                    k.get_xpubkey(*derivation) for k in self.wallet.get_keystores()
+                ],
+                "signatures": [None] * self.wallet.n,
+                "num_sig": self.wallet.m,
+                "pubkeys": None,
+            }
+        else:
+            # Default case for wallet.Simple_Deterministic_Wallet and Mock wallet used
+            # in test
+            derivation = self.wallet.get_address_index(address)
+            x_pubkey = self.wallet.keystore.get_xpubkey(*derivation)
+            sig_info = {
+                "x_pubkeys": [x_pubkey],
+                "signatures": [None],
+                "num_sig": 1,
+            }
+
+        # Add more metadata to coins
+        for i, c in enumerate(self._coins):
+            self.add_input_info(c, sig_info)
+
+    def get_unsigned_transactions(self) -> List[Transaction]:
+        """
+        Build as many raw transactions as needed to consolidate the coins.
+
+        :param output_address: Make all transactions send the total amount to this
+            address.
+        :param max_tx_size: Maximum tx size in bytes. This is what limits the
+            number of inputs per transaction.
+        :return:
+        """
+        return list(self.iter_transactions())
+
+    def iter_transactions(self) -> Iterator[Transaction]:
+        coin_index = 0
+        while coin_index < len(self._coins):
+            coin_index, tx = self.build_another_transaction(coin_index)
+            yield tx
+
+    def build_another_transaction(self, coin_index: int) -> Tuple[int, Transaction]:
+        """Build another transaction using coins starting at index coin_index.
+        Return a 2-tuple with the index of the next unused coin and the transaction.
+        """
+        tx_size = 0
+        amount = 0
+        tx = Transaction(None)
+        tx.set_inputs([])
+        while tx_size < self.max_tx_size and coin_index < len(self._coins):
+            tx_size = self.try_adding_another_coin_to_transaction(
+                tx,
+                self._coins[coin_index],
+                amount + self._coins[coin_index]["value"],
+            )
+            if tx_size < self.max_tx_size:
+                amount = amount + self._coins[coin_index]["value"]
+                coin_index += 1
+        return coin_index, tx
+
+    def try_adding_another_coin_to_transaction(
+        self,
+        tx: Transaction,
+        coin: dict,
+        next_amount: int,
+    ) -> int:
+        """Add coin to tx.inputs() if the resulting tx size is less than max_tx_size.
+        Return the resulting tx_size (no matter if the coin was actually added or not).
+        """
+        dummy_tx = Transaction(None)
+        dummy_tx.set_inputs(tx.inputs() + [coin])
+        dummy_tx.set_outputs([(TYPE_ADDRESS, self.output_address, next_amount)])
+        tx_size = len(dummy_tx.serialize(estimate_size=True)) // 2
+        if tx_size < self.max_tx_size:
+            tx.add_inputs([coin])
+            tx.set_outputs(
+                [(TYPE_ADDRESS, self.output_address, next_amount - tx_size * FEERATE)]
+            )
+        return tx_size
+
+    def add_input_info(self, txin, siginfo: dict):
+        """Reimplemented from wallet.add_input_info to optimize for multiple calls
+        with same address and same history.
+        Caching the transaction history is the most significant optimization,
+        as the original function loads the history from disk (text file) for
+        every call."""
+        txin["type"] = self.txin_type
+        item = self.received.get(txin["prevout_hash"] + f":{txin['prevout_n']}")
+        tx_height, value, is_cb = item
+        txin["value"] = value
+        txin.update(copy.deepcopy(siginfo))
+

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# Electrum ABC - lightweight eCash client
-# Copyright (C) 2021 The Electrum ABC developers 
+# Electron Cash - lightweight Bitcoin Cash client
+# Copyright (C) 2021 The Electrum ABC developers
+# Copyright (C) 2024 The Electrum Cash developers
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -22,9 +23,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """
-This module provides coin consolidation tools.  
+This module provides coin consolidation tools.
 Attribution: https://github.com/scinklja/Electron-Cash/tree/consolidate_address
-""" 
+"""
 import copy
 from typing import Iterator, List, Optional, Tuple
 
@@ -34,13 +35,10 @@ from .bitcoin import TYPE_ADDRESS
 from .transaction import Transaction
 
 MAX_STANDARD_TX_SIZE: int = 100_000
-"""Maximum size for transactions that nodes are willing to relay/mine.
-"""
+"""Maximum size for transactions that nodes are willing to relay/mine."""
 
 MAX_TX_SIZE: int = 1_000_000
-"""
-Maximum allowed size for a transaction in a block.
-"""
+"""Maximum allowed size for a transaction in a block."""
 
 FEERATE: int = 1
 """satoshis per byte"""
@@ -57,6 +55,7 @@ class AddressConsolidator:
         include_non_coinbase: bool = True,
         include_frozen: bool = False,
         include_slp: bool = False,
+        include_cashtokens: bool = False,
         min_value_sats: Optional[int] = None,
         max_value_sats: Optional[int] = None,
         min_height: Optional[int] = None,
@@ -76,6 +75,7 @@ class AddressConsolidator:
                 (include_coinbase or not utxo["coinbase"])
                 and (include_non_coinbase or utxo["coinbase"])
                 and (include_slp or utxo["slp_token"] is None)
+                and (include_cashtokens or utxo["token_data"] is None)
                 and (include_frozen or not utxo["is_frozen_coin"])
                 and (min_value_sats is None or utxo["value"] >= min_value_sats)
                 and (max_value_sats is None or utxo["value"] <= max_value_sats)

--- a/electroncash/tests/test_consolidate.py
+++ b/electroncash/tests/test_consolidate.py
@@ -1,0 +1,247 @@
+import math
+import unittest
+from unittest.mock import Mock
+
+from .. import consolidate
+from ..address import Address
+
+TEST_ADDRESS: Address = Address.from_string(
+    "bitcoincash:qr3l6uufcuwm9prgpa6cfxnez87fzstxescngr64l4"
+)
+
+FEERATE: int = 1
+"""Satoshis per byte"""
+
+
+class TestConsolidateCoinSelection(unittest.TestCase):
+    def setUp(self) -> None:
+        coins = {}
+        tx_history = []
+        i = 0
+        for is_coinbase in (True, False):
+            for is_frozen_coin in (True, False):
+                for slp in (None, "not None"):
+                    coins[f"dummy_txid:{i}"] = {
+                        "address": TEST_ADDRESS,
+                        "prevout_n": i,
+                        "prevout_hash": "a" * 64,
+                        "height": 700_000 + i,
+                        "value": 1000 + i,
+                        "coinbase": is_coinbase,
+                        "is_frozen_coin": is_frozen_coin,
+                        "slp_token": slp,
+                        "type": "p2pkh",
+                    }
+                    i += 1  # noqa: SIM113
+                tx_history.append(("a" * 64, 1))
+
+        self.mock_wallet = Mock()
+        self.mock_wallet.get_addr_utxo.return_value = coins
+        self.mock_wallet.get_address_history.return_value = tx_history
+        self.mock_wallet.get_address_history.return_value = tx_history
+        self.mock_wallet.get_txin_type.return_value = "p2pkh"
+
+        # mock for self.wallet.txo.get(tx_hash, {}).get(address, [])
+        # returns list of (prevout_n, value, is_coinbase)
+        self.mock_wallet.txo = Mock()
+        txo_get_return = Mock()
+        txo_get_return.get.return_value = [
+            (
+                i,
+                1000 + i,
+                True,
+            )
+            for i in range(len(coins))
+        ]
+        self.mock_wallet.txo.get.return_value = txo_get_return
+
+        self.mock_wallet.get_address_index.return_value = True, 0
+
+        self.mock_wallet.keystore.get_xpubkey.return_value = "dummy"
+
+    def test_coin_selection(self) -> None:
+        for incl_coinbase in (True, False):
+            for incl_noncoinbase in (True, False):
+                for incl_frozen in (True, False):
+                    for incl_slp in (True, False):
+                        consolidator = consolidate.AddressConsolidator(
+                            TEST_ADDRESS,
+                            self.mock_wallet,
+                            incl_coinbase,
+                            incl_noncoinbase,
+                            incl_frozen,
+                            incl_slp,
+                        )
+                        for coin in consolidator._coins:
+                            if not incl_coinbase:
+                                self.assertFalse(coin["coinbase"])
+                            if not incl_noncoinbase:
+                                self.assertTrue(coin["coinbase"])
+                            if not incl_frozen:
+                                self.assertFalse(coin["is_frozen_coin"])
+                            if not incl_slp:
+                                self.assertIsNone(coin["slp_token"])
+
+        # test minimum and maximum value
+        consolidator = consolidate.AddressConsolidator(
+            TEST_ADDRESS,
+            self.mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_value_sats=1003,
+            max_value_sats=None,
+        )
+        for coin in consolidator._coins:
+            self.assertGreaterEqual(coin["value"], 1003)
+        self.assertEqual(len(consolidator._coins), 5)
+
+        consolidator = consolidate.AddressConsolidator(
+            TEST_ADDRESS,
+            self.mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_value_sats=None,
+            max_value_sats=1005,
+        )
+        for coin in consolidator._coins:
+            self.assertLessEqual(coin["value"], 1005)
+        self.assertEqual(len(consolidator._coins), 6)
+
+        consolidator = consolidate.AddressConsolidator(
+            TEST_ADDRESS,
+            self.mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_value_sats=1003,
+            max_value_sats=1005,
+        )
+        for coin in consolidator._coins:
+            self.assertGreaterEqual(coin["value"], 1003)
+            self.assertLessEqual(coin["value"], 1005)
+        self.assertEqual(len(consolidator._coins), 3)
+
+        # test minimum and maximum height
+        consolidator = consolidate.AddressConsolidator(
+            TEST_ADDRESS,
+            self.mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_height=None,
+            max_height=700_005,
+        )
+        for coin in consolidator._coins:
+            self.assertLessEqual(coin["height"], 700_005)
+        self.assertEqual(len(consolidator._coins), 6)
+
+        consolidator = consolidate.AddressConsolidator(
+            TEST_ADDRESS,
+            self.mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_height=700_003,
+            max_height=None,
+        )
+        for coin in consolidator._coins:
+            self.assertGreaterEqual(coin["height"], 700_003)
+        self.assertEqual(len(consolidator._coins), 5)
+
+        consolidator = consolidate.AddressConsolidator(
+            TEST_ADDRESS,
+            self.mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_height=700_003,
+            max_height=700_005,
+        )
+        for coin in consolidator._coins:
+            self.assertGreaterEqual(coin["height"], 700_003)
+            self.assertLessEqual(coin["height"], 700_005)
+        self.assertEqual(len(consolidator._coins), 3)
+
+        # Filter both on height and value
+        consolidator = consolidate.AddressConsolidator(
+            TEST_ADDRESS,
+            self.mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_value_sats=1004,
+            max_value_sats=1006,
+            min_height=700_003,
+            max_height=700_005,
+        )
+        for coin in consolidator._coins:
+            self.assertGreaterEqual(coin["value"], 1003)
+            self.assertLessEqual(coin["value"], 1006)
+            self.assertGreaterEqual(coin["height"], 700_003)
+            self.assertLessEqual(coin["height"], 700_005)
+        self.assertEqual(len(consolidator._coins), 2)
+
+    def test_get_unsigned_transactions(self):
+        n_coins = 8
+        min_value = 1000
+        max_value = 1007
+        for max_tx_size in range(200, 1500, 100):
+            # select all coins
+            consolidator = consolidate.AddressConsolidator(
+                TEST_ADDRESS,
+                self.mock_wallet,
+                True,
+                True,
+                True,
+                True,
+                min_value_sats=None,
+                max_value_sats=None,
+                output_address=TEST_ADDRESS,
+                max_tx_size=max_tx_size,
+            )
+            self.assertEqual(n_coins, len(consolidator._coins))
+            txs = consolidator.get_unsigned_transactions()
+            for tx in txs:
+                self.assertLess(len(tx.serialize(estimate_size=True)) // 2, max_tx_size)
+
+            # tx size is roughly 148 * n_in + 34 * n_out + 10
+            expected_max_n_inputs_for_size = math.floor((max_tx_size - 44) / 148)
+            self.assertEqual(
+                len(txs), math.ceil(n_coins / expected_max_n_inputs_for_size)
+            )
+
+            # Check the fee and amount
+            total_input_value = 0
+            total_output_value = 0
+            total_fee = 0
+            total_size = 0
+            for tx in txs:
+                tx_size = len(tx.serialize(estimate_size=True)) // 2
+                self.assertEqual(tx.get_fee(), tx_size * FEERATE)
+                total_fee += tx.get_fee()
+                total_input_value += tx.input_value()
+                total_output_value += tx.output_value()
+                total_size += tx_size
+            self.assertEqual(total_input_value, sum(range(min_value, max_value + 1)))
+            self.assertEqual(total_output_value, total_input_value - total_fee)
+            self.assertEqual(total_fee, total_size * FEERATE)
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestConsolidateCoinSelection))
+    return test_suite
+
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -676,7 +676,7 @@ class Transaction:
         return s
 
     def serialize_output_n_bytes(self, n: int) -> bytes:
-        assert 0 <= n < len(self._outputs)
+        assert 0 <= n < len(self._outputs) 
         assert len(self._token_datas) == len(self._outputs)
         output = self._outputs[n]
         token_data = self._token_datas[n]
@@ -828,7 +828,11 @@ class Transaction:
         self._inputs.extend(inputs)
         self.raw = None
         self.invalidate_common_sighash_cache()
-
+ 
+    def set_inputs(self, inputs):
+        self._inputs = inputs
+        self.raw = None
+        
     def add_outputs(self, outputs, token_datas=None):
         assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
                    for output in outputs)
@@ -840,7 +844,18 @@ class Transaction:
         self._token_datas.extend(token_datas)
         self.raw = None
         self.invalidate_common_sighash_cache()
-
+   
+    def set_outputs(self, outputs):
+        assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
+                   for output in outputs) 
+        self._outputs = outputs
+        self.raw = None 
+        token_datas = []
+        self._token_datas=token_datas
+        if len(token_datas) < len(outputs):
+            token_datas = [None] * (len(outputs) - len(token_datas)) 
+        self._token_datas.extend(token_datas)  
+   
     def input_value(self):
         """ Will return the sum of all input values, if the input values
         are known (may consult self.fetched_inputs() to get a better idea of

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -676,7 +676,7 @@ class Transaction:
         return s
 
     def serialize_output_n_bytes(self, n: int) -> bytes:
-        assert 0 <= n < len(self._outputs) 
+        assert 0 <= n < len(self._outputs)
         assert len(self._token_datas) == len(self._outputs)
         output = self._outputs[n]
         token_data = self._token_datas[n]
@@ -828,11 +828,12 @@ class Transaction:
         self._inputs.extend(inputs)
         self.raw = None
         self.invalidate_common_sighash_cache()
- 
+
     def set_inputs(self, inputs):
+        self.deserialize()  # Ensure class invariant, since we will clobber self.raw below, ensure we deserialized first
         self._inputs = inputs
         self.raw = None
-        
+
     def add_outputs(self, outputs, token_datas=None):
         assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
                    for output in outputs)
@@ -844,18 +845,23 @@ class Transaction:
         self._token_datas.extend(token_datas)
         self.raw = None
         self.invalidate_common_sighash_cache()
-   
-    def set_outputs(self, outputs):
+
+    def set_outputs(self, outputs, token_datas=None):
         assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
-                   for output in outputs) 
+                   for output in outputs)
+        assert token_datas is None or (len(token_datas) == len(outputs)
+                                       and all(isinstance(td, (token.OutputData, type(None))) for td in token_datas))
+        self.deserialize()  # Ensure class invariant, since we will clobber self.raw below, ensure we deserialized first
         self._outputs = outputs
-        self.raw = None 
-        token_datas = []
-        self._token_datas=token_datas
-        if len(token_datas) < len(outputs):
-            token_datas = [None] * (len(outputs) - len(token_datas)) 
-        self._token_datas.extend(token_datas)  
-   
+        self.raw = None
+        if token_datas is None:
+            # if they specified no token_datas, just grab what we had before from self._token_datas
+            token_datas = [None] * len(outputs)  # Class invariant: outputs and token_datas must have same length.
+            token_datas_prev = self._token_datas or []
+            for i in range(min(len(token_datas), len(token_datas_prev))):
+                token_datas[i] = token_datas_prev[i]
+        self._token_datas = token_datas
+
     def input_value(self):
         """ Will return the sum of all input values, if the input values
         are known (may consult self.fetched_inputs() to get a better idea of


### PR DESCRIPTION
Adds the basics for the consolidate tool on the CLI level.  Can be used as a basis for the gui implementation if desired at a later time. Can also be expanded to include more functionality in terms of the command parameters.  To fully test, it should be tested on a wallet with hundreds of UTXO on the same address so that it creates multiple transactions.  Currently, it has been only tested for a wallet with a single consolidate transaction.  To test, enter the command consolidatecoins("your-bch-address") in the command console, then copy the raw transaction and paste into the wallet using the load transaction from text tool, then sign the transaction and broadcast.