### PR TITLE
spv: reduce chunk size for historical simple header verification (SHV)

### DIFF
--- a/electroncash/network.py
+++ b/electroncash/network.py
@@ -231,6 +231,8 @@ class Network(util.DaemonThread):
 
     tor_controller: TorController = None
 
+    SHV_CHUNK_SIZE = 26  # Simple Header Verification (SHV): we request this much headers for historical transactions SPV verification
+
     def __init__(self, config=None):
         if config is None:
             config = {}  # Do not use mutables as default values!
@@ -1173,8 +1175,8 @@ class Network(util.DaemonThread):
         self.requested_chunks.add(chunk_index)
 
         interface.print_error("requesting chunk {}".format(chunk_index))
-        chunk_base_height = chunk_index * 2016
-        chunk_count = 2016
+        chunk_base_height = chunk_index * self.SHV_CHUNK_SIZE
+        chunk_count = self.SHV_CHUNK_SIZE
         return self.request_headers(interface, chunk_base_height, chunk_count, silent=True)
 
     def request_headers(self, interface, base_height, count, silent=False):
@@ -1209,16 +1211,16 @@ class Network(util.DaemonThread):
         params = response.get('params')
         if not request or result is None or params is None or error is not None:
             interface.print_error(error or 'bad response')
-            # Ensure the chunk can be rerequested, but only if the request originated from us.
-            if request and request[1][0] // 2016 in self.requested_chunks:
-                self.requested_chunks.remove(request[1][0] // 2016)
+            # Ensure the SHV chunk can be rerequested, but only if the request originated from us.
+            if request and request[1][0] // self.SHV_CHUNK_SIZE in self.requested_chunks:
+                self.requested_chunks.remove(request[1][0] // self.SHV_CHUNK_SIZE)
             return
 
         # Ignore unsolicited chunks
         request_params = request[1]
         request_base_height = request_params[0]
         expected_header_count = request_params[1]
-        index = request_base_height // 2016
+        index = request_base_height // self.SHV_CHUNK_SIZE
         if request_params != params:
             interface.print_error("unsolicited chunk base_height={} count={}".format(request_base_height, expected_header_count))
             return
@@ -2022,7 +2024,7 @@ class Network(util.DaemonThread):
         return _("An error occurred broadcasting the transaction")
 
     # Used by the verifier job.
-    def get_merkle_for_transaction(self, tx_hash, tx_height, callback, max_qlen=10):
+    def get_merkle_for_transaction(self, tx_hash, tx_height, callback, max_qlen=20):
         """ Asynchronously enqueue a request for a merkle proof for a tx.
             Note that the callback param is required.
             May return None if too many requests were enqueued (max_qlen) or

--- a/electroncash/verifier.py
+++ b/electroncash/verifier.py
@@ -149,10 +149,9 @@ class SPV(ThreadJob):
             header = blockchain.read_header(tx_height)
             if header is None:
                 if tx_height <= networks.net.VERIFICATION_BLOCK_HEIGHT:
-                    # Per-header requests might be a lot heavier.
-                    # Also, they're not supported as header requests are
-                    # currently designed for catching up post-checkpoint headers.
-                    index = tx_height // 2016
+                    # Simple Header Verification (SHV)
+                    # Request small chunk of headers with checkpoint proof
+                    index = tx_height // self.network.SHV_CHUNK_SIZE
                     if self.network.request_chunk(interface, index):
                         interface.print_error("verifier requesting chunk {} for height {}".format(index, tx_height))
                 continue


### PR DESCRIPTION
Reduce the chunk size for pre-checkpoint header requests from 2016
to 26 headers. When verifying old transactions, we now download
~2KB + proof instead of ~161KB + proof per chunk.

The smaller size balances proof overhead (~640 bytes) against header
data, while fitting within a single disk sector for writes and using >50%
of it, meaning each sector gets at most 3 writes when adjacent
chunks are requested. Clustered transaction histories benefit from
chunk locality while scattered histories waste less bandwidth and
storage.

Bumped max_qlen in `get_merkle_for_transaction` from 10 to 20 so SPV
requests get some chances of firing during refresh_all, rather than
most of them waiting for the end and dragging out (10-delay-10-delay...).

SHV = Simple Header Verification
