### PR TITLE
spv: make checkpoint configurable and clarify header file initialization

### DIFF
--- a/electroncash/blockchain.py
+++ b/electroncash/blockchain.py
@@ -186,6 +186,11 @@ def read_blockchains(config):
     fork_files.sort(key=lambda x: x[1])
 
     for filename, parent_base_height, base_height in fork_files:
+        # Forks at or below checkpoint are not supported - checkpoint headers are sparse
+        if networks.net.VERIFICATION_BLOCK_HEIGHT is not None and base_height <= networks.net.VERIFICATION_BLOCK_HEIGHT:
+            util.print_error(f"[Blockchain] skipping fork below checkpoint: {filename}")
+            continue
+
         # Verify parent chain exists and has headers up to base_height - 1
         parent = blockchains.get(parent_base_height)
         if parent is None or parent.height() < base_height - 1:

--- a/electroncash/blockchain.py
+++ b/electroncash/blockchain.py
@@ -160,23 +160,39 @@ blockchains = {}
 
 def read_blockchains(config):
     blockchains[0] = Blockchain(config, 0, None)
+
+    # Verify main chain continuity from checkpoint to tip, truncate at first break
+    checkpoint_height = networks.net.VERIFICATION_BLOCK_HEIGHT
+    if checkpoint_height is not None:
+        _verify_and_truncate_chain(blockchains[0], checkpoint_height)
+
     fdir = os.path.join(util.get_headers_dir(config), 'forks')
     if not os.path.exists(fdir):
         os.mkdir(fdir)
 
-    def parse_fork_filename(filename):
+    def parse_fork_file(filename):
         """Returns (parent_base_height, base_height) or None if invalid."""
         if not filename.startswith('fork_'):
             return None
         try:
             parts = filename.split('_')
-            return int(parts[1]), int(parts[2])
+            parent_base_height = int(parts[1])
+            base_height = int(parts[2])
         except (IndexError, ValueError):
             return None
+        # Verify file size is non-zero and multiple of header size
+        filepath = os.path.join(fdir, filename)
+        try:
+            size = os.path.getsize(filepath)
+            if size == 0 or size % HEADER_SIZE != 0:
+                return None
+        except OSError:
+            return None
+        return parent_base_height, base_height
 
     fork_files = []
     for filename in os.listdir(fdir):
-        parsed = parse_fork_filename(filename)
+        parsed = parse_fork_file(filename)
         if parsed is None:
             util.print_error(f"[Blockchain] skipping invalid file in forks folder: {filename}")
             continue
@@ -186,7 +202,7 @@ def read_blockchains(config):
     fork_files.sort(key=lambda x: x[1])
 
     for filename, parent_base_height, base_height in fork_files:
-        # Forks at or below checkpoint are not supported - checkpoint headers are sparse
+        # Forks at or below checkpoint are not supported
         if networks.net.VERIFICATION_BLOCK_HEIGHT is not None and base_height <= networks.net.VERIFICATION_BLOCK_HEIGHT:
             util.print_error(f"[Blockchain] skipping fork below checkpoint: {filename}")
             continue
@@ -197,10 +213,72 @@ def read_blockchains(config):
             util.print_error(f"[Blockchain] skipping orphaned fork: {filename}")
             continue
 
+        # Verify fork point header exists (not sparse/null)
+        fork_point_header = parent.read_header(base_height - 1)
+        if fork_point_header is None:
+            util.print_error(f"[Blockchain] skipping fork with missing fork point header: {filename}")
+            continue
+
+        # Verify fork's first header connects to parent chain
         b = Blockchain(config, base_height, parent_base_height)
+        first_header = b.read_header(base_height)
+        if first_header is None:
+            util.print_error(f"[Blockchain] skipping fork with missing first header: {filename}")
+            continue
+        if first_header.get('prev_block_hash') != hash_header(fork_point_header):
+            util.print_error(f"[Blockchain] skipping fork that doesn't connect to parent: {filename}")
+            continue
+
+        # Verify fork internal continuity, truncate at first break
+        _verify_and_truncate_chain(b, base_height)
+
         blockchains[b.base_height] = b
 
     return blockchains
+
+def _verify_and_truncate_chain(blockchain, from_height):
+    """Verify chain continuity from from_height to tip, truncate at first break."""
+    tip_height = blockchain.height()
+    if tip_height < from_height:
+        return
+
+    filename = blockchain.path()
+    base_height = blockchain.base_height
+    prev_hash = None
+
+    with open(filename, 'rb') as f:
+        for height in range(from_height, tip_height + 1):
+            offset = (height - base_height) * HEADER_SIZE
+            f.seek(offset)
+            raw_header = f.read(HEADER_SIZE)
+
+            # Check for null header
+            if raw_header == NULL_HEADER:
+                util.print_error(f"[Blockchain] null header at height {height}, truncating")
+                _truncate_at(blockchain, height)
+                return
+
+            header = deserialize_header(raw_header, height)
+
+            # Check hash linkage (skip for first header in range)
+            if prev_hash is not None and header.get('prev_block_hash') != prev_hash:
+                util.print_error(f"[Blockchain] hash mismatch at height {height}, truncating")
+                _truncate_at(blockchain, height)
+                return
+
+            prev_hash = hash_header(header)
+
+def _truncate_at(blockchain, height):
+    """Truncate blockchain file at given height."""
+    filename = blockchain.path()
+    base_height = blockchain.base_height
+    truncate_length = (height - base_height) * HEADER_SIZE
+    with open(filename, 'r+b') as f:
+        f.truncate(truncate_length)
+        f.flush()
+        os.fsync(f.fileno())
+    with blockchain.lock:
+        blockchain.update_size()
 
 def check_header(header):
     if type(header) is not dict:

