### PR TITLE
build: Fix docker legacy env warning

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub2004
+++ b/contrib/build-linux/appimage/Dockerfile_ub2004
@@ -4,7 +4,7 @@ ARG UBUNTU_MIRROR=http://archive.ubuntu.com/ubuntu/
 ENV UBUNTU_DIST=focal
 
 # This prevents questions during package installations
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8 TZ=America/New_York
 
 # If a package version does not exist anymore you can use "apt-cache policy <pkg>" to display the available versions


### PR DESCRIPTION
```
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 7)
```

Changed to use the equals sign.