### PR TITLE
Remove is_beyond_limit check from AddressList to fix O(N²) hang

### DIFF
--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -242,8 +242,6 @@ class AddressList(MyTreeWidget, PrintError):
                 if self.wallet.is_frozen(address):
                     address_item.setBackground(0, ColorScheme.BLUE.as_color(True))
                     address_item.setToolTip(0, _("Address is frozen, right-click to unfreeze"))
-                if self.wallet.is_beyond_limit(address, is_change):
-                    address_item.setBackground(0, ColorScheme.RED.as_color(True))
                 if is_change and self.wallet.is_retired_change_addr(address):
                     address_item.setForeground(0, ColorScheme.GRAY.as_color())
                     old_tt = address_item.toolTip(0)


### PR DESCRIPTION
AddressList.on_update() calls wallet.is_beyond_limit(address, is_change) for every address. That method does addr_list.index(address) which is O(N) per call, making the overall loop O(N²). On a wallet with 137,776 addresses, this single check causes a ~12 second GUI freeze every time the address list is rebuilt.

The check only colors rows red for addresses beyond the gap limit — a minor visual indicator. Removing it eliminates the O(N²) cost entirely.