### PR TITLE
Add Cold Signing for Android

### DIFF
--- a/android/app/src/main/java/org/electroncash/electroncash3/ColdLoad.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/ColdLoad.kt
@@ -1,16 +1,15 @@
 package org.electroncash.electroncash3
 
+import android.app.Activity
 import android.content.ClipboardManager
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
-import androidx.viewbinding.ViewBinding
 import com.chaquo.python.Kwarg
 import com.chaquo.python.PyException
 import com.chaquo.python.PyObject
@@ -19,43 +18,61 @@ import com.google.zxing.integration.android.IntentIntegrator
 import org.electroncash.electroncash3.databinding.LoadBinding
 import org.electroncash.electroncash3.databinding.SignedTransactionBinding
 import org.electroncash.electroncash3.databinding.SweepBinding
-import org.electroncash.electroncash3.databinding.WalletInformationBinding
+import android.provider.OpenableColumns
 
+private const val REQUEST_OPEN_TX_FILE = 2001
 
 val libTransaction by lazy { libMod("transaction") }
-
-
-// This provides a dialog to allow users to input a string, which is then broadcast
-// on the bitcoin cash network. Strings are not validated,
-// but broadcast_transaction should throw error which is toasted.
-// Valid transaction quickly show up in transactions.
 
 class ColdLoadDialog : AlertDialogFragment() {
     private var _binding: LoadBinding? = null
     private val binding get() = _binding!!
 
+    private fun openTransactionFile() {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "*/*"
+        }
+        startActivityForResult(intent, REQUEST_OPEN_TX_FILE)
+    }
+    
+    private fun getDisplayName(uri: android.net.Uri): String? {
+    requireContext().contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+        val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        if (nameIndex >= 0 && cursor.moveToFirst()) {
+            return cursor.getString(nameIndex)
+        }
+    }
+    return null
+}
+
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         _binding = LoadBinding.inflate(LayoutInflater.from(context))
         builder.setTitle(R.string.load_transaction)
