### PR TITLE
[android] Enable receive dialog and fix send warning on watching-only wallets

### DIFF
--- a/android/app/src/main/java/org/electroncash/electroncash3/Requests.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Requests.kt
@@ -80,9 +80,6 @@ class NewRequestDialog : TaskDialog<PyObject>() {
     val listFragment by lazy { targetFragment as ListFragment }
 
     override fun doInBackground(): PyObject {
-        if (listFragment.wallet.callAttr("is_watching_only").toBoolean()) {
-            throw ToastException(R.string.this_wallet_is)
-        }
         return listFragment.wallet.callAttr("get_unused_address")
                ?: throw ToastException(R.string.no_more)
     }

--- a/android/app/src/main/java/org/electroncash/electroncash3/TokenTransactions.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/TokenTransactions.kt
@@ -44,9 +44,13 @@ class TokenTransactionsFragment : ListFragment(R.layout.token_transactions, R.id
         binding.btnRequest.setOnClickListener { showDialog(this, NewRequestDialog().apply {
             arguments = Bundle().apply { putBoolean("token_request", true) }
         }) }
-        binding.btnSend.setOnClickListener { showDialog(this, SendDialog().apply {
-            arguments = Bundle().apply { putBoolean("token_send", true) }
-        }) }
+        binding.btnSend.setOnClickListener {
+            try {
+                showDialog(this, SendDialog().apply {
+                    arguments = Bundle().apply { putBoolean("token_send", true) }
+                })
+            } catch (e: ToastException) { e.show() }
+        }
     }
 
     override fun onCreateAdapter() = TokenTransactionsAdapter(this)


### PR DESCRIPTION
This PR fixes the issue on the Android wallet where users are unable to open the receive dialog on watching-only wallets. It should only ever have been the send functionality disabled for such wallets, not the receive functionality too.

This PR also fixes a related problem where the app would crash when trying to open the send dialog from the Token Transactions screen on a watching only wallet.  It should now correctly raise the "This wallet is watching-only" warning.

Closes #2613, closes #2941, closes #2934, closes #2926, closes #2925, closes #2032