### PR TITLE
build: update tor to version 0.4.9.11

### DIFF
--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN echo "78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6 /tmp/
         # xvfb is needed to launch the Visual Studio installer
         xvfb=2:21.1.4-2ubuntu1.7~22.04.16 \
         # winbind is needed for the Visual Studio installer and cl.exe PDB generation
-        winbind=2:4.15.13+dfsg-0ubuntu1.10
+        winbind=2:4.15.13+dfsg-0ubuntu1.12
 
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \


### PR DESCRIPTION
We need to update tor to version 0.4.9.x+ because 0.4.8.x is being sunset in September 2026, see https://blog.torproject.org/sunsetting-tor-048/ for more information.

See https://gitlab.torproject.org/tpo/core/tor/-/raw/main/ChangeLog for a list of changes.