### PR TITLE
Improve CLI help

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -282,7 +282,9 @@ class Commands:
 
     @command('wp')
     def password(self, password=None, new_password=None):
-        """Change wallet password. """
+        """Change wallet password.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         b = self.wallet.storage.is_encrypted()
         self.wallet.update_password(password, new_password, b)
         self.wallet.storage.write()
@@ -420,7 +422,9 @@ class Commands:
 
     @command('wp')
     def signtransaction(self, tx, privkey=None, password=None):
-        """Sign a transaction. The wallet keys will be used unless a private key is provided."""
+        """Sign a transaction. The wallet keys will be used unless a private key is provided.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         tx = Transaction(tx, sign_schnorr=self.wallet and self.wallet.is_schnorr_enabled())
         if privkey:
             txin_type, privkey2, compressed = bitcoin.deserialize_privkey(privkey)
@@ -478,7 +482,9 @@ class Commands:
 
     @command('wp')
     def getprivatekeys(self, address, password=None):
-        """Get private keys of addresses. You may pass a single wallet address, or a list of wallet addresses."""
+        """Get private keys of addresses. You may pass a single wallet address, or a list of wallet addresses.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         def get_pk(address):
             address = Address.from_string(address)
             return self.wallet.export_private_key(address, password)
@@ -556,18 +562,24 @@ class Commands:
 
     @command('wp')
     def getmasterprivate(self, password=None):
-        """Get master private key. Return your wallet\'s master private key"""
+        """Get master private key. Return your wallet\'s master private key.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         return str(self.wallet.keystore.get_master_private_key(password))
 
     @command('wp')
     def getseed(self, password=None):
-        """Get seed phrase. Print the generation seed of your wallet."""
+        """Get seed phrase. Print the generation seed of your wallet.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         s = self.wallet.get_seed(password)
         return s
 
     @command('wp')
     def importprivkey(self, privkey, password=None):
-        """Import a private key."""
+        """Import a private key.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         if not self.wallet.can_import_privkey():
             return "Error: This type of wallet cannot import private keys. Try to create a new wallet with that key."
         try:
@@ -600,8 +612,9 @@ class Commands:
 
     @command('wp')
     def signmessage(self, address, message, password=None):
-        """Sign a message with a key. Use quotes if your message contains
-        whitespaces"""
+        """Sign a message with a key. Use quotes if your message contains whitespaces.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         address = Address.from_string(address)
         sig = self.wallet.sign_message(address, message, password)
         return base64.b64encode(sig).decode('ascii')
@@ -679,7 +692,9 @@ class Commands:
     @command('wp')
     def payto(self, destination, amount, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None,
               op_return=None, op_return_raw=None, addtransaction=False):
-        """Create a transaction. """
+        """Create a transaction.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         tx_fee = satoshis(fee)
         domain = from_addr.split(',') if from_addr else None
         tx = self._mktx([(destination, amount)], tx_fee, feerate, change_addr, domain, nocheck, unsigned, password, locktime, op_return, op_return_raw, addtransaction=addtransaction)
@@ -687,7 +702,9 @@ class Commands:
 
     @command('wp')
     def paytomany(self, outputs, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, password=None, locktime=None, addtransaction=False):
-        """Create a multi-output transaction. """
+        """Create a multi-output transaction.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         tx_fee = satoshis(fee)
         domain = from_addr.split(',') if from_addr else None
         tx = self._mktx(outputs, tx_fee, feerate, change_addr, domain, nocheck, unsigned, password, locktime, addtransaction=addtransaction)
@@ -835,7 +852,9 @@ class Commands:
 
     @command('wp')
     def decrypt(self, pubkey, encrypted, password=None):
-        """Decrypt a message encrypted with a public key."""
+        """Decrypt a message encrypted with a public key.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         if not isinstance(pubkey, str) or not isinstance(encrypted, str):
             raise ValueError("pubkey and encrypted text must both be strings")
         res = self.wallet.decrypt_message(pubkey, encrypted, password)
@@ -922,7 +941,9 @@ class Commands:
 
     @command('wp')
     def signrequest(self, address, password=None):
-        "Sign payment request with an OpenAlias"
+        """Sign payment request with an OpenAlias.
+        If you want to be prompted for an argument, type '?' or ':' (concealed)
+        """
         alias = self.config.get('alias')
         if not alias:
             raise ValueError('No alias in your configuration')
@@ -1029,7 +1050,7 @@ command_options = {
     'password':    ("-W", "Password"),
     'payment_url': (None, 'Optional URL where you would like users to POST the BIP70 Payment message'),
     'pending':     (None, "Show only pending requests."),
-    'privkey':     (None, "Private key. Set to '?' to get a prompt."),
+    'privkey':     (None, "Private key"),
     'receiving':   (None, "Show only receiving addresses"),
     'seed_type':   (None, "The type of seed to create, currently: 'electrum' and 'bip39' is supported. Default 'bip39'."),
     'show_addresses': (None, "Show input and output addresses"),
@@ -1074,6 +1095,10 @@ config_variables = {
         'url_rewrite': 'Parameters passed to str.replace(), in order to create the r= part of bitcoincash: URIs. Example: \"(\'file:///var/www/\',\'https://electron-cash.org/\')\"',
     }
 }
+
+class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    def _split_lines(self, text, width):
+        return [line.strip() for line in text.splitlines() if line.strip()]
 
 def set_default_subparser(self, name, args=None):
     """see http://stackoverflow.com/questions/5176691/argparse-how-to-specify-a-default-subcommand"""
@@ -1126,7 +1151,6 @@ def subparser_call(self, parser, namespace, values, option_string=None):
 
 argparse._SubParsersAction.__call__ = subparser_call
 
-
 def add_network_options(parser):
     parser.add_argument("-1", "--oneserver", action="store_true", dest="oneserver", default=False, help="connect to one server only")
     parser.add_argument("-s", "--server", dest="server", default=None, help="set server host:port:protocol, where protocol is either t (tcp) or s (ssl)")
@@ -1151,8 +1175,12 @@ def add_global_options(parser):
 
 def get_parser():
     # create main parser
-    parser = argparse.ArgumentParser(
-        epilog="Run 'electron-cash help <command>' to see the help for a command")
+    parser = argparse.ArgumentParser(formatter_class=CustomHelpFormatter,
+        epilog="Special arguments:\n"
+               "  ?  read argument from prompt (? may need escaped in some environments)\n"
+               "  :  read argument from prompt (non-echoing)\n"
+               "  -  read argument from stdin\n\n"
+               "Run 'electron-cash help <command>' to see the help for a command")
     add_global_options(parser)
     subparsers = parser.add_subparsers(dest='cmd', metavar='<command>')
     # gui


### PR DESCRIPTION
This change adds the special arguments to `electron-cash help` and also attempts to mention them in the help of each command that accepts `--privkey` or `--password`.  Line breaks could be added to the command descriptions as well, but the easy way to do this would involve reducing the help comments of commands to long single lines, which may be undesirable.