### PR TITLE
keepkey: fix for protobuf versions >= 5

### DIFF
--- a/contrib/deterministic-build/requirements-hw.txt
+++ b/contrib/deterministic-build/requirements-hw.txt
@@ -92,10 +92,10 @@ hidapi==0.14.0 \
     --hash=sha256:ed112c9ba0adf41d7e04bf5389dc150ada4d94a6ef1cb56c325d5aed1e4e07d2 \
     --hash=sha256:f575381efa788e1a894c68439644817b152b8a68ead643e42c23ba28eeedc33b \
     --hash=sha256:f68bbf88805553911e7e5a9b91136c96a54042b6e3d82d39d733d2edb46ff9a6
-keepkey==6.3.1 \
-    --hash=sha256:88e2b5291c85c8e8567732f675697b88241082884aa1aba32257f35ee722fc09 \
-    --hash=sha256:cef1e862e195ece3e42640a0f57d15a63086fd1dedc8b5ddfcbc9c2657f0bb1e \
-    --hash=sha256:f369d640c65fec7fd8e72546304cdc768c04224a6b9b00a19dc2cd06fa9d2a6b
+# keepkey with a patch to work with newer protobuf versions.
+# See https://github.com/keepkey/python-keepkey/issues/146
+https://github.com/zquestz/python-keepkey/archive/3efc32c5c2c02d1a52663c0fd97bc656227affdd.tar.gz \
+    --hash=sha256:727232eecf10a1afb2b1bc693b023c0d73faf53806020a4211d52fb9ae9c2682
 libusb1==1.9.1 \
     --hash=sha256:16203d77a1f623b6f8f4e6c9d6bac79c1293b8d3e11de5f2f3c30d91380ae478 \
     --hash=sha256:3905e907156f0a3fade75ddf82a777a6a901b245aa14500429275d221a1606c2 \

--- a/contrib/requirements/requirements-hw.txt
+++ b/contrib/requirements/requirements-hw.txt
@@ -1,6 +1,6 @@
 Cython>=0.27,<3
 trezor[hidapi]>=0.13.9
-keepkey>=6.1
+keepkey @ https://github.com/zquestz/python-keepkey/archive/3efc32c5c2c02d1a52663c0fd97bc656227affdd.tar.gz
 btchip-python
 hidapi
 protobuf


### PR DESCRIPTION
The keepkey Python library stopped working with protobuf >= 5. This updates the dependency to a fixed version.

See https://github.com/keepkey/python-keepkey/issues/146

Fixes #2995