-                .setView(binding.root)
-                .setNegativeButton(android.R.string.cancel, null)
-                .setNeutralButton(R.string.scan_qr, null)
-                .setPositiveButton(R.string.OK, null)
+            .setView(binding.root)
+            .setNegativeButton(android.R.string.cancel, null)
+            .setNeutralButton(R.string.scan_qr, null)
+            .setPositiveButton(R.string.OK, null)
     }
 
     override fun onShowDialog() {
         super.onShowDialog()
-        binding.etTransaction.addAfterTextChangedListener{ updateUI() }
+        binding.etTransaction.addAfterTextChangedListener { updateUI() }
         updateUI()
 
         dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener { onOK() }
         dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener { scanQR(this) }
+
         binding.btnPaste.setOnClickListener {
             val clipdata = getSystemService(ClipboardManager::class).primaryClip
-            if (clipdata != null && clipdata.getItemCount() > 0) {
+            if (clipdata != null && clipdata.itemCount > 0) {
                 val cliptext = clipdata.getItemAt(0)
                 binding.etTransaction.setText(cliptext.text)
             }
+        }
+
+        if (arguments?.getBoolean("openFileImmediately") == true) {
+            openTransactionFile()
         }
     }
 
@@ -66,21 +83,65 @@ class ColdLoadDialog : AlertDialogFragment() {
             canSign(tx) || canBroadcast(tx)
     }
 
-    // Receives the result of a QR scan.
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        val result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
-        if (result != null && result.contents != null) {
-            // Try to decode the QR content as Base43; if that fails, treat it as is
-            val txHex: String = try {
-                baseDecode(result.contents, 43)
-            } catch (e: PyException) {
-                result.contents
+    if (requestCode == REQUEST_OPEN_TX_FILE) {
+        if (resultCode == Activity.RESULT_OK) {
+            val uri = data?.data
+            if (uri != null) {
+                val filename = getDisplayName(uri)
+                if (filename == null || !filename.endsWith(".txn", ignoreCase = true)) {
+                    Toast.makeText(
+                        requireContext(),
+                        "Please select a .txn transaction file",
+                        Toast.LENGTH_LONG
+                    ).show()
+
+                    if (arguments?.getBoolean("openFileImmediately") == true) {
+                        dismiss()
+                    }
+                    return
+                }
+
+                try {
+                    val text = requireContext().contentResolver.openInputStream(uri)?.use { input ->
+                        input.bufferedReader().readText()
+                    }
+                    val txHex = libTransaction.callAttr("tx_from_str", text ?: "").toString()
+                    binding.etTransaction.setText(txHex)
+
+                    if (arguments?.getBoolean("openFileImmediately") == true) {
+                        onOK()
+                    }
+                } catch (e: Exception) {
+                    Toast.makeText(
+                        requireContext(),
+                        "Invalid transaction file",
+                        Toast.LENGTH_LONG
+                    ).show()
+
+                    if (arguments?.getBoolean("openFileImmediately") == true) {
+                        dismiss()
+                    }
+                }
             }
-            binding.etTransaction.setText(txHex)
-        } else {
-            super.onActivityResult(requestCode, resultCode, data)
+        } else if (arguments?.getBoolean("openFileImmediately") == true) {
+            dismiss()
         }
+        return
     }
+
+    val result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
+    if (result != null && result.contents != null) {
+        val txHex: String = try {
+            baseDecode(result.contents, 43)
+        } catch (e: PyException) {
+            result.contents
+        }
+        binding.etTransaction.setText(txHex)
+    } else {
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+}
 
     fun onOK() {
         val txHex = binding.etTransaction.text.toString()
@@ -88,9 +149,11 @@ class ColdLoadDialog : AlertDialogFragment() {
 
         try {
             if (canBroadcast(tx)) {
-                showDialog(this, SignedTransactionDialog().apply { arguments = Bundle().apply {
-                    putString("txHex", txHex)
-                }})
+                showDialog(this, SignedTransactionDialog().apply {
+                    arguments = Bundle().apply {
+                        putString("txHex", txHex)
+                    }
+                })
                 dismiss()
             } else {
                 signLoadedTransaction(txHex)
@@ -101,13 +164,17 @@ class ColdLoadDialog : AlertDialogFragment() {
     }
 
     private fun signLoadedTransaction(txHex: String) {
-        val arguments = Bundle().apply {
-            putString("txHex", txHex)
-            putBoolean("unbroadcasted", true)
-        }
-        val dialog = SendDialog()
-        showDialog(this, dialog.apply { setArguments(arguments) })
+    val arguments = Bundle().apply {
+        putString("txHex", txHex)
+        putBoolean("unbroadcasted", true)
     }
+    val dialog = SendDialog()
+    showDialog(this, dialog.apply { setArguments(arguments) })
+    dismiss()
+}
+    
+    
+    
 }
 
 private fun updateStatusText(idTxStatus: TextView, tx: PyObject) {
@@ -123,7 +190,6 @@ private fun updateStatusText(idTxStatus: TextView, tx: PyObject) {
     }
 }
 
-
 class SignedTransactionDialog : TaskLauncherDialog<Unit>() {
     private var _binding: SignedTransactionBinding? = null
     private val binding get() = _binding!!
@@ -136,8 +202,8 @@ class SignedTransactionDialog : TaskLauncherDialog<Unit>() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         _binding = SignedTransactionBinding.inflate(LayoutInflater.from(context))
         builder.setView(binding.root)
-               .setNegativeButton(R.string.close, null)
-               .setPositiveButton(R.string.send, null)
+            .setNegativeButton(R.string.close, null)
+            .setPositiveButton(R.string.send, null)
     }
 
     override fun onShowDialog() {
@@ -173,7 +239,6 @@ fun hideDescription(dialog: DialogFragment, descriptionLabel: TextView, descript
         view.visibility = View.GONE
     }
 }
-
 
 class SweepDialog : TaskLauncherDialog<PyObject>() {
     private var _binding: SweepBinding? = null
@@ -223,7 +288,6 @@ class SweepDialog : TaskLauncherDialog<PyObject>() {
     }
 
     override fun onPostExecute(result: PyObject) {
-        // Convert objects to serializable form so we can pass them in an argument.
         val inputs = result.asList()[0]
         for (i in inputs.asList()) {
             val iMap = i.asMap()
@@ -237,10 +301,11 @@ class SweepDialog : TaskLauncherDialog<PyObject>() {
                 putString("inputs", inputs.repr())
                 putString("sweepKeypairs", result.asList()[1].repr())
             })
-        } catch (e: ToastException) { e.show() }
+        } catch (e: ToastException) {
+            e.show()
+        }
     }
 }
-
 
 fun txFromHex(hex: String) =
     libTransaction.callAttr("Transaction", hex, Kwarg("sign_schnorr", signSchnorr()))!!
@@ -248,7 +313,7 @@ fun txFromHex(hex: String) =
 fun canSign(tx: PyObject): Boolean {
     return try {
         !tx.callAttr("is_complete").toBoolean() &&
-        daemonModel.wallet!!.callAttr("can_sign", tx).toBoolean()
+            daemonModel.wallet!!.callAttr("can_sign", tx).toBoolean()
     } catch (e: PyException) {
         false
     }

--- a/android/app/src/main/java/org/electroncash/electroncash3/ColdLoad.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/ColdLoad.kt
@@ -35,24 +35,24 @@ class ColdLoadDialog : AlertDialogFragment() {
         }
         startActivityForResult(intent, REQUEST_OPEN_TX_FILE)
     }
-    
+
     private fun getDisplayName(uri: android.net.Uri): String? {
-    requireContext().contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-        val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-        if (nameIndex >= 0 && cursor.moveToFirst()) {
-            return cursor.getString(nameIndex)
+        requireContext().contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameIndex >= 0 && cursor.moveToFirst()) {
+                return cursor.getString(nameIndex)
+            }
         }
+        return null
     }
-    return null
-}
 
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         _binding = LoadBinding.inflate(LayoutInflater.from(context))
         builder.setTitle(R.string.load_transaction)
-            .setView(binding.root)
-            .setNegativeButton(android.R.string.cancel, null)
-            .setNeutralButton(R.string.scan_qr, null)
-            .setPositiveButton(R.string.OK, null)
+                .setView(binding.root)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setNeutralButton(R.string.scan_qr, null)
+                .setPositiveButton(R.string.OK, null)
     }
 
     override fun onShowDialog() {
@@ -80,68 +80,68 @@ class ColdLoadDialog : AlertDialogFragment() {
         val tx = txFromHex(binding.etTransaction.text.toString())
         updateStatusText(binding.tvStatus, tx)
         dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled =
-            canSign(tx) || canBroadcast(tx)
+                canSign(tx) || canBroadcast(tx)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-    if (requestCode == REQUEST_OPEN_TX_FILE) {
-        if (resultCode == Activity.RESULT_OK) {
-            val uri = data?.data
-            if (uri != null) {
-                val filename = getDisplayName(uri)
-                if (filename == null || !filename.endsWith(".txn", ignoreCase = true)) {
-                    Toast.makeText(
-                        requireContext(),
-                        "Please select a .txn transaction file",
-                        Toast.LENGTH_LONG
-                    ).show()
+        if (requestCode == REQUEST_OPEN_TX_FILE) {
+            if (resultCode == Activity.RESULT_OK) {
+                val uri = data?.data
+                if (uri != null) {
+                    val filename = getDisplayName(uri)
+                    if (filename == null || !filename.endsWith(".txn", ignoreCase = true)) {
+                        Toast.makeText(
+                                requireContext(),
+                                "Please select a .txn transaction file",
+                                Toast.LENGTH_LONG
+                        ).show()
 
-                    if (arguments?.getBoolean("openFileImmediately") == true) {
-                        dismiss()
+                        if (arguments?.getBoolean("openFileImmediately") == true) {
+                            dismiss()
+                        }
+                        return
                     }
-                    return
+
+                    try {
+                        val text = requireContext().contentResolver.openInputStream(uri)?.use { input ->
+                            input.bufferedReader().readText()
+                        }
+                        val txHex = libTransaction.callAttr("tx_from_str", text ?: "").toString()
+                        binding.etTransaction.setText(txHex)
+
+                        if (arguments?.getBoolean("openFileImmediately") == true) {
+                            onOK()
+                        }
+                    } catch (e: Exception) {
+                        Toast.makeText(
+                                requireContext(),
+                                "Invalid transaction file",
+                                Toast.LENGTH_LONG
+                        ).show()
+
+                        if (arguments?.getBoolean("openFileImmediately") == true) {
+                            dismiss()
+                        }
+                    }
                 }
-
-                try {
-                    val text = requireContext().contentResolver.openInputStream(uri)?.use { input ->
-                        input.bufferedReader().readText()
-                    }
-                    val txHex = libTransaction.callAttr("tx_from_str", text ?: "").toString()
-                    binding.etTransaction.setText(txHex)
-
-                    if (arguments?.getBoolean("openFileImmediately") == true) {
-                        onOK()
-                    }
-                } catch (e: Exception) {
-                    Toast.makeText(
-                        requireContext(),
-                        "Invalid transaction file",
-                        Toast.LENGTH_LONG
-                    ).show()
-
-                    if (arguments?.getBoolean("openFileImmediately") == true) {
-                        dismiss()
-                    }
-                }
+            } else if (arguments?.getBoolean("openFileImmediately") == true) {
+                dismiss()
             }
-        } else if (arguments?.getBoolean("openFileImmediately") == true) {
-            dismiss()
+            return
         }
-        return
-    }
 
-    val result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
-    if (result != null && result.contents != null) {
-        val txHex: String = try {
-            baseDecode(result.contents, 43)
-        } catch (e: PyException) {
-            result.contents
+        val result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
+        if (result != null && result.contents != null) {
+            val txHex: String = try {
+                baseDecode(result.contents, 43)
+            } catch (e: PyException) {
+                result.contents
+            }
+            binding.etTransaction.setText(txHex)
+        } else {
+            super.onActivityResult(requestCode, resultCode, data)
         }
-        binding.etTransaction.setText(txHex)
-    } else {
-        super.onActivityResult(requestCode, resultCode, data)
     }
-}
 
     fun onOK() {
         val txHex = binding.etTransaction.text.toString()
@@ -164,17 +164,16 @@ class ColdLoadDialog : AlertDialogFragment() {
     }
 
     private fun signLoadedTransaction(txHex: String) {
-    val arguments = Bundle().apply {
-        putString("txHex", txHex)
-        putBoolean("unbroadcasted", true)
+        val arguments = Bundle().apply {
+            putString("txHex", txHex)
+            putBoolean("unbroadcasted", true)
+        }
+        val dialog = SendDialog()
+        showDialog(this, dialog.apply { setArguments(arguments) })
+        dismiss()
     }
-    val dialog = SendDialog()
-    showDialog(this, dialog.apply { setArguments(arguments) })
-    dismiss()
-}
-    
-    
-    
+
+
 }
 
 private fun updateStatusText(idTxStatus: TextView, tx: PyObject) {
@@ -202,8 +201,8 @@ class SignedTransactionDialog : TaskLauncherDialog<Unit>() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         _binding = SignedTransactionBinding.inflate(LayoutInflater.from(context))
         builder.setView(binding.root)
-            .setNegativeButton(R.string.close, null)
-            .setPositiveButton(R.string.send, null)
+                .setNegativeButton(R.string.close, null)
+                .setPositiveButton(R.string.send, null)
     }
 
     override fun onShowDialog() {
@@ -253,10 +252,10 @@ class SweepDialog : TaskLauncherDialog<PyObject>() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         _binding = SweepBinding.inflate(LayoutInflater.from(context))
         builder.setTitle(R.string.sweep_private)
-            .setView(binding.root)
-            .setNeutralButton(R.string.scan_qr, null)
-            .setNegativeButton(android.R.string.cancel, null)
-            .setPositiveButton(android.R.string.ok, null)
+                .setView(binding.root)
+                .setNeutralButton(R.string.scan_qr, null)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok, null)
     }
 
     override fun onShowDialog() {
@@ -308,12 +307,12 @@ class SweepDialog : TaskLauncherDialog<PyObject>() {
 }
 
 fun txFromHex(hex: String) =
-    libTransaction.callAttr("Transaction", hex, Kwarg("sign_schnorr", signSchnorr()))!!
+        libTransaction.callAttr("Transaction", hex, Kwarg("sign_schnorr", signSchnorr()))!!
 
 fun canSign(tx: PyObject): Boolean {
     return try {
         !tx.callAttr("is_complete").toBoolean() &&
-            daemonModel.wallet!!.callAttr("can_sign", tx).toBoolean()
+                daemonModel.wallet!!.callAttr("can_sign", tx).toBoolean()
     } catch (e: PyException) {
         false
     }

--- a/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
@@ -140,7 +140,7 @@ class MainActivity : AppCompatActivity(R.layout.main) {
             invalidateOptionsMenu()
             clearFragments()
             binding.navBottom.selectedItemId = if (walletName == null) R.id.navNoWallet
-                                       else R.id.navTransactions
+            else R.id.navTransactions
         }
     }
 
@@ -204,9 +204,11 @@ class MainActivity : AppCompatActivity(R.layout.main) {
         } else if (item.itemId == Menu.NONE) {
             val walletName = item.title.toString()
             if (walletName != daemonModel.walletName) {
-                showDialog(this, WalletOpenDialog().apply { arguments = Bundle().apply {
-                    putString("walletName", walletName)
-                }})
+                showDialog(this, WalletOpenDialog().apply {
+                    arguments = Bundle().apply {
+                        putString("walletName", walletName)
+                    }
+                })
             }
         } else if (item.itemId == R.id.navAbout) {
             showDialog(this, AboutDialog())
@@ -222,7 +224,7 @@ class MainActivity : AppCompatActivity(R.layout.main) {
             menuInflater.inflate(R.menu.wallet, menu)
             MenuCompat.setGroupDividerEnabled(menu, true)
             menu.findItem(R.id.menuUseChange)!!.isChecked =
-                wallet.get("use_change")!!.toBoolean()
+                    wallet.get("use_change")!!.toBoolean()
         }
         return true
     }
@@ -239,31 +241,40 @@ class MainActivity : AppCompatActivity(R.layout.main) {
                     wallet.get("storage")!!.callAttr("put", "use_change", useChange)
                 }
             }
+
             R.id.menuChangePassword -> showDialog(this, PasswordChangeDialog())
-            R.id.menuWalletInformation -> { showDialog(this, WalletInformationDialog()) }
+            R.id.menuWalletInformation -> {
+                showDialog(this, WalletInformationDialog())
+            }
+
             R.id.menuSignTx -> {
                 try {
                     showDialog(this, SendDialog().apply {
                         arguments = Bundle().apply { putBoolean("unbroadcasted", true) }
                     })
-                } catch (e: ToastException) { e.show() }
+                } catch (e: ToastException) {
+                    e.show()
+                }
             }
+
             R.id.menuLoadTx -> {
-    showDialog(this, ColdLoadDialog())
-}
+                showDialog(this, ColdLoadDialog())
+            }
 
 
-R.id.menuLoadTxFromFile -> {
-    showDialog(this, ColdLoadDialog().apply {
-        arguments = Bundle().apply {
-            putBoolean("openFileImmediately", true)
-        }
-    })
-}
+            R.id.menuLoadTxFromFile -> {
+                showDialog(this, ColdLoadDialog().apply {
+                    arguments = Bundle().apply {
+                        putBoolean("openFileImmediately", true)
+                    }
+                })
+            }
+
             R.id.menuSweep -> showDialog(this, SweepDialog())
             R.id.menuExport -> showDialog(this, WalletExportDialog().apply {
                 arguments = Bundle().apply { putString("walletName", daemonModel.walletName) }
             })
+
             R.id.menuClose -> showDialog(this, WalletCloseDialog())
             else -> throw Exception("Unknown item $item")
         }
@@ -315,7 +326,9 @@ R.id.menuLoadTxFromFile -> {
                             showDialog(this, dialog)
                         }
                         dialog.onUri(uri.toString())
-                    } catch (e: ToastException) { e.show() }
+                    } catch (e: ToastException) {
+                        e.show()
+                    }
                 }
             }
         }
