### PR TITLE
Fix repeated device enumeration in hardware wallet wizard

### DIFF
--- a/electroncash/base_wizard.py
+++ b/electroncash/base_wizard.py
@@ -222,13 +222,14 @@ class BaseWizard(util.PrintError):
         title = _('Hardware Keystore')
         # check available plugins
         support = self.plugins.get_hardware_support()
-        # scan devices
+        # scan devices once upfront (not per-plugin) to avoid repeated enumeration
         devices = []
         devmgr = self.plugins.device_manager
+        scanned = devmgr.scan_devices()
         for name, description, plugin in support:
             try:
                 # FIXME: side-effect: unpaired_device_info sets client.handler
-                u = devmgr.unpaired_device_infos(None, plugin)
+                u = devmgr.unpaired_device_infos(None, plugin, devices=scanned)
             except:
                 devmgr.print_exception("error", name)
                 continue


### PR DESCRIPTION
choose_hw_device() called unpaired_device_infos() per plugin, and each call triggered a full scan_devices() across all plugins — creating N² enumeration calls. Now scan_devices() is called once before the loop and the cached result is passed via the existing devices= parameter.