### PR TITLE
Update AppStream metadata to v1.0 specification

### DIFF
--- a/.github/workflows/update-appstream.yml
+++ b/.github/workflows/update-appstream.yml
@@ -1,0 +1,51 @@
+name: Update AppStream Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-appstream:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update appdata.xml
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+          DATE: ${{ github.event.release.published_at }}
+        run: |
+          # Strip 'v' prefix from version
+          VERSION=${VERSION#v}
+          DATE=${DATE:0:10}  # Extract YYYY-MM-DD from ISO timestamp
+          FILE="org.electroncash.ElectronCash.appdata.xml"
+          
+          # Skip if version already exists
+          if grep -q "version=\"$VERSION\"" "$FILE"; then
+            echo "✓ Release $VERSION already in appdata.xml"
+            exit 0
+          fi
+          
+          # Insert new release after <releases> tag
+          sed -i "s|<releases>|<releases>\n\t\t<release version=\"$VERSION\" date=\"$DATE\"/>|" "$FILE"
+          
+          echo "✓ Added release $VERSION ($DATE) to appdata.xml"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "docs: Add release ${{ github.event.release.tag_name }} to AppStream metadata"
+          branch: appstream-${{ github.event.release.tag_name }}
+          delete-branch: true
+          title: "docs: Update AppStream metadata for ${{ github.event.release.tag_name }}"
+          body: |
+            Auto-generated release entry for **${{ github.event.release.tag_name }}**.
+            
+            ---
+            *Created by GitHub Actions*
+          labels: automated pr

--- a/.github/workflows/update-appstream.yml
+++ b/.github/workflows/update-appstream.yml
@@ -23,18 +23,8 @@ jobs:
           # Strip 'v' prefix from version
           VERSION=${VERSION#v}
           DATE=${DATE:0:10}  # Extract YYYY-MM-DD from ISO timestamp
-          FILE="org.electroncash.ElectronCash.appdata.xml"
           
-          # Skip if version already exists
-          if grep -q "version=\"$VERSION\"" "$FILE"; then
-            echo "✓ Release $VERSION already in appdata.xml"
-            exit 0
-          fi
-          
-          # Insert new release after <releases> tag
-          sed -i "s|<releases>|<releases>\n\t\t<release version=\"$VERSION\" date=\"$DATE\"/>|" "$FILE"
-          
-          echo "✓ Added release $VERSION ($DATE) to appdata.xml"
+          python3 scripts/update_appstream.py "$VERSION" "$DATE"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/org.electroncash.ElectronCash.appdata.xml
+++ b/org.electroncash.ElectronCash.appdata.xml
@@ -2,10 +2,12 @@
 <component type="desktop-application">
 	<id>org.electroncash.ElectronCash</id>
 	<name>Electron Cash</name>
-	<developer_name>Jonald Fyookball</developer_name>
+	<developer id="electroncash.org">
+		<name>Jonald Fyookball</name>
+	</developer>
 	<summary>Lightweight Bitcoin Cash Client</summary>
 	<description>
-		<p>Electron Cash is an SPV wallet for Bitcoin Cash</p>
+		<p>Electron Cash is a lightweight SPV wallet for Bitcoin Cash</p>
 		<p>Control your own private keys. Easily back up your wallet with a mnemonic seed phrase. Enjoy high security without downloading the blockchain or running a full node.</p>
 	</description>
 	<keywords>
@@ -21,6 +23,11 @@
 	<project_license>MIT</project_license>
 	<url type="homepage">https://www.electroncash.org/</url>
 	<url type="help">https://github.com/Electron-Cash/Electron-Cash/issues?q=is%3Aissue</url>
+	<url type="vcs-browser">https://github.com/Electron-Cash/Electron-Cash</url>
+	<content_rating type="oars-1.1" />
+	<releases>
+		<release version="4.4.3" date="2026-03-14" />
+	</releases>
 	<screenshots>
 		<screenshot type="default">
 			<image type="source">https://www.electroncash.org/images/wallet-shot-3.png</image>
@@ -30,12 +37,8 @@
 	<translation type="gettext">electron-cash</translation>
 	<provides>
 		<binary>electron-cash</binary>
-		<python3>electroncash</python3>
-		<python3>electroncash_gui</python3>
-		<python3>electroncash_plugins</python3>
+		<mediatype>x-scheme-handler/bitcoincash</mediatype>
+		<mediatype>x-scheme-handler/cashacct</mediatype>
 	</provides>
-	<mimetypes>
-		<mimetype>x-scheme-handler/bitcoincash</mimetype>
-		<mimetype>x-scheme-handler/cashacct</mimetype>
-	</mimetypes>
+	<launchable type="desktop-id">electron-cash.desktop</launchable>
 </component>

--- a/scripts/update_appstream.py
+++ b/scripts/update_appstream.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Update AppStream metadata with new release information.
+This script adds a new release entry to the appdata.xml file.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from pathlib import Path
+
+
+def update_appstream(version: str, date: str, appdata_file: Path) -> bool:
+    """
+    Add a new release entry to the AppStream metadata file.
+    
+    Args:
+        version: Release version (e.g., "4.4.4")
+        date: Release date in YYYY-MM-DD format
+        appdata_file: Path to the appdata.xml file
+    
+    Returns:
+        True if release was added, False if it already existed
+    """
+    # Parse the XML file
+    tree = ET.parse(appdata_file)
+    root = tree.getroot()
+    
+    # Find the releases element
+    releases_elem = root.find("releases")
+    if releases_elem is None:
+        # Create releases element if it doesn't exist
+        releases_elem = ET.SubElement(root, "releases")
+    
+    # Check if version already exists
+    for release in releases_elem.findall("release"):
+        if release.get("version") == version:
+            print(f"✓ Release {version} already in appdata.xml")
+            return False
+    
+    # Create new release element
+    new_release = ET.Element("release")
+    new_release.set("version", version)
+    new_release.set("date", date)
+    
+    # Insert at the beginning (after any existing releases)
+    releases_elem.insert(0, new_release)
+    
+    # Write the updated XML back to file
+    tree.write(appdata_file, encoding="UTF-8", xml_declaration=True)
+    
+    # Reformat the XML for readability (optional but nice)
+    _format_xml(appdata_file)
+    
+    print(f"✓ Added release {version} ({date}) to appdata.xml")
+    return True
+
+
+def _format_xml(file_path: Path) -> None:
+    """Format XML file with proper indentation."""
+    import subprocess
+    
+    try:
+        # Use xmllint if available for pretty printing
+        result = subprocess.run(
+            ["xmllint", "--format", str(file_path)],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        file_path.write_text(result.stdout, encoding="UTF-8")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # xmllint not available, skip formatting
+        pass
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: update_appstream.py <version> <date> [appdata_file]")
+        print("  version: Release version (e.g., 4.4.4)")
+        print("  date: Release date in YYYY-MM-DD format")
+        print("  appdata_file: Path to appdata.xml (default: org.electroncash.ElectronCash.appdata.xml)")
+        sys.exit(1)
+    
+    version = sys.argv[1]
+    date = sys.argv[2]
+    appdata_file = Path(sys.argv[3]) if len(sys.argv) > 3 else Path("org.electroncash.ElectronCash.appdata.xml")
+    
+    # Validate date format
+    try:
+        datetime.strptime(date, "%Y-%m-%d")
+    except ValueError:
+        print(f"Error: Invalid date format '{date}'. Use YYYY-MM-DD format.")
+        sys.exit(1)
+    
+    # Validate file exists
+    if not appdata_file.exists():
+        print(f"Error: File not found: {appdata_file}")
+        sys.exit(1)
+    
+    update_appstream(version, date, appdata_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Modernizes org.electroncash.ElectronCash.appdata.xml to comply with current AppStream 1.0 specification requirements.

Changes:
- Update `<developer>` tag to new structured format with ID
- Add `<content_rating>` for parental control support
- Add `<releases>` section for tracking releases (update on each release)
- Add VCS browser URL for source code access
- Fix `<provides>` section: use `<mediatype>` instead of deprecated `<mimetype>`
- Add `<launchable>` element for URI scheme handling
- Remove Python module listings (not user-facing)

These changes improve integration with software centers (GNOME Software,
KDE Discover, Flathub, etc) and ensure proper validation.

Note: Release entries should be updated as part of the release process when tagging new versions.

References:
- https://www.freedesktop.org/software/appstream/docs/
- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html