@@ -356,8 +369,8 @@ R.id.menuLoadTxFromFile -> {
         } else {
             frag = FRAGMENTS[id]!!.java.getDeclaredConstructor().newInstance()
             supportFragmentManager.beginTransaction()
-                .add(binding.flContent.id, frag, fragTag(id))
-                .commitNow()
+                    .add(binding.flContent.id, frag, fragTag(id))
+                    .commitNow()
             return frag
         }
     }
@@ -387,31 +400,31 @@ class WalletNotOpenFragment : Fragment(), MainFragment {
 
 class AboutDialog : AlertDialogFragment() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
-        with (builder) {
+        with(builder) {
             val version = app.packageManager.getPackageInfo(app.packageName, 0).versionName
             setTitle(getString(R.string.app_name) + " " + version)
             val message = SpannableStringBuilder()
             listOf(R.string.copyright_2017, R.string.made_with, R.string.for_support)
-                .forEachIndexed { i, stringId ->
-                    if (i != 0) {
-                        message.append("\n\n")
+                    .forEachIndexed { i, stringId ->
+                        if (i != 0) {
+                            message.append("\n\n")
+                        }
+                        @Suppress("DEPRECATION")
+                        message.append(Html.fromHtml(getString(stringId)))
                     }
-                    @Suppress("DEPRECATION")
-                    message.append(Html.fromHtml(getString(stringId)))
-                }
             setMessage(message)
         }
     }
 
     override fun onShowDialog() {
         dialog.findViewById<TextView>(android.R.id.message)!!.movementMethod =
-            LinkMovementMethod.getInstance()
+                LinkMovementMethod.getInstance()
     }
 }
 
 
 // Not happy about this one. Didn't figure out how the view binding works when inhereting PasswordDialog
-class WalletOpenDialog: TaskLauncherDialog<String>() {
+class WalletOpenDialog : TaskLauncherDialog<String>() {
     var password: String = ""
     val walletName by lazy { arguments!!.getString("walletName")!! }
     private var _binding: WalletOpenBinding? = null
@@ -430,13 +443,14 @@ class WalletOpenDialog: TaskLauncherDialog<String>() {
         daemonModel.commands.callAttr("select_wallet", result)
         (activity as MainActivity).updateDrawer()
     }
+
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         _binding = WalletOpenBinding.inflate(LayoutInflater.from(context))
         builder.setView(binding.root)
                 .setNeutralButton(R.string.Delete, null)
                 .setTitle(R.string.Enter_password)
-            .setPositiveButton(android.R.string.ok, null)
-            .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok, null)
+                .setNegativeButton(android.R.string.cancel, null)
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
@@ -471,7 +485,7 @@ class WalletOpenDialog: TaskLauncherDialog<String>() {
         binding.etPassword.setOnEditorActionListener { _, actionId: Int, event: KeyEvent? ->
             // See comments in ConsoleActivity.createInput.
             if (actionId == EditorInfo.IME_ACTION_DONE ||
-                event?.action == KeyEvent.ACTION_UP) {
+                    event?.action == KeyEvent.ACTION_UP) {
                 dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick()
             }
             true
@@ -497,15 +511,15 @@ class WalletDeleteConfirmDialog : AlertDialogFragment() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         val walletName = arguments!!.getString("walletName")!!
         val message = getString(R.string.are_you_sure_you_want_to_delete, walletName) +
-                      "\n\n" + getString(R.string.if_your)
+                "\n\n" + getString(R.string.if_your)
         builder.setTitle(R.string.confirm_delete)
-            .setMessage(message)
-            .setPositiveButton(R.string.delete, { _, _ ->
-                showDialog(activity!!, WalletDeleteDialog().apply {
-                    arguments = Bundle().apply { putString("walletName", walletName) }
+                .setMessage(message)
+                .setPositiveButton(R.string.delete, { _, _ ->
+                    showDialog(activity!!, WalletDeleteDialog().apply {
+                        arguments = Bundle().apply { putString("walletName", walletName) }
+                    })
                 })
-            })
-            .setNegativeButton(android.R.string.cancel, null)
+                .setNegativeButton(android.R.string.cancel, null)
     }
 }
 
@@ -528,11 +542,11 @@ class WalletDeleteDialog : WalletCloseDialog() {
 class WalletCloseConfirmDialog : AlertDialogFragment() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         builder.setTitle(daemonModel.walletName!!)
-            .setMessage(R.string.do_you_want_to_close)
-            .setPositiveButton(R.string.close_wallet, { _, _ ->
-                showDialog(activity!!, WalletCloseDialog())
-            })
-            .setNegativeButton(android.R.string.cancel, null)
+                .setMessage(R.string.do_you_want_to_close)
+                .setPositiveButton(R.string.close_wallet, { _, _ ->
+                    showDialog(activity!!, WalletCloseDialog())
+                })
+                .setNegativeButton(android.R.string.cancel, null)
     }
 }
 
@@ -555,7 +569,7 @@ open class WalletCloseDialog : TaskDialog<Unit>() {
     }
 
     override fun onPostExecute(result: Unit) {
-        with (activity as MainActivity) {
+        with(activity as MainActivity) {
             updateDrawer()
             openDrawer()
         }
@@ -573,9 +587,9 @@ class PasswordChangeDialog : TaskLauncherDialog<String>() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         _binding = PasswordChangeBinding.inflate(LayoutInflater.from(context))
         builder.setTitle(R.string.Change_password)
-            .setView(binding.root)
-            .setPositiveButton(android.R.string.ok, null)
-            .setNegativeButton(android.R.string.cancel, null)
+                .setView(binding.root)
+                .setPositiveButton(android.R.string.ok, null)
+                .setNegativeButton(android.R.string.cancel, null)
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
@@ -589,7 +603,7 @@ class PasswordChangeDialog : TaskLauncherDialog<String>() {
         binding.etPassword.setOnEditorActionListener { _, actionId: Int, event: KeyEvent? ->
             // See comments in ConsoleActivity.createInput.
             if (actionId == EditorInfo.IME_ACTION_DONE ||
-                event?.action == KeyEvent.ACTION_UP) {
+                    event?.action == KeyEvent.ACTION_UP) {
                 dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick()
             }
             true
@@ -610,7 +624,8 @@ class PasswordChangeDialog : TaskLauncherDialog<String>() {
                 ToastException(R.string.incorrect_password, Toast.LENGTH_SHORT) else e
         }
     }
-    fun onPassword(password: String) : String {
+
+    fun onPassword(password: String): String {
         val wallet = daemonModel.wallet!!
         wallet.callAttr("update_password", password, newPassword, Kwarg("encrypt", true))
         toast(R.string.password_was, Toast.LENGTH_SHORT)
@@ -711,7 +726,7 @@ class WalletExportDialog : TaskLauncherDialog<Uri>() {
         waitForSave()
         val exportFile = File(exportFilePath)
         val exportFileUri: Uri = FileProvider.getUriForFile(app,
-            "org.electroncash.wallet.wallet_exports", exportFile)
+                "org.electroncash.wallet.wallet_exports", exportFile)
         daemonModel.commands.callAttr("copy_wallet", walletName, exportFilePath)
         return exportFileUri
     }
@@ -733,14 +748,16 @@ class SeedPasswordDialog : PasswordDialog<SeedResult>() {
     override fun onPassword(password: String): SeedResult {
         val keystore = daemonModel.wallet!!.callAttr("get_keystore")!!
         return SeedResult(keystore.callAttr("get_seed", password).toString(),
-                              keystore.callAttr("get_passphrase", password).toString())
+                keystore.callAttr("get_passphrase", password).toString())
     }
 
     override fun onPostExecute(result: SeedResult) {
-        showDialog(activity!!, SeedDialog().apply { arguments = Bundle().apply {
-            putString("seed", result.seed)
-            putString("passphrase", result.passphrase)
-        }})
+        showDialog(activity!!, SeedDialog().apply {
+            arguments = Bundle().apply {
+                putString("seed", result.seed)
+                putString("passphrase", result.passphrase)
+            }
+        })
     }
 }
 
@@ -764,9 +781,9 @@ class WalletInformationDialog : AlertDialogFragment() {
     private var _binding: WalletInformationBinding? = null
     private val binding get() = _binding!!
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
     ): View? {
         super.onCreateView(inflater, container, savedInstanceState)
         return binding.root
@@ -780,7 +797,7 @@ class WalletInformationDialog : AlertDialogFragment() {
     override fun onBuildDialog(builder: AlertDialog.Builder) {
         _binding = WalletInformationBinding.inflate(LayoutInflater.from(context))
         builder.setView(binding.root)
-            .setPositiveButton(android.R.string.ok, null)
+                .setPositiveButton(android.R.string.ok, null)
 
         if (daemonModel.wallet!!.callAttr("has_seed").toBoolean()) {
             builder.setNeutralButton(R.string.show_seed, null)
@@ -828,6 +845,7 @@ class WalletInformationDialog : AlertDialogFragment() {
                                             position: Int, id: Long) {
                     binding.walletMasterKey.setText(mpks[position].toString())
                 }
+
                 override fun onNothingSelected(parent: AdapterView<*>?) {}
             }
         } else {

--- a/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Main.kt
@@ -248,7 +248,18 @@ class MainActivity : AppCompatActivity(R.layout.main) {
                     })
                 } catch (e: ToastException) { e.show() }
             }
-            R.id.menuLoadTx -> { showDialog(this, ColdLoadDialog()) }
+            R.id.menuLoadTx -> {
+    showDialog(this, ColdLoadDialog())
+}
+
+
+R.id.menuLoadTxFromFile -> {
+    showDialog(this, ColdLoadDialog().apply {
+        arguments = Bundle().apply {
+            putBoolean("openFileImmediately", true)
+        }
+    })
+}
             R.id.menuSweep -> showDialog(this, SweepDialog())
             R.id.menuExport -> showDialog(this, WalletExportDialog().apply {
                 arguments = Bundle().apply { putString("walletName", daemonModel.walletName) }

--- a/android/app/src/main/java/org/electroncash/electroncash3/Send.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Send.kt
@@ -24,17 +24,38 @@ import com.chaquo.python.PyObject.fromJava
 import com.google.zxing.integration.android.IntentIntegrator
 import org.electroncash.electroncash3.databinding.SendBinding
 import kotlin.math.pow
+import android.app.Activity 
 
 
 val libPaymentRequest by lazy { libMod("paymentrequest") }
 val libStorage by lazy { libMod("storage") }
 
 val MIN_FEE = 1  // sat/byte
+private const val REQUEST_SAVE_TX_FILE = 2002
 
 
 class SendDialog : TaskLauncherDialog<Unit>() {
     private var _binding: SendBinding? = null
     private val binding get() = _binding!!
+
+    private fun saveTransactionFile() {
+    val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+        addCategory(Intent.CATEGORY_OPENABLE)
+        type = "application/octet-stream"
+        putExtra(Intent.EXTRA_TITLE, "transaction.txn")
+    }
+    startActivityForResult(intent, REQUEST_SAVE_TX_FILE)
+}
+
+    private fun getTransactionJsonForFile(): String {
+    model.tx.waitUntilComplete()
+    val tx = model.tx.value!!.get()
+    return py.getModule("json").callAttr(
+        "dumps",
+        tx.callAttr("as_dict"),
+        Kwarg("indent", 4)
+    ).toString() + "\n"
+    }  
 
     val wallet = daemonModel.wallet!!
 
@@ -116,23 +137,20 @@ class SendDialog : TaskLauncherDialog<Unit>() {
     }
 
     override fun onBuildDialog(builder: AlertDialog.Builder) {
-        _binding = SendBinding.inflate(LayoutInflater.from(context))
-        buildCategorySpinner()
-        buildNftSpinner()
-        if (!unbroadcasted) {
-            builder.setPositiveButton(R.string.send, null)
-        } else {
-            builder.setTitle(R.string.sign_transaction)
-                .setPositiveButton(R.string.sign, null)
-            binding.tvTitle.visibility = View.GONE
-            binding.header.removeView(binding.spnCoinType)
-            binding.sendRow.addView(binding.spnCoinType)
-            binding.sendRow.visibility = View.VISIBLE
-        }
-        builder.setView(binding.root)
-            .setNegativeButton(android.R.string.cancel, null)
-            .setNeutralButton(R.string.scan_qr, null)
+    _binding = SendBinding.inflate(LayoutInflater.from(context))
+    buildCategorySpinner()
+    buildNftSpinner()
+
+    if (unbroadcasted) {
+        builder.setTitle(R.string.sign_transaction)
+        binding.tvTitle.visibility = View.GONE
+        binding.header.removeView(binding.spnCoinType)
+        binding.sendRow.addView(binding.spnCoinType)
+        binding.sendRow.visibility = View.VISIBLE
     }
+
+    builder.setView(binding.root)
+}
 
     private fun buildCategorySpinner() {
         val categoryLabels = getCategoryOptions()
@@ -348,7 +366,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
              (binding.btnContacts as View).visibility = View.GONE
              amountBox.isEditable = false
              binding.btnMax.isEnabled = false
-             dialog.getButton(AlertDialog.BUTTON_NEUTRAL).visibility = View.GONE
+             binding.btnScanQr.visibility = View.GONE
         }
 
         val spinner: Spinner = binding.spnCoinType
@@ -375,7 +393,11 @@ class SendDialog : TaskLauncherDialog<Unit>() {
         }
         updateUI()
 
-        dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener { scanQR(this) }
+        binding.btnScanQr.setOnClickListener { scanQR(this) }
+        binding.btnSaveTxFile.setOnClickListener { saveTransactionFile() }
+        binding.btnCancel.setOnClickListener { dismiss() }
+        binding.btnSend.setText(if (unbroadcasted) R.string.sign else R.string.send)
+        binding.btnSend.setOnClickListener { launchTask() }
         model.tx.observe(this, Observer { onTx(it) })
     }
 
@@ -565,15 +587,36 @@ class SendDialog : TaskLauncherDialog<Unit>() {
         fun get() = tx ?: throw error!!
     }
 
-    // Receives the result of a QR scan.
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        val result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
-        if (result != null && result.contents != null) {
-            onUri(result.contents)
-        } else {
-            super.onActivityResult(requestCode, resultCode, data)
+    if (requestCode == REQUEST_SAVE_TX_FILE) {
+        if (resultCode == Activity.RESULT_OK) {
+            val uri = data?.data
+            if (uri != null) {
+                try {
+                    requireContext().contentResolver.openOutputStream(uri)?.use { output ->
+                        val txJson = getTransactionJsonForFile()
+                        output.write(txJson.toByteArray())
+                    }
+                    Toast.makeText(requireContext(), "Saved transaction", Toast.LENGTH_SHORT).show()
+                } catch (e: Exception) {
+                    Toast.makeText(
+                        requireContext(),
+                        e.message ?: "Unable to save file",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
         }
+        return
     }
+
+    val result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
+    if (result != null && result.contents != null) {
+        onUri(result.contents)
+    } else {
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+}
 
     fun onUri(uri: String) {
         try {

--- a/android/app/src/main/java/org/electroncash/electroncash3/Send.kt
+++ b/android/app/src/main/java/org/electroncash/electroncash3/Send.kt
@@ -24,7 +24,7 @@ import com.chaquo.python.PyObject.fromJava
 import com.google.zxing.integration.android.IntentIntegrator
 import org.electroncash.electroncash3.databinding.SendBinding
 import kotlin.math.pow
-import android.app.Activity 
+import android.app.Activity
 
 
 val libPaymentRequest by lazy { libMod("paymentrequest") }
@@ -39,23 +39,23 @@ class SendDialog : TaskLauncherDialog<Unit>() {
     private val binding get() = _binding!!
 
     private fun saveTransactionFile() {
-    val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-        addCategory(Intent.CATEGORY_OPENABLE)
-        type = "application/octet-stream"
-        putExtra(Intent.EXTRA_TITLE, "transaction.txn")
+        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "application/octet-stream"
+            putExtra(Intent.EXTRA_TITLE, "transaction.txn")
+        }
+        startActivityForResult(intent, REQUEST_SAVE_TX_FILE)
     }
-    startActivityForResult(intent, REQUEST_SAVE_TX_FILE)
-}
 
     private fun getTransactionJsonForFile(): String {
-    model.tx.waitUntilComplete()
-    val tx = model.tx.value!!.get()
-    return py.getModule("json").callAttr(
-        "dumps",
-        tx.callAttr("as_dict"),
-        Kwarg("indent", 4)
-    ).toString() + "\n"
-    }  
+        model.tx.waitUntilComplete()
+        val tx = model.tx.value!!.get()
+        return py.getModule("json").callAttr(
+                "dumps",
+                tx.callAttr("as_dict"),
+                Kwarg("indent", 4)
+        ).toString() + "\n"
+    }
 
     val wallet = daemonModel.wallet!!
 
@@ -69,6 +69,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
         var hasNfts: Boolean = false
         var hasFts: Boolean = false
     }
+
     val model: Model by viewModels()
 
     class LabelWithId(val label: String, val id: String) {
@@ -98,7 +99,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
             arguments!!.getBoolean("unbroadcasted")
         } else {
             val multisigType = libStorage.callAttr("multisig_type", daemonModel.walletType)
-                ?.toJava(IntArray::class.java)
+                    ?.toJava(IntArray::class.java)
             multisigType != null && multisigType[0] != 1
         }
     }
@@ -115,7 +116,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
 
     val readOnly by lazy {
         arguments != null &&
-            (arguments!!.containsKey("txHex") || arguments!!.containsKey("sweepKeypairs"))
+                (arguments!!.containsKey("txHex") || arguments!!.containsKey("sweepKeypairs"))
     }
 
     lateinit var amountBox: AmountBox
@@ -129,42 +130,42 @@ class SendDialog : TaskLauncherDialog<Unit>() {
         if (daemonModel.wallet!!.callAttr("is_watching_only").toBoolean()) {
             throw ToastException(R.string.this_wallet_is)
         } else if (daemonModel.wallet!!.callAttr("get_receiving_addresses")
-                   .asList().isEmpty()) {
+                        .asList().isEmpty()) {
             // At least one receiving address is needed to call wallet.dummy_address.
             throw ToastException(
-                R.string.electron_cash_is_generating_your_addresses__please_wait_)
+                    R.string.electron_cash_is_generating_your_addresses__please_wait_)
         }
     }
 
     override fun onBuildDialog(builder: AlertDialog.Builder) {
-    _binding = SendBinding.inflate(LayoutInflater.from(context))
-    buildCategorySpinner()
-    buildNftSpinner()
+        _binding = SendBinding.inflate(LayoutInflater.from(context))
+        buildCategorySpinner()
+        buildNftSpinner()
 
-    if (unbroadcasted) {
-        builder.setTitle(R.string.sign_transaction)
-        binding.tvTitle.visibility = View.GONE
-        binding.header.removeView(binding.spnCoinType)
-        binding.sendRow.addView(binding.spnCoinType)
-        binding.sendRow.visibility = View.VISIBLE
+        if (unbroadcasted) {
+            builder.setTitle(R.string.sign_transaction)
+            binding.tvTitle.visibility = View.GONE
+            binding.header.removeView(binding.spnCoinType)
+            binding.sendRow.addView(binding.spnCoinType)
+            binding.sendRow.visibility = View.VISIBLE
+        }
+
+        builder.setView(binding.root)
     }
-
-    builder.setView(binding.root)
-}
 
     private fun buildCategorySpinner() {
         val categoryLabels = getCategoryOptions()
         val spnAdapter = ArrayAdapter(context!!, android.R.layout.simple_spinner_dropdown_item,
-                                      categoryLabels)
+                categoryLabels)
         binding.spnCategory.setAdapter(spnAdapter)
         binding.spnCategory.onItemSelectedListener = object :
-            AdapterView.OnItemSelectedListener {
+                AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View?,
                                         position: Int, id: Long) {
                 val category = getSelectedCategory()
                 val nftLabels = getNftOptions(category)
                 val newAdapter = ArrayAdapter(
-                    context!!, android.R.layout.simple_spinner_dropdown_item, nftLabels)
+                        context!!, android.R.layout.simple_spinner_dropdown_item, nftLabels)
                 binding.spnNft.setAdapter(newAdapter)
                 model.hasNfts = nftLabels.size > 1
                 var fungibles = "0"
@@ -185,6 +186,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
                 updateUI()
 
             }
+
             override fun onNothingSelected(parent: AdapterView<*>) {}
         }
     }
@@ -225,20 +227,20 @@ class SendDialog : TaskLauncherDialog<Unit>() {
     private fun getCategoriesDetails(categoryIdFilter: String = ""): HashMap<String, Category> {
         val categories = HashMap<String, Category>()
         val tokens = guiTokens.callAttr("get_tokens", wallet,
-                                        Kwarg("category_id_filter", categoryIdFilter))!!
+                Kwarg("category_id_filter", categoryIdFilter))!!
         for (token in tokens.asList()) {
             val tokenMap: Map<String, PyObject> = token.asMap().mapKeys { it.key.toString() }
             val categoryId = tokenMap["tokenId"].toString();
-            val nftList = tokenMap["nftDetails"]!!.asList().map { it.asList().map{ it.toString() } }
+            val nftList = tokenMap["nftDetails"]!!.asList().map { it.asList().map { it.toString() } }
             val nfts = ArrayList<NFT>()
             for (nft in nftList) {
                 nfts.add(NFT(nft[0], nft[1], nft[2]))
             }
             val category = Category(
-                categoryId,
-                tokenMap["name"].toString(),
-                tokenMap["amount"]!!.toString(),
-                nfts)
+                    categoryId,
+                    tokenMap["name"].toString(),
+                    tokenMap["amount"]!!.toString(),
+                    nfts)
             categories[categoryId] = category
         }
         return categories
@@ -247,14 +249,15 @@ class SendDialog : TaskLauncherDialog<Unit>() {
     private fun buildNftSpinner() {
         val nftArray = ArrayList<String>()
         val spnAdapter = ArrayAdapter(context!!, android.R.layout.simple_spinner_dropdown_item,
-                                      nftArray)
+                nftArray)
         binding.spnNft.setAdapter(spnAdapter)
         binding.spnNft.onItemSelectedListener = object :
-            AdapterView.OnItemSelectedListener {
+                AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View?,
                                         position: Int, id: Long) {
                 refreshTx()
             }
+
             override fun onNothingSelected(parent: AdapterView<*>) {}
         }
     }
@@ -313,7 +316,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
             refreshTx()
         }
 
-        with (binding.sbFee) {
+        with(binding.sbFee) {
             // setMin is not available until API level 26, so values are offset by MIN_FEE.
             progress = (daemonModel.config.callAttr("fee_per_kb").toInt() / 1000) - MIN_FEE
             max = (daemonModel.config.callAttr("max_fee_rate").toInt() / 1000) - MIN_FEE
@@ -328,9 +331,11 @@ class SendDialog : TaskLauncherDialog<Unit>() {
                         refreshTx()
                     }
                 }
+
                 override fun onStartTrackingTouch(seekBar: SeekBar) {
                     tracking = true
                 }
+
                 override fun onStopTrackingTouch(seekBar: SeekBar) {
                     tracking = false
                     refreshTx()
@@ -358,32 +363,32 @@ class SendDialog : TaskLauncherDialog<Unit>() {
             // The inputs may be truncated to avoid exceeding the maximum transaction size,
             // Display the input count so the user knows to sweep again in that situation.
             dialog.setTitle(app.getQuantityString1(R.plurals.sweep_input,
-                                                   inputs!!.asList().size))
+                    inputs!!.asList().size))
         }
 
         if (readOnly) {
             binding.etAddress.isFocusable = false
-             (binding.btnContacts as View).visibility = View.GONE
-             amountBox.isEditable = false
-             binding.btnMax.isEnabled = false
-             binding.btnScanQr.visibility = View.GONE
+            (binding.btnContacts as View).visibility = View.GONE
+            amountBox.isEditable = false
+            binding.btnMax.isEnabled = false
+            binding.btnScanQr.visibility = View.GONE
         }
 
         val spinner: Spinner = binding.spnCoinType
         ArrayAdapter.createFromResource(
-            activity!!,
-            R.array.coin_type,
-            android.R.layout.simple_spinner_item
+                activity!!,
+                R.array.coin_type,
+                android.R.layout.simple_spinner_item
         ).also { adapter ->
             adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
             spinner.adapter = adapter
         }
         spinner.setSelection(if (model.tokenSend) 1 else 0)
         spinner.onItemSelectedListener = object :
-            AdapterView.OnItemSelectedListener {
+                AdapterView.OnItemSelectedListener {
             override fun onItemSelected(
-                parent: AdapterView<*>, view: View?,
-                position: Int, id: Long
+                    parent: AdapterView<*>, view: View?,
+                    position: Int, id: Long
             ) {
                 model.tokenSend = (position == 1)
                 updateUI()
@@ -436,9 +441,9 @@ class SendDialog : TaskLauncherDialog<Unit>() {
             val nftId = selectedNft?.id ?: ""
             val ftAmountStr = binding.etFtAmount.text.toString()
             model.tx.refresh(TxArgs(wallet, model.paymentRequest, binding.etAddress.text.toString(),
-                amountBox.amount, binding.btnMax.isChecked, inputs,
-                categoryId, ftAmountStr, nftId,
-                model.tokenSend, model.hasNfts, model.hasFts, feeSpb * 1000))
+                    amountBox.amount, binding.btnMax.isChecked, inputs,
+                    categoryId, ftAmountStr, nftId,
+                    model.tokenSend, model.hasNfts, model.hasFts, feeSpb * 1000))
         }
     }
 
@@ -470,7 +475,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
     fun setFeeLabel(tx: PyObject? = null): Int {
         val fee = tx?.callAttr("get_fee")?.toInt()
         val spb = if (fee != null) fee / tx.callAttr("estimated_size").toInt()
-                  else feeSpb
+        else feeSpb
         var feeLabel = getString(R.string.sats_per, spb)
         if (fee != null) {
             feeLabel += " (${ltr(formatSatoshisAndUnit(fee.toLong()))})"
@@ -525,13 +530,13 @@ class SendDialog : TaskLauncherDialog<Unit>() {
                         return TxResult(ToastException(R.string.please_select_a))
                     } else if (nft.isEmpty() && !hasFungible) {
                         return TxResult(ToastException(
-                            if (hasNfts && hasFts) {
-                                R.string.please_choose_an
-                            } else if (hasNfts) {
-                                R.string.please_select_an
-                            } else {
-                                R.string.please_choose_a_fungible
-                            }
+                                if (hasNfts && hasFts) {
+                                    R.string.please_choose_an
+                                } else if (hasNfts) {
+                                    R.string.please_select_an
+                                } else {
+                                    R.string.please_choose_a_fungible
+                                }
                         ))
                     } else if (hasFractionalFTs(fungibleAmountStr, categoryId)) {
                         return TxResult(ToastException(R.string.too_many_fungible))
@@ -539,14 +544,14 @@ class SendDialog : TaskLauncherDialog<Unit>() {
                         val (toAddress, type) = getAddress()
                         addressType = type
                         transaction = guiTokens.callAttr(
-                            "make_tx", wallet, daemonModel.config, toAddress,
-                            feePerKb, categoryId, fungibleAmountStr, nft
+                                "make_tx", wallet, daemonModel.config, toAddress,
+                                feePerKb, categoryId, fungibleAmountStr, nft
                         )
                     }
                 } else {
                     val inputs = this.inputs ?: wallet.callAttr(
-                        "get_spendable_coins", null, daemonModel.config,
-                        Kwarg("isInvoice", pr != null)
+                            "get_spendable_coins", null, daemonModel.config,
+                            Kwarg("isInvoice", pr != null)
                     )
                     val fusion = daemonModel.daemon.get("plugins")!!.callAttr("find_plugin", "fusion")
                     fusion.callAttr("spendable_coin_filter", daemonModel.wallet, inputs)
@@ -561,22 +566,22 @@ class SendDialog : TaskLauncherDialog<Unit>() {
                         val (toAddress, type) = getAddress()
                         addressType = type
                         val output = py.builtins.callAttr(
-                            "tuple", arrayOf(
+                                "tuple", arrayOf(
                                 libBitcoin.get("TYPE_ADDRESS"), toAddress,
                                 if (max) "!" else amount
-                            )
+                        )
                         )
                         outputs = py.builtins.callAttr("list", arrayOf(output))
                     }
                     transaction = wallet.callAttr(
-                        "make_unsigned_transaction", inputs, outputs,
-                        daemonModel.config, Kwarg("sign_schnorr", signSchnorr())
+                            "make_unsigned_transaction", inputs, outputs,
+                            daemonModel.config, Kwarg("sign_schnorr", signSchnorr())
                     )
                 }
                 TxResult(transaction, addressType)
             } catch (e: PyException) {
                 TxResult(if (e.message!!.startsWith("NotEnoughFunds"))
-                         ToastException(R.string.insufficient_funds) else e)
+                    ToastException(R.string.insufficient_funds) else e)
             }
         }
     }
@@ -584,39 +589,40 @@ class SendDialog : TaskLauncherDialog<Unit>() {
     class TxResult(val tx: PyObject?, val addressType: AddressType = AddressType.CASH,
                    val error: Throwable? = null) {
         constructor(error: Throwable) : this(null, AddressType.TOKEN, error)
+
         fun get() = tx ?: throw error!!
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-    if (requestCode == REQUEST_SAVE_TX_FILE) {
-        if (resultCode == Activity.RESULT_OK) {
-            val uri = data?.data
-            if (uri != null) {
-                try {
-                    requireContext().contentResolver.openOutputStream(uri)?.use { output ->
-                        val txJson = getTransactionJsonForFile()
-                        output.write(txJson.toByteArray())
+        if (requestCode == REQUEST_SAVE_TX_FILE) {
+            if (resultCode == Activity.RESULT_OK) {
+                val uri = data?.data
+                if (uri != null) {
+                    try {
+                        requireContext().contentResolver.openOutputStream(uri)?.use { output ->
+                            val txJson = getTransactionJsonForFile()
+                            output.write(txJson.toByteArray())
+                        }
+                        Toast.makeText(requireContext(), "Saved transaction", Toast.LENGTH_SHORT).show()
+                    } catch (e: Exception) {
+                        Toast.makeText(
+                                requireContext(),
+                                e.message ?: "Unable to save file",
+                                Toast.LENGTH_LONG
+                        ).show()
                     }
-                    Toast.makeText(requireContext(), "Saved transaction", Toast.LENGTH_SHORT).show()
-                } catch (e: Exception) {
-                    Toast.makeText(
-                        requireContext(),
-                        e.message ?: "Unable to save file",
-                        Toast.LENGTH_LONG
-                    ).show()
                 }
             }
+            return
         }
-        return
-    }
 
-    val result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
-    if (result != null && result.contents != null) {
-        onUri(result.contents)
-    } else {
-        super.onActivityResult(requestCode, resultCode, data)
+        val result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
+        if (result != null && result.contents != null) {
+            onUri(result.contents)
+        } else {
+            super.onActivityResult(requestCode, resultCode, data)
+        }
     }
-}
 
     fun onUri(uri: String) {
         try {
@@ -641,7 +647,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
                 parsed.callAttr("get", "amount")?.let {
                     try {
                         amountBox.amount = it.toLong()
-                    }  catch (e: PyException) {
+                    } catch (e: PyException) {
                         throw if (e.message!!.startsWith("OverflowError")) ToastException(e)
                         else e
                     }
@@ -670,7 +676,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
         }
 
         binding.btnContacts.setImageResource(if (pr == null) R.drawable.ic_person_24dp
-                                     else R.drawable.ic_check_24dp)
+        else R.drawable.ic_check_24dp)
         binding.btnContacts.setOnClickListener {
             if (pr == null) {
                 showDialog(this, SendContactsDialog())
@@ -714,7 +720,7 @@ class SendDialog : TaskLauncherDialog<Unit>() {
     }
 
     private fun filterOutputs(outputs: List<PyObject>, wallet: PyObject, methodName: String) =
-        outputs.filter { !wallet.callAttr(methodName, it.asList()[1]).toBoolean() }
+            outputs.filter { !wallet.callAttr(methodName, it.asList()[1]).toBoolean() }
 
     override fun onPreExecute() {
         description = binding.etDescription.text.toString()
@@ -745,10 +751,14 @@ class SendDialog : TaskLauncherDialog<Unit>() {
                     AddressType.PAYMENT_REQUEST -> {}
                 }
                 txResult.get()   // May throw ToastException.
-                showDialog(this, SendPasswordDialog().apply { arguments = Bundle().apply {
-                    putString("description", this@SendDialog.binding.etDescription.text.toString())
-                }})
-            } catch (e: ToastException) { e.show() }
+                showDialog(this, SendPasswordDialog().apply {
+                    arguments = Bundle().apply {
+                        putString("description", this@SendDialog.binding.etDescription.text.toString())
+                    }
+                })
+            } catch (e: ToastException) {
+                e.show()
+            }
         }
     }
 }
@@ -763,7 +773,7 @@ class GetPaymentRequestDialog() : TaskDialog<PyObject>() {
 
     override fun doInBackground(): PyObject {
         val pr = libPaymentRequest.callAttr("get_payment_request",
-                                            arguments!!.getString("url")!!)!!
+                arguments!!.getString("url")!!)!!
         if (!pr.callAttr("verify", sendDialog.wallet.get("contacts")!!).toBoolean()) {
             throw ToastException(pr.get("error").toString())
         }
@@ -783,9 +793,9 @@ class SendContactsDialog : MenuDialog() {
     private val binding get() = _binding!!
 
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
     ): View? {
         _binding = SendBinding.inflate(inflater, container, false)
         return binding.root
@@ -814,7 +824,7 @@ class SendContactsDialog : MenuDialog() {
 
     override fun onShowDialog() {
         if (contacts.isEmpty()) {
-            toast (if (hasAnyContacts) {
+            toast(if (hasAnyContacts) {
                 R.string.you_dont_have_any_token
             } else {
                 R.string.you_dont_have_any_contacts
@@ -831,7 +841,7 @@ class SendContactsDialog : MenuDialog() {
             "to_ui_string"
         }
         val address = makeAddress(contact["address"].toString())
-        with (sendDialog) {
+        with(sendDialog) {
             setAddress(address.callAttr(addressFormat).toString())
             amountBox.requestFocus()
         }
@@ -849,14 +859,14 @@ class SendPasswordDialog : PasswordDialog<Unit>() {
         if (!sendDialog.unbroadcasted) {
             val pr = sendDialog.model.paymentRequest
             val broadcastFunc: ((PyObject) -> PyObject)? =
-                if (pr == null) null
-                else { tx ->
-                    checkExpired(pr)
-                    val refundAddr = wallet.callAttr("get_receiving_addresses").asList().get(0)
-                    pr.callAttr("send_payment", tx.toString(), refundAddr)
-                }
+                    if (pr == null) null
+                    else { tx ->
+                        checkExpired(pr)
+                        val refundAddr = wallet.callAttr("get_receiving_addresses").asList().get(0)
+                        pr.callAttr("send_payment", tx.toString(), refundAddr)
+                    }
             broadcastTransaction(wallet, tx, arguments!!.getString("description")!!,
-                                 broadcastFunc)
+                    broadcastFunc)
         }
     }
 
@@ -865,9 +875,11 @@ class SendPasswordDialog : PasswordDialog<Unit>() {
         if (!sendDialog.unbroadcasted) {
             toast(if (sendDialog.model.tokenSend) R.string.tokens_sent else R.string.payment_sent, Toast.LENGTH_SHORT)
         } else {
-            showDialog(this, SignedTransactionDialog().apply { arguments = Bundle().apply {
-                putString("txHex", tx.toString())
-            }})
+            showDialog(this, SignedTransactionDialog().apply {
+                arguments = Bundle().apply {
+                    putString("txHex", tx.toString())
+                }
+            })
         }
     }
 }
@@ -899,4 +911,4 @@ fun broadcastTransaction(wallet: PyObject, tx: PyObject, description: String,
 
 
 fun literalEval(str: String): PyObject? =
-    py.getModule("ast").callAttr("literal_eval", str)
+        py.getModule("ast").callAttr("literal_eval", str)

--- a/android/app/src/main/res/layout/send.xml
+++ b/android/app/src/main/res/layout/send.xml
@@ -288,4 +288,42 @@
 
         </LinearLayout>
     </ScrollView>
+    <LinearLayout
+        android:id="@+id/buttonRow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:orientation="horizontal"
+        android:padding="8dp">
+
+        <Button
+            android:id="@+id/btnScanQr"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="0dp"
+            android:text="QR" />
+
+        <Button
+            android:id="@+id/btnSaveTxFile"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="0dp"
+            android:text="@string/save" />
+
+        <Button
+            android:id="@+id/btnCancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="0dp"
+            android:text="@android:string/cancel" />
+
+        <Button
+            android:id="@+id/btnSend"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="0dp"
+            android:text="@string/send" />
+
+    </LinearLayout>
 </LinearLayout>
+

--- a/android/app/src/main/res/layout/send.xml
+++ b/android/app/src/main/res/layout/send.xml
@@ -288,6 +288,7 @@
 
         </LinearLayout>
     </ScrollView>
+
     <LinearLayout
         android:id="@+id/buttonRow"
         android:layout_width="match_parent"

--- a/android/app/src/main/res/menu/wallet.xml
+++ b/android/app/src/main/res/menu/wallet.xml
@@ -7,34 +7,34 @@
             android:title="@string/Wallet_information" />
         <item
             android:id="@+id/menuChangePassword"
-            android:title="@string/Change_password"/>
+            android:title="@string/Change_password" />
         <item
             android:id="@+id/menuExport"
-            android:title="@string/export_wallet"/>
+            android:title="@string/export_wallet" />
         <item
             android:id="@+id/menuUseChange"
-            android:title="@string/use_change"
-            android:checkable="true"/>
+            android:checkable="true"
+            android:title="@string/use_change" />
         <item
             android:id="@+id/menuClose"
-            android:title="@string/close_wallet"/>
+            android:title="@string/close_wallet" />
     </group>
 
     <group android:id="@+id/menuGroupTransaction">
         <item
             android:id="@+id/menuSignTx"
-            android:title="@string/sign_transaction"/>
+            android:title="@string/sign_transaction" />
         <item
             android:id="@+id/menuLoadTx"
-            android:title="@string/load_transaction"/>
-            
-             <item
-        android:id="@+id/menuLoadTxFromFile"
-        android:title="Load tx from file"/>
-        
+            android:title="@string/load_transaction" />
+
+        <item
+            android:id="@+id/menuLoadTxFromFile"
+            android:title="Load tx from file" />
+
         <item
             android:id="@+id/menuSweep"
-            android:title="@string/sweep_private"/>
+            android:title="@string/sweep_private" />
     </group>
 
 </menu>

--- a/android/app/src/main/res/menu/wallet.xml
+++ b/android/app/src/main/res/menu/wallet.xml
@@ -27,6 +27,11 @@
         <item
             android:id="@+id/menuLoadTx"
             android:title="@string/load_transaction"/>
+            
+             <item
+        android:id="@+id/menuLoadTxFromFile"
+        android:title="Load tx from file"/>
+        
         <item
             android:id="@+id/menuSweep"
             android:title="@string/sweep_private"/>


### PR DESCRIPTION
This allows users to save transaction files (.txn) from the send dialog.  It will open up the standard android file picker interface and prompt the user to save as a .txn file in the same format as desktop.  Was cross-tested with android to desktop and vice-versa.  In conjunction with this, you can also load transaction from a txn file and it will then get loaded into the wallet flow for signing and broadcasting.