### PR TITLE
New domain bchexplorer.cash

### DIFF
--- a/electroncash/web.py
+++ b/electroncash/web.py
@@ -65,7 +65,7 @@ mainnet_block_explorers = {
     'Loping.net': ('https://bch.loping.net',
                    Address.FMT_CASHADDR,
                    {'tx': 'tx', 'addr': 'address', 'block': 'block-height'}),
-    "Melroy's BCH Explorer": ('https://explorer.melroy.org',
+    "BCH Explorer": ('https://bchexplorer.cash',
                               Address.FMT_CASHADDR,
                               {'tx': 'tx', 'addr': 'address', 'block': 'block'}),
     '3XPL': ('https://3xpl.com/bitcoin-cash',


### PR DESCRIPTION
Its official now.. I registered a dedicated domain: https://bchexplorer.cash to make it more official.. Instead of using a sub-domain.

Also coming soon v3 of the explorer (not yet live): https://gitlab.melroy.org/bitcoincash/bitcoin-cash-explorer