### PR TITLE
Headers & SPV: fix CVE-2012-2459 in merkle proof verification

### DIFF
--- a/electroncash/blockchain.py
+++ b/electroncash/blockchain.py
@@ -201,15 +201,47 @@ def verify_proven_chunk(chunk_base_height, chunk_data):
                 raise VerifyError("prev hash mismatch: %s vs %s" % (prev_header_hash, header.get('prev_block_hash')))
         prev_header_hash = this_header_hash
 
-# Copied from electrumx
 def root_from_proof(hash, branch, index):
+    """
+    Compute merkle root from inclusion proof.
+
+    CVE-2012-2459 protection: rejects proofs where a left sibling
+    equals the current hash, which only occurs in forged proofs.
+    Legitimate duplicates from odd-sized tree levels appear as
+    right siblings.
+
+    Args:
+        hash: Leaf hash (bytes)
+        branch: Sibling hashes from leaf to root (list of bytes)
+        index: Zero-based leaf position
+
+    Returns:
+        Computed root (bytes), or None if invalid proof detected.
+
+    Raises:
+        ValueError: If index out of range for branch.
+    """
     hash_func = Hash
     for elt in branch:
-        if index & 1:
+        is_right_child = index & 1
+
+        # CVE-2012-2459 protection: reject left-sibling duplicates.
+        # The duplicate subtree attack exploits merkle tree construction
+        # ambiguity where odd-sized levels duplicate the last node.
+        # An attacker can craft proofs for non-existent leaves by providing
+        # a sibling equal to the current hash. However, legitimate duplicates
+        # only ever appear as right siblings (the last node duplicated to
+        # create a right child). Thus, a left sibling matching the current
+        # hash indicates a forged proof.
+        if is_right_child and elt == hash:
+            return None
+
+        if is_right_child:
             hash = hash_func(elt + hash)
         else:
             hash = hash_func(hash + elt)
         index >>= 1
+
     if index:
         raise ValueError('index out of range for branch')
     return hash

--- a/electroncash/network.py
+++ b/electroncash/network.py
@@ -1775,6 +1775,12 @@ class Network(util.DaemonThread):
         header_hash = Hash(bfh(header))
         byte_branches = [bfh(v)[::-1] for v in merkle_branch]
         proven_merkle_root = blockchain.root_from_proof(header_hash, byte_branches, header_height)
+
+        if proven_merkle_root is None:
+            interface.print_error("CVE-2012-2459 attack detected in checkpoint proof for height {}"
+                                  .format(header_height))
+            return False
+
         if proven_merkle_root != expected_merkle_root:
             interface.print_error("Sent incorrect merkle branch, expected: {}, proved: {}"
                                   .format(networks.net.VERIFICATION_BLOCK_MERKLE_ROOT, proven_merkle_root[::-1].hex()))

--- a/electroncash/verifier.py
+++ b/electroncash/verifier.py
@@ -206,6 +206,11 @@ class SPV(ThreadJob):
             tx_height = merkle['block_height']
             pos = merkle['pos']
             merkle_root = self.hash_merkle_root(merkle['merkle'], tx_hash, pos)
+            if merkle_root is None:
+                self.print_error(f"CVE-2012-2459 attack detected for tx {tx_hash}")
+                self.wallet.verification_failed(tx_hash, self.failure_reasons[4])
+                return
+
         except Exception as e:
             self.print_error(f"exception while verifying tx {tx_hash}: {repr(e)}")
             self.wallet.verification_failed(tx_hash, self.failure_reasons[4])
@@ -240,30 +245,51 @@ class SPV(ThreadJob):
 
     @classmethod
     def hash_merkle_root(cls, merkle_s, target_hash, pos):
+        """
+        Compute merkle root from transaction inclusion proof.
+
+        Security notes:
+
+        CVE-2012-2459 (duplicate subtree attack): Protected by rejecting
+        proofs where a left sibling equals the current hash. Legitimate
+        duplicates from odd-sized tree levels only appear as right siblings.
+
+        CVE-2017-12842 (leaf-node weakness / inner node spoofing): This attack
+        allowed SPV clients to be tricked by crafting a valid 64-byte
+        transaction that could be interpreted as an inner merkle node.
+        Bitcoin Cash is protected against this attack at the protocol level
+        since the November 2018 upgrade enforces minimum 100-byte transaction
+        size, later reduced to 65 bytes in May 2023. Both limits prevent
+        confusion with 64-byte inner merkle nodes.
+        See: https://upgradespecs.bitcoincashnode.org/2018-nov-upgrade/
+             https://upgradespecs.bitcoincashnode.org/2023-05-15-upgrade/
+
+        Args:
+            merkle_s: Sibling hashes as hex strings
+            target_hash: Transaction hash (hex string)
+            pos: Transaction position in block
+
+        Returns:
+            Computed root as hex string, or None if CVE-2012-2459 attack detected.
+
+        Raises:
+            ValueError: If pos out of range for branch.
+        """
         h = hash_decode(target_hash)
