### PR TITLE
Update for latest May 2026 upgrade + fix some long-standing Cash Token "dust" limit issues

### DIFF
--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -107,11 +107,13 @@ class OpCodes(IntEnum):
 
     # control
     OP_NOP = 0x61
-    OP_VER = 0x62
+    OP_VER = 0x62  # Historical (early bitcoin)
     OP_IF = 0x63
     OP_NOTIF = 0x64
-    OP_VERIF = 0x65
-    OP_VERNOTIF = 0x66
+    # OP_VERIF = 0x65 # Historical (early bitcoin)
+    # OP_VERNOTIF = 0x66 # Historical (early bitcoin)
+    OP_BEGIN = 0x65  # after upgrade12 (May 2026)
+    OP_UNTIL = 0x66  # after upgrade12 (May 2026)
     OP_ELSE = 0x67
     OP_ENDIF = 0x68
     OP_VERIFY = 0x69
@@ -146,20 +148,24 @@ class OpCodes(IntEnum):
     OP_SIZE = 0x82
 
     # bit logic
-    OP_INVERT = 0x83
+    OP_INVERT = 0x83  # after upgrade12 (May 2026); Existed in early Bitcoin before being disabled.
     OP_AND = 0x84
     OP_OR = 0x85
     OP_XOR = 0x86
     OP_EQUAL = 0x87
     OP_EQUALVERIFY = 0x88
-    OP_RESERVED1 = 0x89
-    OP_RESERVED2 = 0x8a
+
+    # function support
+    OP_DEFINE = 0x89  # after upgrade12 (May 2026), was: OP_RESERVED1
+    OP_INVOKE = 0x8a  # after upgrade12 (May 2026), was: OP_RESERVED2
 
     # numeric
     OP_1ADD = 0x8b
     OP_1SUB = 0x8c
-    OP_2MUL = 0x8d
-    OP_2DIV = 0x8e
+    # OP_2MUL = 0x8d  # Historical (early Bitcoin)
+    # OP_2DIV = 0x8e  # Historical (early Bitcoin)
+    OP_LSHIFTNUM = 0x8d  # after upgrade12 (May 2026); arithmetic left-shift, defined as in C++20
+    OP_RSHIFTNUM = 0x8e  # after upgrade12 (May 2026); arithmetic right-shift, defined as in C++20
     OP_NEGATE = 0x8f
     OP_ABS = 0x90
     OP_NOT = 0x91
@@ -170,8 +176,10 @@ class OpCodes(IntEnum):
     OP_MUL = 0x95
     OP_DIV = 0x96
     OP_MOD = 0x97
-    OP_LSHIFT = 0x98
-    OP_RSHIFT = 0x99
+    # OP_LSHIFT = 0x98  # Historical (early Bitcoin)
+    # OP_RSHIFT = 0x99  # Historical (early Bitcoin)
+    OP_LSHIFTBIN = 0x98  # after upgrade12 (May 2026); binary blob left-shift (non-arithmetic)
+    OP_RSHIFTBIN = 0x99  # after upgrade12 (May 2026); binary blob right-shift (non-arithmetic)
 
     OP_BOOLAND = 0x9a
     OP_BOOLOR = 0x9b

--- a/electroncash/token.py
+++ b/electroncash/token.py
@@ -19,7 +19,7 @@ from .util import print_error
 from . import wallet
 
 # By consensus, NFT commitment byte blobs may not exceed this length
-MAX_CONSENSUS_COMMITMENT_LENGTH = 40
+MAX_CONSENSUS_COMMITMENT_LENGTH = 128  # Originally was 40, upgraded to 128 after May 2026
 
 
 class Structure(IntEnum):

--- a/electroncash/token.py
+++ b/electroncash/token.py
@@ -203,11 +203,20 @@ def unwrap_spk(wrapped_spk: bytes) -> Tuple[Optional[OutputData], bytes]:
     return token_data, spk  # Parsed ok
 
 
