### PR TITLE
wine: support both 32-bit and 64-bit Windows builds

### DIFF
--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -44,7 +44,7 @@ binaries += [('C:/tmp/tor.exe', '.')]
 # Workaround for "Retro Look":
 binaries += [b for b in collect_dynamic_libs('PyQt5') if 'qwindowsvista' in b[0]]
 
-binaries += [('C:/python*/Lib/site-packages/smartcard/scard/_scard.cp*-win32.pyd', '.')]  # Satochip
+binaries += [('C:/python*/Lib/site-packages/smartcard/scard/_scard.*.pyd', '.')]  # Satochip
 
 datas = [
     (home+'electroncash/currencies.json', 'electroncash'),

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -67,7 +67,7 @@ ARG USER_ID
 ARG GROUP_ID
 
 ENV HOME=/homedir
-ENV WINEARCH=win32
+ENV WINEARCH=win64
 ENV WINEPREFIX=${HOME}/wine
 ENV WINEDEBUG=-all
 
@@ -104,18 +104,18 @@ RUN wget https://aka.ms/vs/16/release/installer -O /tmp/vs_installer.opc && \
         --add "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" \
         --add "Microsoft.VisualStudio.Component.Windows10SDK.19041" && \
     # vswhere.exe needs to be installed in this path so setuptools can detect the VS installation
-    mkdir "${WINEPREFIX}"/"drive_c/Program Files/Microsoft Visual Studio/Installer" && \
-    mv opc/Contents/vswhere.exe "${WINEPREFIX}"/"drive_c/Program Files/Microsoft Visual Studio/Installer" && \
+    mkdir "${WINEPREFIX}"/"drive_c/Program Files (x86)/Microsoft Visual Studio/Installer" && \
+    mv opc/Contents/vswhere.exe "${WINEPREFIX}"/"drive_c/Program Files (x86)/Microsoft Visual Studio/Installer" && \
     rm -rf opc && wineserver -w
 
 #RUN wine "${WINEPREFIX}"/"drive_c/windows/Microsoft.NET/Framework/v4.0.30319/ngen.exe" executequeueditems && \
 #    wineserver -w
 
 # Patch to make vcvarsall.bat work
-# "C:\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86 && set
+# "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86 && set
 # python -c "from setuptools import msvc; print(msvc.msvc14_get_vc_env('x86'))"
 # Caused by wrong delayed expansion in Wine, see https://bugs.winehq.org/show_bug.cgi?id=38289
-RUN sed -i -e 's/!result:~0,3!/10./g' "${WINEPREFIX}"/"drive_c/Program Files/Microsoft Visual Studio/2019/BuildTools/Common7/Tools/vsdevcmd/core/winsdk.bat"
+RUN sed -i -e 's/!result:~0,3!/10./g' "${WINEPREFIX}"/"drive_c/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/Common7/Tools/vsdevcmd/core/winsdk.bat"
 
 # Clean up some left overs only needed for the Visual Studio installer
 USER 0:0

--- a/contrib/build-wine/docker/wrapper_install.bat
+++ b/contrib/build-wine/docker/wrapper_install.bat
@@ -1,7 +1,7 @@
 @echo off
 
 set VCYEAR=2019
-set VCDIR=c:\Program Files\Microsoft Visual Studio\%VCYEAR%\BuildTools\VC
+set VCDIR=c:\Program Files (x86)\Microsoft Visual Studio\%VCYEAR%\BuildTools\VC
 
 call "%VCDIR%\Auxiliary\Build\vcvarsall.bat" x86
 

--- a/contrib/build-wine/electron-cash.nsi
+++ b/contrib/build-wine/electron-cash.nsi
@@ -29,7 +29,11 @@
   OutFile "dist/${INTERNAL_NAME}-setup.exe"
 
   ;Default installation folder
-  InstallDir "$PROGRAMFILES\${PRODUCT_NAME}"
+  !if "${GCC_TRIPLET_HOST_ARCH}" == "x86_64"
+    InstallDir "$PROGRAMFILES64\${PRODUCT_NAME}"
+  !else
+    InstallDir "$PROGRAMFILES\${PRODUCT_NAME}"
+  !endif
 
   ;Get installation folder from registry if available
   InstallDirRegKey ${INSTDIR_REG_ROOT} "Software\${PRODUCT_NAME}" ""
@@ -105,6 +109,12 @@
 ;--------------------------------
 ;Functions
 
+!macro SetRegView64
+  !if "${GCC_TRIPLET_HOST_ARCH}" == "x86_64"
+    SetRegView 64 ; Use the 64-bit registry view
+  !endif
+!macroend
+
 !macro CreateEnsureNotRunning prefix operation
 
 Function ${prefix}EnsureNotRunning
@@ -164,6 +174,7 @@ Function .onInit
 FunctionEnd
 
 Section
+  !insertmacro SetRegView64
   SetOutPath $INSTDIR ; side-effect is it creates dir if not exist
 
   !insertmacro UNINSTALL.LOG_OPEN_INSTALL
@@ -236,6 +247,8 @@ SectionEnd
 ;Uninstaller Section
 
 Section "Uninstall"
+  !insertmacro SetRegView64
+
   !insertmacro UNINSTALL.LOG_UNINSTALL "$INSTDIR"
 
   Delete "$DESKTOP\${PRODUCT_NAME}.lnk"

--- a/contrib/make_openssl
+++ b/contrib/make_openssl
@@ -32,7 +32,12 @@ if ! [ -d dist ] ; then
                 ./Configure darwin64-$(uname -m)-cc --prefix="$here/$pkgname/dist" $CONFIG_OPTIONS
                 ;;
             wine)
-                ./Configure --cross-compile-prefix=${GCC_TRIPLET_HOST}- mingw --prefix="$here/$pkgname/dist" $CONFIG_OPTIONS
+                case "${GCC_TRIPLET_HOST_ARCH:-${GCC_TRIPLET_HOST%%-*}}" in
+                    x86_64) OPENSSL_TARGET="mingw64" ;;
+                    i686)   OPENSSL_TARGET="mingw" ;;
+                    *)      fail "Unknown architecture for OpenSSL: $GCC_TRIPLET_HOST" ;;
+                esac
+                ./Configure --cross-compile-prefix="$GCC_TRIPLET_HOST"- $OPENSSL_TARGET --prefix="$here/$pkgname/dist" $CONFIG_OPTIONS
                 ;;
         esac
     ) || fail "Could not configure $pkgname. Please make sure you have a C compiler installed and try again."


### PR DESCRIPTION
- Make `GCC_TRIPLET_HOST` configurable from environment
- Map architecture to Python installer paths (`amd64`/`win32`)
- Add SHA256 checksums for both 32-bit and 64-bit Python MSIs
- Configure OpenSSL target (`mingw64`/`mingw`) based on architecture
- Include architecture in output filenames (e.g. `Electron-Cash-4.2.2-x86_64.exe`)

The 64-bit Wine install with Visual Studio can cross-compile to both
x86 and x64 targets, so we only need a single build container.

I tested:

- All `ctypes` usages directly in the app.
- tor
- Ledger, Keepkey plugins
- zbar and zxing-cpp