--- a/electroncash/network.py
+++ b/electroncash/network.py
@@ -237,6 +237,16 @@ class Network(util.DaemonThread):
         util.DaemonThread.__init__(self)
         self.name = "Net" + self.name
         self.config = SimpleConfig(config) if isinstance(config, dict) else config
+
+        # Apply any checkpoint overrides from config
+        result = networks._apply_config_overrides(self.config)
+        if result is True:
+            self.print_error("using custom checkpoint: height={} merkle_root={}".format(
+                networks.net.VERIFICATION_BLOCK_HEIGHT,
+                networks.net.VERIFICATION_BLOCK_MERKLE_ROOT))
+        elif result is False:
+            self.print_error("invalid checkpoint override in config, using defaults")
+
         self.num_server = 10 if not self.config.get('oneserver') else 0
         self.blockchains = blockchain.read_blockchains(self.config)
         self.print_error("blockchains", self.blockchains.keys())
@@ -1581,14 +1591,32 @@ class Network(util.DaemonThread):
     def init_headers_file(self):
         b = self.blockchains[0]
         filename = b.path()
-        # NB: HEADER_SIZE = 80 bytes
-        length = blockchain.HEADER_SIZE * (networks.net.VERIFICATION_BLOCK_HEIGHT + 1)
-        if not os.path.exists(filename) or os.path.getsize(filename) < length:
-            with open(filename, 'wb') as f:
-                if length>0:
-                    f.seek(length-1)
+        checkpoint_height = networks.net.VERIFICATION_BLOCK_HEIGHT
+
+        if checkpoint_height is not None:
+            # File should contain at least headers [0, checkpoint_height] inclusive
+            required_length = blockchain.HEADER_SIZE * (checkpoint_height + 1)
+
+            if os.path.exists(filename):
+                current_length = os.path.getsize(filename)
+            else:
+                current_length = 0
+
+            if current_length < required_length:
+                # Extend file with sparse allocation
+                mode = 'r+b' if current_length > 0 else 'wb'
+                with open(filename, mode) as f:
+                    f.seek(required_length - 1)
                     f.write(b'\x00')
-        util.ensure_sparse_file(filename)
+                    f.flush()
+                    os.fsync(f.fileno())
+                util.ensure_sparse_file(filename)
+        else:
+            # No checkpoint - just ensure file exists
+            if not os.path.exists(filename):
+                with open(filename, 'wb') as f:
+                    pass
+
         with b.lock:
             b.update_size()
 

--- a/electroncash/networks.py
+++ b/electroncash/networks.py
@@ -209,6 +209,59 @@ class RegtestNet(TestNet):
     DEFAULT_SERVERS = _read_json_dict('servers_regtest.json')  # DO NOT MODIFY IN CLIENT CODE
 
 
+def _apply_config_overrides(config):
+    """Apply checkpoint overrides from config. Called once at startup.
+
+    Only allowed for networks with a hardcoded ASERT anchor (MainNet, TestNet,
+    TestNet4, ChipNet). ScaleNet and RegTest are excluded.
+
+    Config keys:
+        verification_block_height: int - Must be higher than hardcoded checkpoint
+        verification_block_merkle_root: str - 64-char hex string
+
+    Returns:
+        True if overrides were applied successfully
+        False if configuration was invalid
+        None if no overrides were configured
+    """
+    if config is None:
+        return None
+
+    height = config.get('verification_block_height')
+    merkle_root = config.get('verification_block_merkle_root')
+
+    if height is None and merkle_root is None:
+        return None
+
+    if height is None or merkle_root is None:
+        return False
+
+    # Minimum height is 1 - Electrum protocol interprets cp_height=0 as no proof needed
+    if not isinstance(height, int) or height < 1:
+        return False
+    if net.VERIFICATION_BLOCK_HEIGHT is None:
+        return False
+    if height <= net.VERIFICATION_BLOCK_HEIGHT:
+        return False
+
+    # Disallow checkpoint override for networks without hardcoded ASERT anchor
+    # These networks need historical headers to calculate the anchor dynamically
+    if net.asert_daa.anchor is None:
+        return False
+
+    if not isinstance(merkle_root, str) or len(merkle_root) != 64:
+        return False
+    try:
+        bytes.fromhex(merkle_root)
+    except ValueError:
+        return False
+
+    net.VERIFICATION_BLOCK_HEIGHT = height
+    net.VERIFICATION_BLOCK_MERKLE_ROOT = merkle_root
+
+    return True
+
+
 # All new code should access this to get the current network config.
 net = MainNet
 


### PR DESCRIPTION
Add support for custom checkpoint configuration via config keys:
- verification_block_height: must be higher than hardcoded checkpoint
- verification_block_merkle_root: 64-char hex merkle root

Checkpoint override is restricted to networks with hardcoded ASERT
anchors (MainNet, TestNet, TestNet4, ChipNet) since ScaleNet and
RegTest need historical headers to calculate the anchor dynamically.

Clarify header file initialization behavior:
- With checkpoint: ensure file contains at least headers [0, checkpoint_height]
- Without checkpoint: ensure file exists

This prepares for automated checkpoint updating using trustless MMR
extension off the hardcoded checkpoint.

---

blockchain: skip forks at or below checkpoint height

Forks below the checkpoint reference sparse/null headers that don't
actually exist. Skip loading them to avoid verification failures.