-def heuristic_dust_limit_for_token_bearing_output() -> int:
-    """If calculating dust, wallet.dust_threshold should be used instead of a new function, but it may be desirable 
-    to retain this function beyond deprecation to support hypothetical private plugins.
-    800 was originally hard-coded at implementation and expected to be enough to cover all conceivable token-bearing UTXOs."""
-    return wallet.dust_threshold(None, output_bytes=118) # This should return 798, supports same UTXOs as 800.
+# The length of the longest possible token serialization, if it has full max amount and largest possible commitment.
+# Used by `heuristic_dust_limit_for_longest_possible_token_bearing_p2pkh_output` below.
+LONGEST_POSSIBLE_TOKEN_SERIALIZATON_LEN = len(
+    OutputData(amount=2**63-1, bitfield=Structure.HasAmount | Structure.HasNFT | Structure.HasCommitmentLength,
+               commitment=b'\x00' * MAX_CONSENSUS_COMMITMENT_LENGTH).serialize()
+)
+
+
+def heuristic_dust_limit_for_longest_possible_token_bearing_p2pkh_output() -> int:
+    """The dust limit for a very long token-bearing output (largest possible serialization) that pays to a standard
+    p2pkh output."""
+    script_byte_len = len(PREFIX_BYTE) + LONGEST_POSSIBLE_TOKEN_SERIALIZATON_LEN + 25  # 25 is a p2pkh script
+    # Pre-May 2026 this returned 798, post May-2026 this returns 1062
+    return wallet.dust_threshold(None, script_byte_len=script_byte_len)
 
 
 def get_nft_flag_text(td: OutputData) -> Optional[str]:

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -107,7 +107,7 @@ def relayfee(network):
     return min(f, MAX_RELAY_FEE)
 
 
-def dust_threshold(network, *, script_bytes=25, output_bytes=None):
+def dust_threshold(network, *, script_byte_len=25, output_byte_len=None):
     """To calculate the dust threshold for BCH and cashtoken UTXOs alike, various variables can be used.
     This implementation is using a default of 25 bytes for the output script (P2PKH).
     Alternatviely, the size of the serialized output can be used (34 bytes for P2PKH).
@@ -115,15 +115,31 @@ def dust_threshold(network, *, script_bytes=25, output_bytes=None):
     Hard-coded 148 covers all bytes but the actual output of the next tx for dust limit purposes,
     other variables are named for easy adjustment in the case of future changes.
     We don't need to reimplement *relayfee/1000 until/unless relay fees vary."""
-    if output_bytes is None:
-        value_bytes = 8
-        if script_bytes < 253:
-            length_bytes = 1
+    if output_byte_len is None:
+        value_byte_len = 8
+        if script_byte_len < 253:
+            length_byte_len = 1
         else:
             # this can only be reached in the case of a non-standard transaction
-            length_bytes = 3
-        output_bytes = value_bytes + length_bytes + script_bytes
-    return (148 + output_bytes) * 3
+            length_byte_len = 3
+        output_byte_len = value_byte_len + length_byte_len + script_byte_len
+    return (148 + output_byte_len) * 3
+
+
+def calc_dust(script_or_address: Union[bytes, bytearray, Address, ScriptOutput, PublicKey],
+              td: Optional[token.OutputData]) -> int:
+    """Returns the dust amount for this output given a destination address and/or a locking script, etc,
+    and an optional token"""
+    if isinstance(script_or_address, (Address, PublicKey, ScriptOutput)):
+        script = script_or_address.to_script()
+    elif isinstance(script_or_address, bytearray):
+        script = bytes(script_or_address)
+    else:
+        assert isinstance(script_or_address, bytes)
+        script = script_or_address
+    script_byte_len = len(token.wrap_spk(td, script))
+    return dust_threshold(None, script_byte_len=script_byte_len)
+
 
 def sweep_preparations(privkeys, network, imax=100):
     class InputsMaxxed(Exception):
