### PR TITLE
fix: swap bytes for Ledger product IDs

### DIFF
--- a/electroncash_plugins/ledger/ledger.py
+++ b/electroncash_plugins/ledger/ledger.py
@@ -568,15 +568,17 @@ class LedgerPlugin(HW_PluginBase):
                    (0x2c97, 0x0000), # Blue
                    (0x2c97, 0x0011), # Blue app-bitcoin >= 1.5.1
                    (0x2c97, 0x0015), # Blue app-bitcoin >= 1.5.1
-                   (0x2c97, 0x0001), # Nano-S
+                   (0x2c97, 0x1000), # Nano-S
                    (0x2c97, 0x1011), # Nano-S app-bitcoin >= 1.5.1
                    (0x2c97, 0x1015), # Nano-S app-bitcoin >= 1.5.1
-                   (0x2c97, 0x0004), # Nano-X
+                   (0x2c97, 0x4000), # Nano-X
                    (0x2c97, 0x4011), # Nano-X app-bitcoin >= 1.5.1
                    (0x2c97, 0x4015), # Nano-X app-bitcoin >= 1.5.1
-                   (0x2c97, 0x0005), # Nano-S-Plus
+                   (0x2c97, 0x5000), # Nano-S-Plus
                    (0x2c97, 0x5011), # Nano-S-Plus app-bitcoin >= 1.5.1
                    (0x2c97, 0x5015), # Nano-S-Plus app-bitcoin >= 1.5.1
+                   (0x2c97, 0x6000),  # Stax
+                   (0x2c97, 0x7000),  # Flex
                  ]
 
     def __init__(self, parent, config, name):


### PR DESCRIPTION
- closes #3081 

Debugging shows that `hid.enumerate` returns a different endian-ness than what is listed in the Ledger `DEVICE_IDS` for only the `product_id`.
Swapping the endianness works and I can confirm it's working for Ledger Flex on the latest firmware and Ledger app version `2.4.9`.

I am unable to test the other models, for the full flow, but my Ledger Nano S+ shows the same endianness issue.