### PR TITLE
hw: avoid holding hid_lock during user interaction to prevent deadlock

### DIFF
--- a/electroncash_plugins/digitalbitbox/digitalbitbox.py
+++ b/electroncash_plugins/digitalbitbox/digitalbitbox.py
@@ -738,8 +738,7 @@ class DigitalBitboxPlugin(HW_PluginBase):
     def get_client(self, keystore, force_pair=True):
         devmgr = self.device_manager()
         handler = keystore.handler
-        with devmgr.hid_lock:
-            client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
+        client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
         if client is not None:
             client.check_device_dialog()
         return client

--- a/electroncash_plugins/keepkey/keepkey.py
+++ b/electroncash_plugins/keepkey/keepkey.py
@@ -190,8 +190,7 @@ class KeepKeyPlugin(HW_PluginBase):
     def get_client(self, keystore, force_pair=True):
         devmgr = self.device_manager()
         handler = keystore.handler
-        with devmgr.hid_lock:
-            client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
+        client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
         # returns the client for a given keystore. can use xpub
         if client:
             client.used()

--- a/electroncash_plugins/ledger/ledger.py
+++ b/electroncash_plugins/ledger/ledger.py
@@ -632,8 +632,7 @@ class LedgerPlugin(HW_PluginBase):
         #assert self.main_thread != threading.current_thread()
         devmgr = self.device_manager()
         handler = keystore.handler
-        with devmgr.hid_lock:
-            client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
+        client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
         # returns the client for a given keystore. can use xpub
         #if client:
         #    client.used()

--- a/electroncash_plugins/satochip/satochip.py
+++ b/electroncash_plugins/satochip/satochip.py
@@ -703,8 +703,7 @@ class SatochipPlugin(HW_PluginBase):
         # All client interaction should not be in the main GUI thread
         devmgr = self.device_manager()
         handler = keystore.handler
-        with devmgr.hid_lock:
-            client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
+        client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
         # returns the client for a given keystore. can use xpub
         #if client:
         #    client.used()

--- a/electroncash_plugins/trezor/trezor.py
+++ b/electroncash_plugins/trezor/trezor.py
@@ -190,8 +190,7 @@ class TrezorPlugin(HW_PluginBase):
     def get_client(self, keystore, force_pair=True):
         devmgr = self.device_manager()
         handler = keystore.handler
-        with devmgr.hid_lock:
-            client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
+        client = devmgr.client_for_keystore(self, handler, keystore, force_pair)
         # returns the client for a given keystore. can use xpub
         if client:
             client.used()


### PR DESCRIPTION
Remove `devmgr.hid_lock` usage around `client_for_keystore()` in Ledger, Trezor, KeepKey, DigitalBitbox, and Satochip plugins. This fixes a UI deadlock when a hardware wallet prompt is open and another wallet is opened. `hid_lock` is already held in `DeviceMgr` internally so not needed in the plugins.