@@ -2991,16 +3007,18 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                         if not spec.change_addr:
                             raise RuntimeError("Can't find a change address!")
 
-
         # Setup outputs
-        token_dust = token.heuristic_dust_limit_for_token_bearing_output()
-        outputs: List[Tuple[int, Address, Union[int, str]]]
-        outputs = [(TYPE_ADDRESS, spec.payto_addr, token_dust)] * len(tds_out)
+        outputs: List[Tuple[int, Address, Union[int, str]]] = []
+        addr_script = spec.payto_addr.to_script()
+        for td in tds_out:
+            outputs.append((TYPE_ADDRESS, spec.payto_addr, calc_dust(addr_script, td)))
         tds_satoshis = []
         if spec.send_satoshis > 0:
             outputs += [(TYPE_ADDRESS, spec.payto_addr, spec.send_satoshis)]
             tds_satoshis += [None]  # Non-token output for pure BCH
-        outputs += [(TYPE_ADDRESS, spec.change_addr, token_dust)] * len(tds_change_out)
+        change_addr_script = spec.change_addr.to_script()
+        for td in tds_change_out:
+            outputs.append((TYPE_ADDRESS, spec.change_addr, calc_dust(change_addr_script, td)))
 
         if spec.opreturn_msg:
             assert isinstance(spec.opreturn_msg, (bytes, bytearray))
@@ -3054,9 +3072,9 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         tx = self.make_unsigned_transaction(inputs, outputs, config, token_datas=token_datas, fixed_fee=get_fee,
                                             sign_schnorr=sign_schnorr, bip69_sort=False)
         if tx._outputs:
-            # Corner case: delete the change output if it contains dust
+            # Corner case: delete the change output if it contains dust; dust goes to fee as a result
             t, addr, value = tx._outputs[i_change]
-            if addr == spec.change_addr and value < dust_threshold(self.network):
+            if addr == spec.change_addr and value < calc_dust(change_addr_script, token_datas[i_change]):
                 self.print_error(f"Deleting change output at position {i_change} with value: {value}")
                 del tx._outputs[i_change]
                 assert tx._token_datas[i_change] is None

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2090,7 +2090,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 if self.is_token_tx:
                     try:
                         token_id = self.token_c.currentData(TokenSendComboBox.DataRoles.token_id)
-                        amount = self.send_token_util.estimate_max_bch_amount(token_id)
+                        token_amount = self._parse_token_amount(token_id)
+                        amount = self.send_token_util.estimate_max_bch_amount(token_id, token_amount=token_amount)
                         self.not_enough_funds = False
                     except NotEnoughFunds:
                         self.not_enough_funds = True
@@ -2394,6 +2395,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         else:
             return outputs, fee, label, coins
 
+    def _parse_token_amount(self, token_id) -> Optional[int]:
+        token_amount_text = self.token_amount_e.text()
+        if not token_amount_text:
+            return None
+        return self.token_meta.parse_amount(token_id, token_amount_text)
+
     # Process the token send action in a separate method to minimize potential side effects from using
     # the new CashTokens code.
     # It might be a good idea to combine this with read_send_tab() later.
@@ -2425,11 +2432,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         tx_desc = self.message_e.text()
 
-        token_amount = self.token_amount_e.text()
-        if not token_amount:
+        amount = self._parse_token_amount(token_id)
+        if amount is None:
             self.show_error(_('Invalid Token Amount'))
             return
-        amount = self.token_meta.parse_amount(token_id, token_amount)
 
         send_satoshis = self.amount_e.get_amount() or 0
 

--- a/electroncash_gui/qt/token_create.py
+++ b/electroncash_gui/qt/token_create.py
@@ -245,10 +245,9 @@ class CreateTokenForm(QtWidgets.QWidget, MessageBoxMixin, PrintError, OnDestroye
         col = 0
         row += 1
         help_text = _("The destination address to which the newly created token should be sent."
-                      " {coin_amt} satoshis will accompany the token on the same UTXO. You can either send this new"
+                      " Some 'dust' satoshis will accompany the token on the same UTXO. You can either send this new"
                       " token to a new receiving address in your wallet, or you can send it to any Bitcoin Cash"
-                      " address outside this wallet.").format(
-            coin_amt=token.heuristic_dust_limit_for_token_bearing_output())
+                      " address outside this wallet.")
         tt = _("Address to which to send the newly created token")
         l = HelpLabel(_("Send To"), help_text)
         l.setToolTip(tt)