+
         for i, item in enumerate(merkle_s):
-            h = Hash(hash_decode(item) + h) if ((pos >> i) & 1) else Hash(h + hash_decode(item))
-            # An attack was once upon a time possible for SPV, before Nov. 2018
-            # which is described here:
-            #
-            # https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-June/016105.html
-            # https://lists.linuxfoundation.org/pipermail/bitcoin-dev/attachments/20180609/9f4f5b1f/attachment-0001.pdf
-            # https://bitcoin.stackexchange.com/questions/76121/how-is-the-leaf-node-weakness-in-merkle-trees-exploitable/76122#76122
-            #
-            # As such, at this point we used to verify the inner node didn't
-            # "look" like a tx using some heuristics (which had a very small
-            # chance of returning false positives, about 1 in quadrillion).
-            #
-            # We no longer need do the "inner node looks like tx" check here,
-            # however, since no such attack has occurred on the BTC or BCH chain
-            # before Nov. 2018. After Nov. 2018 the tx size is now required to
-            # be >= 100 bytes which is larger than the 64 byte size of inner
-            # nodes.  Thus, the check is rendered superfluous as the attack
-            # itself is now no longer even possible after Nov. 2018's hard fork,
-            # and so was removed.
-            #
-            # TL;DR: There used to be some strange check here. It's gone now.
-            # Check git history if you're really curious. :)
+            is_right_child = (pos >> i) & 1
+            sibling = hash_decode(item)
+
+            # CVE-2012-2459 protection: reject left-sibling duplicates
+            if is_right_child and sibling == h:
+                return None
+
+            h = Hash(sibling + h) if is_right_child else Hash(h + sibling)
+
+        if pos >> len(merkle_s):
+            raise ValueError('pos out of range for branch')
+
         return hash_encode(h)
 
     def undo_verifications(self):


### PR DESCRIPTION
Add protection against the duplicate subtree attack in root_from_proof() and hash_merkle_root(). The attack allows a malicious server to construct valid merkle proofs for phantom tree positions by exploiting how odd-sized tree levels duplicate the last node.

The fix rejects proofs where a left sibling equals the current hash, which only occurs in forged proofs. Legitimate duplicates from odd-sized levels only appear as right siblings.

Severity: Low
- Transaction proofs: no balance impact due to txid-based deduplication
- Header proofs: mitigated by known checkpoint height (won't verify headers beyond it) and chunk hash-chain verification

The fix provides defense in depth and enables early detection/blacklisting of malicious servers rather than relying on downstream validation.

Also documents that CVE-2017-12842 (inner node spoofing) is mitigated at the protocol level since the November 2018 upgrade enforces minimum 100-byte transaction size, later reduced to 65 bytes in May 2023. Both limits prevent confusion with 64-byte inner merkle nodes.
See: https://upgradespecs.bitcoincashnode.org/2018-nov-upgrade/
     https://upgradespecs.bitcoincashnode.org/2023-05-15-upgrade/

---

CVE-2012-2459 Explanation

Bitcoin's Merkle tree duplicates odd nodes to balance the tree. An attacker can exploit this by constructing a tree where a duplicated subtree is treated as containing real leaves, allowing forged proofs for phantom leaf positions.

Example with 11 real leaves and forged 16-leaf claim:

Real tree (11 leaves):

                          **root**
                  __________/  \_________
                 /                       \
                14                        c       Height 3
            _ /   \ _                    / \
          /           \                 /   \
         6             13              b     b'   Height 2
       /    \        /    \         /     \
      2      5      9      12      17      a      Height 1
     / \    / \    / \    /  \    /  \    /  \
    0   1  3   4  7   8  10  11  15  16  18  18'  Height 0
    --------------------------------------------------------
    0   1  2   3  4   5   6   7   8   9  10       Leaf index

    Nodes marked with ' are duplicates to balance the tree.

Forged tree (attacker claims 16 leaves):

                          **root**
                  __________/  \________________
                 /                              \
                14                              c                   Height 3
            _ /   \ _                    _____/   \_____
          /           \                 /               \
         6             13              b                 b'         Height 2
       /    \        /    \         /     \           /     \
      2      5      9      12      17      a        17'      a'     Height 1
     / \    / \    / \    /  \    /  \    /  \     /  \     /  \
    0   1  3   4  7   8  10  11  15  16  18  18'  15' 16'  18' 18'  Height 0
    --------------------------------------------------------------------------
    0   1  2   3  4   5   6   7   8   9  10  11!  12! 13!  14! 15!  Leaf index

    Nodes with ! are phantom leaves. The attacker duplicated the entire
    subtree under 'b' to create fake leaves 11-15.

The attack works because:
  - Real proof for leaf 10:   [18', 17 , b', 14] with b' as RIGHT sibling
  - Forged proof for leaf 14: [18', 17', b , 14] with b as LEFT sibling

The CVE guard detects this: in forged proofs, a duplicate will appear as a LEFT sibling (sibling == current when index bit is 1). Legitimate duplicates for balancing only appear as RIGHT siblings.