### PR TITLE
Add `libsecp256k1.so` as another secp256k1 fallback

### DIFF
--- a/electroncash/secp256k1.py
+++ b/electroncash/secp256k1.py
@@ -53,7 +53,8 @@ def _load_library():
         library_paths =  (sys.executable,)
     else:
         library_paths = (os.path.join(os.path.dirname(__file__), 'libsecp256k1.so.0'),  # on linux we install it alongside the python scripts.
-                         'libsecp256k1.so.0')  # fall back to system lib, if any
+                         'libsecp256k1.so.0', # fall back to system lib, if any
+                         'libsecp256k1.so') # fall back to any version of it
 
     secp256k1 = None
     secp256k1_exceptions = {}


### PR DESCRIPTION
The filename is that on Alpine, FreeBSD and Archlinux. I don't have a Debian machine to check. But on Ubuntu and Debian it seems to have a `.2` prefix. Note that on Alpine and FreeBSD it also have the prefix but `libsecp256k1.so` exists as a symlink.