@@ -503,7 +502,7 @@ class CreateTokenForm(QtWidgets.QWidget, MessageBoxMixin, PrintError, OnDestroye
         # genesis-capable UTXOs.
         change_addr = self.wallet.get_unused_address(for_change=True, frozen_ok=False) or utxo["address"]
         outputs = [(bitcoin.TYPE_ADDRESS, change_addr, '!'),
-                   (bitcoin.TYPE_ADDRESS, addr, token.heuristic_dust_limit_for_token_bearing_output())]
+                   (bitcoin.TYPE_ADDRESS, addr, wallet.calc_dust(addr, tok))]
         if hash_bytes and url_bytes:
             script = address.ScriptOutput.from_string("OP_RETURN {BCMR} {hash} {url}"
                                                       .format(BCMR=b'BCMR'.hex(),
@@ -644,8 +643,8 @@ class CreateTokenForm(QtWidgets.QWidget, MessageBoxMixin, PrintError, OnDestroye
 
         # Try and guess the worst-case value we need on a single utxo for creating a new token.
         # min_val: roughly 800 + 310 byte txn -> 1310 sats.
-        min_val = token.heuristic_dust_limit_for_token_bearing_output() + self.est_tx_fee()
-        min_val_other = token.heuristic_dust_limit_for_token_bearing_output() + self.est_tx_fee(200) * 2
+        min_val = token.heuristic_dust_limit_for_longest_possible_token_bearing_p2pkh_output() + self.est_tx_fee()
+        min_val_other = token.heuristic_dust_limit_for_longest_possible_token_bearing_p2pkh_output() + self.est_tx_fee(200) * 2
         utxos = []
         utxos_other = []
         for utxo in self.get_utxos():

--- a/electroncash_gui/qt/token_send.py
+++ b/electroncash_gui/qt/token_send.py
@@ -964,14 +964,21 @@ class SendTokenForm(WindowModalDialog, PrintError, OnDestroyedMixin):
         except Exception as e:
             self.print_error("_estimate_max_amount:", repr(e))
             return None
-        dust_regular = wallet.dust_threshold(self.wallet.network)
-        dust_token = token.heuristic_dust_limit_for_token_bearing_output()
-        # Consider all non-token non-dust utxos as potentially contributing to max_amount
-        max_in = sum(x['value'] for x in spec.non_token_utxos.values() if x['value'] >= dust_regular)
-        # Quirk: We don't choose token utxos for contributing to BCH amount unless the token was selected for
-        # sending by the user in the UI. So only consider BCH amounts > 800 sats for tokens chosen for this tx
-        # by the user's NFT/FT selections in the UI.
-        max_in += sum(x['value'] - dust_token for x in tx.inputs() if x['token_data'] and x['value'] > dust_token)
+        max_in = 0
+        seen = set()
+        for inp in list(spec.non_token_utxos.values()) + list(tx.inputs()):
+            # 1. Consider all non-token non-dust utxos as potentially contributing to max_amount
+            # 2. Also consider token UTXOs that are over dust limit as contributing as well.
+            #    Quirk: We don't choose token utxos for contributing to BCH amount unless the token was selected for
+            #    sending by the user in the UI. So only consider BCH amounts > "dust' sats for tokens chosen for this tx
+            #    by the user's NFT/FT selections in the UI.
+            outpt = self.get_outpoint_longname(inp)
+            if outpt not in seen:
+                dust_amt = wallet.calc_dust(inp['address'], inp['token_data'])
+                val = inp['value']
+                if val > dust_amt:
+                    max_in += val - dust_amt
+                seen.add(outpt)
 
         val_out_minus_change = 0
         for (_, addr, val), td in tx.outputs(tokens=True):

--- a/electroncash_gui/qt/token_send_tab_util.py
+++ b/electroncash_gui/qt/token_send_tab_util.py
@@ -146,26 +146,33 @@ class TokenSendUtil(PrintError):
     def get_outpoint_longname(utxo) -> str:
         return f"{utxo['prevout_hash']}:{utxo['prevout_n']}"
 
-    def estimate_max_bch_amount(self, token_id=None):
+    def estimate_max_bch_amount(self, token_id=None, token_amount=None):
         # make a dummy token spec
         tokens, _ = self.get_wallet_fungible_only_tokens()
-        dummy_tid = token_id if token_id else next(iter(tokens))
-        dummy_amount = tokens[dummy_tid][0]['token_data'].amount
-        spec = self.get_ft_send_spec(None, dummy_tid, dummy_amount, tokens, dummy=True)
+        tid = token_id if token_id else next(iter(tokens))
+        amt = tokens[tid][0]['token_data'].amount if token_amount is None else token_amount
+        spec = self.get_ft_send_spec(None, tid, amt, tokens, dummy=True)
 
         try:
             tx = self.wallet.make_token_send_tx(self.config, spec)
         except Exception as e:
-            self.print_error("_estimate_max_bch_amount:", repr(e))
+            self.print_error("estimate_max_bch_amount:", repr(e))
             raise e
-        dust_regular = wallet.dust_threshold(self.wallet.network)
-        dust_token = token.heuristic_dust_limit_for_token_bearing_output()
-        # Consider all non-token non-dust utxos as potentially contributing to max_amount
-        max_in = sum(x['value'] for x in spec.non_token_utxos.values() if x['value'] >= dust_regular)
-        # Quirk: We don't choose token utxos for contributing to BCH amount unless the token was selected for
-        # sending by the user in the UI. So only consider BCH amounts > 800 sats for tokens chosen for this tx
-        # by the user's NFT/FT selections in the UI.
-        max_in += sum(x['value'] - dust_token for x in tx.inputs() if x['token_data'] and x['value'] > dust_token)
+        max_in = 0
+        seen = set()
+        for inp in list(spec.non_token_utxos.values()) + list(tx.inputs()):
+            # 1. Consider all non-token non-dust utxos as potentially contributing to max_amount
+            # 2. Also consider token UTXOs that are over dust limit as contributing as well.
+            #    Quirk: We don't choose token utxos for contributing to BCH amount unless the token was selected for
+            #    sending by the user in the UI. So only consider BCH amounts > "dust' sats for tokens chosen for this tx
+            #    by the user's NFT/FT selections in the UI.
+            outpt = self.get_outpoint_longname(inp)
+            if outpt not in seen:
+                dust_amt = wallet.calc_dust(inp['address'], inp['token_data'])
+                val = inp['value']
+                if val > dust_amt:
+                    max_in += val - dust_amt
+                seen.add(outpt)
 
         val_out_minus_change = 0
         for (_, addr, val), td in tx.outputs(tokens=True):


### PR DESCRIPTION
Closes #3217 .

This PR does the following:

- Add new May 2026 op-codes to `bitcoin.py` `OpCodes` enum to be able to parse and display new scripts after May 2026 correctly.
- Bumped the CashToken consensus limit for commitments to 40 bytes (so we can create and parse txns that contain long CT commitments in them after May 2026).

Additionally, we fixed some issues with Cash Token related "dust" calculations:

- Removed the hard-coded heuristic 800 (or 798) sat "dust" we place onto CashToken-bearing utxos. Instead, we prefer to calculate the actual dust needed per-utxo. So often you end up with ~660 sats on a CT utxo rather than 800.
- Fixed the "max BCH" button in the CashToken send window and in the send tab to no longer overshoot, which was a strange UI glitch.
 