### PR TITLE
Add token switches for CLI address commands

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -383,8 +383,8 @@ class Commands:
 
     @command('n')
     def getaddressunspent(self, address, include_tokens=False, tokens_only=False):
-        """Returns the UTXO list of any address. Note: This
-        is a walletless server query, results are not checked by SPV.
+        """Returns the UTXO list of any address. Note: This is a walletless server
+        query that excludes token UTXOs by default, results are not checked by SPV.
         """
         sh = Address.from_string(address).to_scripthash_hex()
         token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else None
@@ -534,8 +534,8 @@ class Commands:
 
     @command('n')
     def getaddressbalance(self, address, include_tokens=False, tokens_only=False):
-        """Return the balance of any address. Note: This is a walletless
-        server query, results are not checked by SPV.
+        """Return the balance of any address. Note: This is a walletless server
+        query that excludes token dust by default, results are not checked by SPV.
         """
         sh = Address.from_string(address).to_scripthash_hex()
         token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else None

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -387,11 +387,8 @@ class Commands:
         query that excludes token UTXOs by default, results are not checked by SPV.
         """
         sh = Address.from_string(address).to_scripthash_hex()
-        token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else None
-        params = [sh]
-        if token_filter:
-            params.append(token_filter)
-        return self.network.synchronous_get(('blockchain.scripthash.listunspent', params))
+        token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else "exclude_tokens"
+        return self.network.synchronous_get(('blockchain.scripthash.listunspent', [sh, token_filter]))
 
     @command('')
     def serialize(self, jsontx):
@@ -538,11 +535,8 @@ class Commands:
         query that excludes token dust by default, results are not checked by SPV.
         """
         sh = Address.from_string(address).to_scripthash_hex()
-        token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else None
-        params = [sh]
-        if token_filter:
-            params.append(token_filter)
-        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', params))
+        token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else "exclude_tokens"
+        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', [sh, token_filter]))
         out["confirmed"] =  str(PyDecimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(PyDecimal(out["unconfirmed"])/COIN)
         return out

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -382,20 +382,18 @@ class Commands:
         return l
 
     @command('n')
-    def getaddresstokens(self, address):
-        """Returns the token UTXO list of any address. Note: This
+    def getaddressunspent(self, address, include_tokens=False, tokens_only=False):
+        """Returns the UTXO list of any address. Note: This
         is a walletless server query, results are not checked by SPV.
+        Use --include_tokens to include token UTXOs
+        Use --tokens_only to exclude non-token UTXOs
         """
         sh = Address.from_string(address).to_scripthash_hex()
-        return self.network.synchronous_get(('blockchain.scripthash.listunspent', [sh, "include_tokens"]))
-
-    @command('n')
-    def getaddressunspent(self, address):
-        """Returns the non-token UTXO list of any address. Note: This
-        is a walletless server query, results are not checked by SPV.
-        """
-        sh = Address.from_string(address).to_scripthash_hex()
-        return self.network.synchronous_get(('blockchain.scripthash.listunspent', [sh]))
+        token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else None
+        params = [sh]
+        if token_filter:
+            params.append(token_filter)
+        return self.network.synchronous_get(('blockchain.scripthash.listunspent', params))
 
     @command('')
     def serialize(self, jsontx):
@@ -537,12 +535,18 @@ class Commands:
         return out
 
     @command('n')
-    def getaddressbalance(self, address):
+    def getaddressbalance(self, address, include_tokens=False, tokens_only=False):
         """Return the balance of any address. Note: This is a walletless
         server query, results are not checked by SPV.
+        Use --include_tokens to include "dust" from token UTXOs.
+        Use --tokens_only to exclude BCH from non-token UTXOs.
         """
         sh = Address.from_string(address).to_scripthash_hex()
-        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', [sh]))
+        token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else None
+        params = [sh]
+        if token_filter:
+            params.append(token_filter)
+        out = self.network.synchronous_get(('blockchain.scripthash.get_balance', params))
         out["confirmed"] =  str(PyDecimal(out["confirmed"])/COIN)
         out["unconfirmed"] =  str(PyDecimal(out["unconfirmed"])/COIN)
         return out
@@ -1045,6 +1049,7 @@ command_options = {
     'frozen':      (None, "Show only frozen addresses"),
     'funded':      (None, "Show only funded addresses"),
     'imax':        (None, "Maximum number of inputs"),
+    'include_tokens': (None, "Include CashToken-containing UTXOs"),
     'index_url':   (None, 'Override the URL where you would like users to be shown the BIP70 Payment Request'),
     'labels':      ("-l", "Show the labels of listed addresses"),
     'language':    ("-L", "Default language for wordlist"),
@@ -1068,6 +1073,7 @@ command_options = {
     'show_fiat':   (None, "Show fiat value of transactions"),
     'timeout':     (None, "Timeout in seconds to wait for the overall operation to complete. Defaults to 30.0."),
     'token_request': (None, "Cashtokens payment request"),
+    'tokens_only': (None, "Return only CashToken-containing UTXOs"),
     'unsigned':    ("-u", "Do not sign transaction"),
     'unused':      (None, "Show only unused addresses"),
     'use_net':     (None, "Go out to network for accurate fiat value and/or fee calculations and/or token meta-data for history. If not specified only the wallet's cache is used which may lead to inaccurate/missing fees and/or FX rates and/or token meta-data."),

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -385,8 +385,6 @@ class Commands:
     def getaddressunspent(self, address, include_tokens=False, tokens_only=False):
         """Returns the UTXO list of any address. Note: This
         is a walletless server query, results are not checked by SPV.
-        Use --include_tokens to include token UTXOs
-        Use --tokens_only to exclude non-token UTXOs
         """
         sh = Address.from_string(address).to_scripthash_hex()
         token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else None
@@ -538,8 +536,6 @@ class Commands:
     def getaddressbalance(self, address, include_tokens=False, tokens_only=False):
         """Return the balance of any address. Note: This is a walletless
         server query, results are not checked by SPV.
-        Use --include_tokens to include "dust" from token UTXOs.
-        Use --tokens_only to exclude BCH from non-token UTXOs.
         """
         sh = Address.from_string(address).to_scripthash_hex()
         token_filter = "tokens_only" if tokens_only else "include_tokens" if include_tokens else None

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -382,8 +382,16 @@ class Commands:
         return l
 
     @command('n')
+    def getaddresstokens(self, address):
+        """Returns the token UTXO list of any address. Note: This
+        is a walletless server query, results are not checked by SPV.
+        """
+        sh = Address.from_string(address).to_scripthash_hex()
+        return self.network.synchronous_get(('blockchain.scripthash.listunspent', [sh, "include_tokens"]))
+
+    @command('n')
     def getaddressunspent(self, address):
-        """Returns the UTXO list of any address. Note: This
+        """Returns the non-token UTXO list of any address. Note: This
         is a walletless server query, results are not checked by SPV.
         """
         sh = Address.from_string(address).to_scripthash_hex()


### PR DESCRIPTION
I think this is pretty self explanatory, but see https://electrum-cash-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain.scripthash.listunspent for reference.  Tested with cash address and token address.